### PR TITLE
fix: highlight du menu sur une page enfant

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -1,7 +1,10 @@
 <script setup>
 import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 
 import config from '@/config'
+
+const route = useRoute()
 
 const props = defineProps({
   onClick: {
@@ -10,13 +13,21 @@ const props = defineProps({
   }
 })
 
+const isActive = (link) => {
+  return route.matched.some(({ path }) => {
+    if (path === '/') return link === path
+    return link.indexOf(path) === 0
+  })
+}
+
 const navItems = computed(() => {
   const items = []
   config.website.router_items.forEach((item) => {
     if (item.display_menu) {
       items.push({
         to: item.linkPage,
-        text: item.name
+        text: item.name,
+        'aria-current': isActive(item.linkPage) ? true : undefined
       })
     }
   })
@@ -30,10 +41,8 @@ const navItems = computed(() => {
       <DsfrNavigationMenuLink
         v-if="navItem.to && navItem.text"
         v-bind="navItem"
-        @toggle-id="onClick"
+        @toggle-id="props.onClick"
       />
     </DsfrNavigationItem>
   </DsfrNavigation>
 </template>
-
-<style scoped></style>

--- a/src/services/routerUtils.js
+++ b/src/services/routerUtils.js
@@ -19,39 +19,50 @@ export default class RouterFetch {
       if (item.id === 'datasets') {
         items.push({
           path: item.linkPage,
-          name: item.id,
-          component: DatasetsListView
-        })
-        items.push({
-          path: `${item.linkPage}/:did`,
-          name: 'dataset_detail',
-          component: DatasetDetailView
+          children: [
+            {
+              path: '',
+              name: item.id,
+              component: DatasetsListView
+            },
+            {
+              path: ':did',
+              name: 'dataset_detail',
+              component: DatasetDetailView
+            }
+          ]
         })
       } else if (item.id === 'organizations') {
         items.push({
           path: item.linkPage,
-          name: item.id,
-          component: OrganizationsListView
-        })
-        items.push({
-          path: `${item.linkPage}/:oid`,
-          name: 'organization_detail',
-          component: OrganizationDetailView
+          children: [
+            {
+              path: '',
+              name: item.id,
+              component: OrganizationsListView
+            },
+            {
+              path: ':oid',
+              name: 'organization_detail',
+              component: OrganizationDetailView
+            }
+          ]
         })
       } else if (item.id === 'bouquets') {
         items.push({
           path: item.linkPage,
-          name: item.id,
-          component: BouquetsListView,
-          props: (route) => ({
-            initThemeName: route.query.theme,
-            initSubthemeName: route.query.subtheme
-          })
-        })
-        items.push({
-          path: `${item.linkPage}/:bid`,
-          name: 'bouquet_detail',
-          component: BouquetDetailView
+          children: [
+            {
+              path: '',
+              name: item.id,
+              component: BouquetsListView
+            },
+            {
+              path: ':bid',
+              name: 'bouquet_detail',
+              component: BouquetDetailView
+            }
+          ]
         })
 
         /** protected / admin route  **/
@@ -82,7 +93,7 @@ export default class RouterFetch {
           meta: { title: item.name },
           props: { url: item.url }
         })
-      } else if (item.type == 'custom') {
+      } else if (item.type === 'custom') {
         items.push({
           path: item.linkPage,
           name: item.id,


### PR DESCRIPTION
Fix #236

Un peu compliqué à cause de deux choses :
- il faut réécrire les routes pour que vue-router considère `/xxx/yyy` comme enfant de `/xxx` et donc réputée active  https://github.com/vuejs/rfcs/blob/master/active-rfcs/0028-router-active-link.md#unrelated-but-similiar-routes
- [le DSFR se base sur `aria-current`](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/navigation-principale) pour appliquer le style, et ce style est difficile à répliquer pour l'appliquer à la classe `router-link-active` qui est posée par `vue-router` grâce à supra. On manipule donc l'attribut `aria-current` en utilisant le matching des liens de `vue-router` avant d'injecter l'item de navigation au menu DSFR.