### PR TITLE
feat(discussions): allow discussion and comment creation

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -99,8 +99,10 @@ website:
   discussions:
     dataset:
       display: true
+      create: true
     topic:
       display: true
+      create: true
 
 themes:
   - name: Se loger

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -114,8 +114,10 @@ website:
   discussions:
     dataset:
       display: true
+      create: false
     topic:
       display: false
+      create: false
 
 # list of organisations' ids that should be handled by the portal
 # to find an id go to https://www.data.gouv.fr/fr/organizations/ministere-de-la-transition-ecologique/

--- a/src/components/DiscussionsList.vue
+++ b/src/components/DiscussionsList.vue
@@ -58,7 +58,7 @@ const pages: ComputedRef<object[]> = computed(() => {
 const allowDiscussionCreation = computed(() => {
   return (
     config.website.discussions[props.subjectClass.toLowerCase()].create &&
-    loggedIn
+    loggedIn.value
   )
 })
 

--- a/src/components/DiscussionsList.vue
+++ b/src/components/DiscussionsList.vue
@@ -235,7 +235,10 @@ watchEffect(() => {
           v-if="postFormId !== discussion.id && loggedIn"
           type="button"
           class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-grey-500 fr-icon-chat-3-line fr-btn--icon-left"
-          @click.stop.prevent="postFormId = discussion.id"
+          @click.stop.prevent="
+            postForm.comment = ''
+            postFormId = discussion.id
+          "
         >
           Répondre
         </button>

--- a/src/components/DiscussionsList.vue
+++ b/src/components/DiscussionsList.vue
@@ -38,12 +38,10 @@ const props = defineProps({
   }
 })
 
-/* eslint-disable no-unused-vars */
-enum SubjectClassLabel {
-  Dataset = 'jeu de données',
-  Topic = 'bouquet'
+const subjectClassLabels = {
+  Dataset: 'jeu de données',
+  Topic: 'bouquet'
 }
-/* eslint-enable no-unused-vars */
 
 const discussionForm: Ref<DiscussionForm> = ref({
   title: '',
@@ -175,7 +173,7 @@ watchEffect(() => {
   </div>
 
   <div v-if="!discussions?.data?.length">
-    Pas de discussion pour ce {{ SubjectClassLabel[props.subjectClass] }}.
+    Pas de discussion pour ce {{ subjectClassLabels[props.subjectClass] }}.
   </div>
   <div>
     <div

--- a/src/components/DiscussionsList.vue
+++ b/src/components/DiscussionsList.vue
@@ -38,6 +38,13 @@ const props = defineProps({
   }
 })
 
+/* eslint-disable no-unused-vars */
+enum SubjectClassLabel {
+  Dataset = 'jeu de données',
+  Topic = 'bouquet'
+}
+/* eslint-enable no-unused-vars */
+
 const discussionForm: Ref<DiscussionForm> = ref({
   title: '',
   comment: '',
@@ -168,8 +175,7 @@ watchEffect(() => {
   </div>
 
   <div v-if="!discussions?.data?.length">
-    Pas de discussion pour ce
-    {{ props.subjectClass === 'Dataset' ? 'jeu de données' : 'bouquet' }}.
+    Pas de discussion pour ce {{ SubjectClassLabel[props.subjectClass] }}.
   </div>
   <div>
     <div

--- a/src/components/DiscussionsList.vue
+++ b/src/components/DiscussionsList.vue
@@ -1,17 +1,24 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
-import { defineProps, ref, watchEffect } from 'vue'
+import { defineProps, ref, watchEffect, computed } from 'vue'
 
 import config from '../config'
 import type { DiscussionResponse } from '../model/discussion'
 import { useDiscussionStore } from '../store/DiscussionStore'
 import { formatDate, fromMarkdown } from '../utils'
 
+interface DiscussionForm {
+  title: string
+  content: string
+}
+
 const discussionStore = useDiscussionStore()
 
 const discussions: Ref<DiscussionResponse | null> = ref(null)
 const currentPage: Ref<number> = ref(1)
 const pages: Ref<object[]> = ref([])
+const showDiscussionForm: Ref<boolean> = ref(false)
+const discussionForm: Ref<DiscussionForm> = ref({ title: '', content: '' })
 
 type SubjectType = 'dataset' | 'topic'
 
@@ -24,6 +31,10 @@ const props = defineProps({
     type: String as () => SubjectType,
     default: 'dataset'
   }
+})
+
+const allowDiscussionCreation = computed(() => {
+  return config.website.discussions[props.subjectType].create
 })
 
 const getUserAvatar = (post) => {
@@ -49,7 +60,56 @@ watchEffect(() => {
 </script>
 
 <template>
-  <h2 class="fr-mt-4w">Discussions</h2>
+  <div class="fr-grid-row fr-grid-row--middle">
+    <div class="fr-col">
+      <h2 class="fr-mt-4w">Discussions</h2>
+    </div>
+    <div v-if="allowDiscussionCreation" class="fr-col text-align-right">
+      <button
+        type="button"
+        class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-grey-500 fr-icon-add-line fr-btn--icon-left"
+        @click.stop.prevent="showDiscussionForm = true"
+      >
+        Démarrer une nouvelle discussion
+      </button>
+    </div>
+  </div>
+
+  <div v-if="showDiscussionForm" class="fr-mb-4w">
+    <form>
+      <div class="fr-input-group">
+        <label class="fr-label" for="discussion-title"> Titre * </label>
+        <input
+          id="discussion-title"
+          v-model="discussionForm.title"
+          required
+          class="fr-input"
+          name="title"
+        />
+      </div>
+      <div class="fr-input-group">
+        <label class="fr-label" for="discussion-message"> Message * </label>
+        <textarea
+          id="discussion-message"
+          v-model="discussionForm.content"
+          required
+          class="fr-input"
+          name="message"
+        ></textarea>
+      </div>
+      <div class="text-align-right">
+        <button
+          type="button"
+          class="fr-btn fr-btn--secondary fr-mr-1w"
+          @click.stop.prevent="showDiscussionForm = false"
+        >
+          Annuler
+        </button>
+        <button type="submit" class="fr-btn">Soumettre</button>
+      </div>
+    </form>
+  </div>
+
   <div v-if="!discussions?.data?.length">
     Pas de discussion pour ce jeu de données.
   </div>

--- a/src/components/DiscussionsList.vue
+++ b/src/components/DiscussionsList.vue
@@ -236,8 +236,10 @@ watchEffect(() => {
           type="button"
           class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-grey-500 fr-icon-chat-3-line fr-btn--icon-left"
           @click.stop.prevent="
-            postForm.comment = ''
-            postFormId = discussion.id
+            () => {
+              postForm.comment = ''
+              postFormId = discussion.id
+            }
           "
         >
           Répondre

--- a/src/model/discussion.ts
+++ b/src/model/discussion.ts
@@ -4,10 +4,12 @@ import type { GenericResponse } from './api'
 
 interface Discussion {
   discussion: Post[]
-  id: string
+  id: DiscussionId
   subject: Subject
   title: string
 }
+
+type DiscussionId = string
 
 interface DiscussionForm {
   title: string
@@ -19,6 +21,10 @@ interface Post {
   content: string
   posted_by: User
   posted_on: string
+}
+
+interface PostForm {
+  comment: string
 }
 
 interface Subject {
@@ -41,5 +47,7 @@ export type {
   SubjectId,
   SubjectClass,
   DiscussionResponse,
-  DiscussionForm
+  DiscussionForm,
+  PostForm,
+  DiscussionId
 }

--- a/src/model/discussion.ts
+++ b/src/model/discussion.ts
@@ -9,6 +9,12 @@ interface Discussion {
   title: string
 }
 
+interface DiscussionForm {
+  title: string
+  comment: string
+  subject: Subject
+}
+
 interface Post {
   content: string
   posted_by: User
@@ -16,9 +22,11 @@ interface Post {
 }
 
 interface Subject {
-  class: 'Dataset' | 'Topic'
+  class: SubjectClass
   id: SubjectId
 }
+
+type SubjectClass = 'Dataset' | 'Topic'
 
 type SubjectId = string
 
@@ -26,4 +34,12 @@ interface DiscussionResponse extends GenericResponse {
   data: Discussion[]
 }
 
-export type { Discussion, Post, Subject, SubjectId, DiscussionResponse }
+export type {
+  Discussion,
+  Post,
+  Subject,
+  SubjectId,
+  SubjectClass,
+  DiscussionResponse,
+  DiscussionForm
+}

--- a/src/services/api/resources/DiscussionsAPI.ts
+++ b/src/services/api/resources/DiscussionsAPI.ts
@@ -1,4 +1,10 @@
-import type { SubjectId } from '@/model/discussion'
+import type {
+  SubjectId,
+  PostForm,
+  Discussion,
+  DiscussionResponse,
+  DiscussionId
+} from '@/model/discussion'
 
 import DatagouvfrAPI from '../DatagouvfrAPI'
 
@@ -8,8 +14,22 @@ export default class DiscussionsAPI extends DatagouvfrAPI {
   /**
    * Get discussions for an object
    */
-  async getDiscussions(subjectId: SubjectId, page: number = 1): Promise<any> {
+  async getDiscussions(
+    subjectId: SubjectId,
+    page: number = 1
+  ): Promise<DiscussionResponse> {
     const url = `${this.url()}/?for=${subjectId}&page=${page}`
     return await this.makeRequestAndHandleResponse(url)
+  }
+
+  /**
+   * Create a post on a discussion
+   */
+  async createPost(
+    discussionId: DiscussionId,
+    postForm: PostForm
+  ): Promise<Discussion> {
+    const url = `${this.url()}/${discussionId}/`
+    return await this.makeRequestAndHandleResponse(url, 'post', postForm)
   }
 }

--- a/src/store/DiscussionStore.ts
+++ b/src/store/DiscussionStore.ts
@@ -1,6 +1,11 @@
 import { defineStore } from 'pinia'
 
-import type { SubjectId, DiscussionResponse } from '@/model/discussion'
+import type {
+  SubjectId,
+  DiscussionResponse,
+  DiscussionForm,
+  Discussion
+} from '@/model/discussion'
 
 import DiscussionsAPI from '../services/api/resources/DiscussionsAPI'
 
@@ -12,6 +17,26 @@ export const useDiscussionStore = defineStore('discussion', {
     return { data }
   },
   actions: {
+    /**
+     * Refresh discussions for a subject, by loading the first page
+     */
+    async reloadForSubject(subjectId: SubjectId) {
+      console.log('reloadForSubject', subjectId, this.data[subjectId])
+      if (this.data[subjectId] === undefined) return
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete this.data[subjectId]
+      return await this.loadDiscussionsForSubject(subjectId)
+    },
+    /**
+     * Add a discussion
+     */
+    async createDiscussion(
+      discussionForm: DiscussionForm
+    ): Promise<Discussion> {
+      const res = await discussionsAPI.create(discussionForm)
+      await this.reloadForSubject(discussionForm.subject.id)
+      return res
+    },
     /**
      * Get discussions for a subject from store
      */

--- a/src/store/UserStore.js
+++ b/src/store/UserStore.js
@@ -11,6 +11,11 @@ export const useUserStore = defineStore('user', {
     data: {},
     token: undefined
   }),
+  getters: {
+    loggedIn(state) {
+      return state.isLoggedIn
+    }
+  },
   actions: {
     /**
      * Init store from localStorage

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -245,11 +245,14 @@ onMounted(() => {
       Copier l'url de la page
     </DsfrButton>
 
-    <DiscussionsList
-      v-if="showDiscussions"
-      :subject="bouquet"
-      subject-type="topic"
-    />
+    <div class="fr-mt-8w">
+      <DiscussionsList
+        v-if="showDiscussions"
+        :subject="bouquet"
+        subject-class="Topic"
+        class="fr-mt-8w"
+      />
+    </div>
   </div>
 </template>
 

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -250,7 +250,6 @@ onMounted(() => {
         v-if="showDiscussions"
         :subject="bouquet"
         subject-class="Topic"
-        class="fr-mt-8w"
       />
     </div>
   </div>

--- a/src/views/datasets/DatasetDetailView.vue
+++ b/src/views/datasets/DatasetDetailView.vue
@@ -318,7 +318,11 @@ watch(
         tab-id="tab-2"
         :selected="selectedTabIndex === 2"
       >
-        <Well color="blue-cumulus" weight="regular">
+        <Well
+          v-if="!config.website.discussions.dataset.create"
+          color="blue-cumulus"
+          weight="regular"
+        >
           <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
             <div class="fr-col-12 fr-col-lg-8">
               <p class="fr-text--bold fr-mb-0">{{ discussionWellTitle }}</p>


### PR DESCRIPTION
Permet la création de discussions et de réponse aux discussions dans le composant `DiscussionsList`. 

Activable via le feature flag `website.discussions.(topic|dataset).create`.

Limitations connues : 
- ~~le statut connecté est attendu comme pré-requis, pas de redirection vers l'authentification car elle est aujourd'hui hijackée par les bouquets (autre PR je pense)~~
- la redirection vers le login ne ramène pas à l'endroit exact de l'action
- bug (?) sur data.gouv.fr qui empêche la création de plusieurs commentaires à moins de ~10 sec d'intervalle (mais le cas est géré, on peut réessayer)

<img width="893" alt="Capture d’écran 2023-12-18 à 11 10 50" src="https://github.com/ecolabdata/ecospheres-front/assets/119625/4613e879-8c3b-441d-9b5c-9da040a17555">

<img width="873" alt="Capture d’écran 2023-12-18 à 11 10 59" src="https://github.com/ecolabdata/ecospheres-front/assets/119625/2a2504f8-1097-4c10-a983-042c3e8301c6">

<img width="874" alt="Capture d’écran 2023-12-18 à 11 11 05" src="https://github.com/ecolabdata/ecospheres-front/assets/119625/a60e194b-3af4-4d38-9b13-5269c5c49d0c">
