### PR TITLE
feat(deploy): add Dockerfile and CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      # FIXME: remove before merge
+      - dockerfile
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      # FIXME: remove before merge
-      - dockerfile
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+    tags: [v*]
 
 jobs:
   build:
@@ -20,9 +21,16 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract metadata for the Docker image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,28 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# build stage
+FROM node:lts-alpine as build-stage
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+# production stage
+FROM nginx:stable-alpine as production-stage
+COPY --from=build-stage /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,3 @@ RUN npm run build
 # production stage
 FROM nginx:stable-alpine
 COPY --from=build-stage /app/dist /usr/share/nginx/html
-CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN npm ci
 COPY . .
 RUN npm run build
 # production stage
-FROM nginx:stable-alpine as production-stage
+FROM nginx:stable-alpine
 COPY --from=build-stage /app/dist /usr/share/nginx/html
-EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Ajoute la construction d'une image docker minimaliste au push sur main et quand un tag est publié.

L'image construit le site et le sert via nginx, via des _stages_ distincts.

Pour l'instant la publication se fait sur la registry publique GitHub.

```
# Use a PAT to login https://github.com/settings/tokens
docker login ghcr.io -u {username}
docker pull ghcr.io/ecolabdata/ecospheres-front:latest
docker run -it -p 8080:80 --rm --name ecospheres-front ghcr.io/ecolabdata/ecospheres-front
```

[docker/metadata-actions](https://github.com/docker/metadata-action) est utilisé pour taguer les images, avec la conf par défaut. [Tests sur mon fork ici](https://github.com/abulte/ecospheres-front/pkgs/container/ecospheres-front).

<img width="285" alt="Capture d’écran 2023-12-11 à 11 30 22" src="https://github.com/ecolabdata/ecospheres-front/assets/119625/6ee3778a-7052-4efc-ae5e-98f7e3bac884">