### PR TITLE
fix: refactor: bouquets breadcrumb

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -68,19 +68,6 @@
   align-items: center;
 }
 
-.without_breadcrumb {
-  margin: 128px 0 0;
-}
-
-.with_breadcrumb {
-  margin: 60px 0 0;
-}
-
-.breadcrumb {
-  margin-top: 40px;
-  text-align: left;
-}
-
 .actionTile {
   background: #000092;
   .fr-tile__link {

--- a/src/components/HomeThemes.vue
+++ b/src/components/HomeThemes.vue
@@ -1,7 +1,11 @@
 <template>
-  <div className="without_breadcrumb" v-if="selectedTheme === null">
+  <div v-if="selectedTheme === null" className="without_breadcrumb">
     <ul class="fr-grid-row fr-grid-row--gutters es__tiles__list fr-mt-1w">
-      <li v-for="theme in themeList" class="fr-col-12 fr-col-lg-4">
+      <li
+        v-for="theme in themeList"
+        :key="theme.name"
+        class="fr-col-12 fr-col-lg-4"
+      >
         <Tile
           :style="getCustomBoxShadow(theme.color)"
           :link="`/?theme=${theme.name}`"
@@ -17,6 +21,7 @@
       <ul class="fr-grid-row fr-grid-row--gutters es__tiles__list fr-mt-1w">
         <li
           v-for="subtheme in selectedTheme.subthemes"
+          :key="subtheme.name"
           class="fr-col-12 fr-col-lg-4"
         >
           <Tile
@@ -42,7 +47,8 @@ export default {
   },
   props: {
     selectedThemeName: {
-      type: String
+      type: String,
+      default: ''
     }
   },
   computed: {
@@ -82,3 +88,18 @@ export default {
   }
 }
 </script>
+
+<style scoped lang="scss">
+.without_breadcrumb {
+  margin: 128px 0 0;
+}
+
+.with_breadcrumb {
+  margin: 60px 0 0;
+}
+
+.breadcrumb {
+  margin-top: 40px;
+  text-align: left;
+}
+</style>

--- a/src/custom/ecospheres/components/BouquetList.vue
+++ b/src/custom/ecospheres/components/BouquetList.vue
@@ -1,3 +1,87 @@
+<script setup lang="ts">
+import type { ComputedRef } from 'vue'
+import { onMounted, computed } from 'vue'
+import { useLoading } from 'vue-loading-overlay'
+import { useRouter } from 'vue-router'
+
+import Tile from '@/components/Tile.vue'
+import type { Topic } from '@/model'
+import { NoOptionSelected } from '@/model'
+import { useTopicStore } from '@/store/TopicStore'
+
+const router = useRouter()
+
+const props = defineProps({
+  themeName: {
+    type: String,
+    default: NoOptionSelected
+  },
+  subthemeName: {
+    type: String,
+    default: NoOptionSelected
+  }
+})
+
+const bouquets: ComputedRef<Topic[]> = computed(() => {
+  const allTopics = useTopicStore().$state.data
+  if (props.themeName === NoOptionSelected) {
+    return allTopics
+  }
+  const relevantTopics: Topic[] = []
+  if (props.subthemeName !== NoOptionSelected) {
+    for (const topic of allTopics) {
+      if (
+        isRelevant(topic, 'subtheme', props.subthemeName) &&
+        isRelevant(topic, 'theme', props.themeName)
+      ) {
+        relevantTopics.push(topic)
+      }
+    }
+  } else if (props.themeName !== NoOptionSelected) {
+    for (const topic of allTopics) {
+      if (isRelevant(topic, 'theme', props.themeName)) {
+        relevantTopics.push(topic)
+      }
+    }
+  }
+  return relevantTopics
+})
+
+const numberOfResultMsg: ComputedRef<string> = computed(() => {
+  if (bouquets.value.length === 1) {
+    return '1 bouquet disponible'
+  } else {
+    return bouquets.value.length + ' bouquets disponibles'
+  }
+})
+
+const isRelevant = (topic: Topic, property: string, value: string): Boolean => {
+  const topicInformations: { [key: string]: string }[] =
+    topic.extras['ecospheres:informations']
+  if (topicInformations) {
+    for (const information of topicInformations) {
+      if (information[property] === value) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+const goToCreate = () => {
+  router.push({ name: 'bouquet_add' })
+}
+
+onMounted(() => {
+  const loader = useLoading().show()
+  useTopicStore()
+    .loadTopicsForUniverse()
+    .finally(() => {
+      loader.hide()
+    })
+})
+</script>
+
 <template>
   <div v-if="bouquets.length > 0">
     <p>{{ numberOfResultMsg }}</p>
@@ -38,90 +122,3 @@
     </ul>
   </div>
 </template>
-
-<script lang="ts">
-import { onMounted } from 'vue'
-import { useLoading } from 'vue-loading-overlay'
-
-import Tile from '@/components/Tile.vue'
-import type { Topic } from '@/model'
-import { NoOptionSelected } from '@/model'
-import { useTopicStore } from '@/store/TopicStore'
-
-export default {
-  name: 'BouquetList',
-  components: {
-    Tile
-  },
-  props: {
-    themeName: {
-      type: String,
-      default: NoOptionSelected
-    },
-    subthemeName: {
-      type: String,
-      default: NoOptionSelected
-    }
-  },
-  setup() {
-    onMounted(() => {
-      const loader = useLoading().show()
-      useTopicStore()
-        .loadTopicsForUniverse()
-        .finally(() => {
-          loader.hide()
-        })
-    })
-  },
-  computed: {
-    bouquets(): Topic[] {
-      const allTopics = useTopicStore().$state.data
-      if (this.themeName === NoOptionSelected) {
-        return allTopics
-      }
-      const relevantTopics: Topic[] = []
-      if (this.subthemeName !== NoOptionSelected) {
-        for (const topic of allTopics) {
-          if (
-            this.isRelevant(topic, 'subtheme', this.subthemeName) &&
-            this.isRelevant(topic, 'theme', this.themeName)
-          ) {
-            relevantTopics.push(topic)
-          }
-        }
-      } else if (this.themeName !== NoOptionSelected) {
-        for (const topic of allTopics) {
-          if (this.isRelevant(topic, 'theme', this.themeName)) {
-            relevantTopics.push(topic)
-          }
-        }
-      }
-      return relevantTopics
-    },
-    numberOfResultMsg(): string {
-      if (this.bouquets.length === 1) {
-        return '1 bouquet disponible'
-      } else {
-        return this.bouquets.length + ' bouquets disponibles'
-      }
-    }
-  },
-  methods: {
-    isRelevant(topic: Topic, property: string, value: string): Boolean {
-      const topicInformations: { [key: string]: string }[] =
-        topic.extras['ecospheres:informations']
-      if (topicInformations) {
-        for (const information of topicInformations) {
-          if (information[property] === value) {
-            return true
-          }
-        }
-      }
-      return false
-    },
-    goToCreate() {
-      this.$router.push({ name: 'bouquet_add' })
-    }
-  }
-}
-</script>

--- a/src/custom/ecospheres/views/bouquets/BouquetsListView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetsListView.vue
@@ -1,3 +1,60 @@
+<script setup lang="ts">
+import { ref, watch, computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+import BouquetList from '@/custom/ecospheres/components/BouquetList.vue'
+import BouquetSearch from '@/custom/ecospheres/components/BouquetSearch.vue'
+import { type BreadcrumbItem, NoOptionSelected } from '@/model'
+
+const route = useRoute()
+
+const props = defineProps({
+  initThemeName: {
+    type: String,
+    default: NoOptionSelected
+  },
+  initSubthemeName: {
+    type: String,
+    default: NoOptionSelected
+  }
+})
+
+const themeName = ref(props.initThemeName)
+const subthemeName = ref(props.initSubthemeName)
+
+const subThemeQuery = computed(() => route.query.subtheme)
+const themeQuery = computed(() => route.query.theme)
+
+watch([subThemeQuery], (newVal) => {
+  subthemeName.value = newVal
+})
+
+watch([themeQuery], (newVal) => {
+  themeName.value = newVal
+})
+
+const breadcrumbList = computed(() => {
+  const links: BreadcrumbItem[] = []
+  if (themeName.value !== NoOptionSelected) {
+    links.push({ text: 'Accueil', to: '/' })
+    links.push({
+      text: themeName.value,
+      to: `/bouquets?theme=${themeName.value}`
+    })
+    if (subthemeName.value !== NoOptionSelected) {
+      links.push({ text: subthemeName.value })
+    }
+  }
+  return links
+})
+
+const classDependingOnBreadcrumb = computed(() => {
+  return breadcrumbList.value.length > 0
+    ? 'with_breadcrumb'
+    : 'without_breadcrumb'
+})
+</script>
+
 <template>
   <div class="fr-container fr-mt-4w fr-mb-4w">
     <DsfrBreadcrumb class="breadcrumb" :links="breadcrumbList" />
@@ -8,7 +65,7 @@
           aria-labelledby="fr-sidemenu-title"
         >
           <div className="fr-sidemenu__inner">
-            <div className="fr-sidemenu__title" id="fr-sidemenu-title">
+            <div id="fr-sidemenu-title" className="fr-sidemenu__title">
               Filtres
             </div>
             <BouquetSearch
@@ -18,68 +75,9 @@
           </div>
         </nav>
         <div className="fr-col-8">
-          <BouquetList :themeName="themeName" :subthemeName="subthemeName" />
+          <BouquetList :theme-name="themeName" :subtheme-name="subthemeName" />
         </div>
       </div>
     </div>
   </div>
 </template>
-
-<script lang="ts">
-import BouquetList from '@/custom/ecospheres/components/BouquetList.vue'
-import BouquetSearch from '@/custom/ecospheres/components/BouquetSearch.vue'
-import { type BreadcrumbItem, NoOptionSelected } from '@/model'
-
-export default {
-  name: 'BouquetsListView',
-  components: {
-    BouquetSearch: BouquetSearch,
-    BouquetList: BouquetList
-  },
-  props: {
-    initThemeName: {
-      type: String,
-      default: NoOptionSelected
-    },
-    initSubthemeName: {
-      type: String,
-      default: NoOptionSelected
-    }
-  },
-  data() {
-    return {
-      themeName: this.initThemeName,
-      subthemeName: this.initSubthemeName
-    }
-  },
-  watch: {
-    '$route.query.subtheme'(newVal) {
-      this.subthemeName = newVal
-    },
-    '$route.query.theme'(newVal) {
-      this.themeName = newVal
-    }
-  },
-  computed: {
-    breadcrumbList() {
-      const links: BreadcrumbItem[] = []
-      if (this.themeName !== NoOptionSelected) {
-        links.push({ text: 'Accueil', to: '/' })
-        links.push({
-          text: this.themeName,
-          to: `/bouquets?theme=${this.themeName}`
-        })
-        if (this.subthemeName !== NoOptionSelected) {
-          links.push({ text: this.subthemeName })
-        }
-      }
-      return links
-    },
-    classDependingOnBreadcrumb() {
-      return this.breadcrumbList.length > 0
-        ? 'with_breadcrumb'
-        : 'without_breadcrumb'
-    }
-  }
-}
-</script>

--- a/src/custom/ecospheres/views/bouquets/BouquetsListView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetsListView.vue
@@ -8,57 +8,52 @@ import { type BreadcrumbItem, NoOptionSelected } from '@/model'
 
 const route = useRoute()
 
-const props = defineProps({
-  initThemeName: {
-    type: String,
-    default: NoOptionSelected
-  },
-  initSubthemeName: {
-    type: String,
-    default: NoOptionSelected
-  }
-})
-
-const themeName = ref(props.initThemeName)
-const subthemeName = ref(props.initSubthemeName)
+const themeName = ref(NoOptionSelected)
+const subthemeName = ref(NoOptionSelected)
 
 const subThemeQuery = computed(() => route.query.subtheme)
 const themeQuery = computed(() => route.query.theme)
 
-watch([subThemeQuery], (newVal) => {
-  subthemeName.value = newVal
-})
+watch(
+  [subThemeQuery],
+  (newVal) => {
+    subthemeName.value = newVal[0]?.toString() ?? NoOptionSelected
+  },
+  { immediate: true }
+)
 
-watch([themeQuery], (newVal) => {
-  themeName.value = newVal
-})
+watch(
+  [themeQuery],
+  (newVal) => {
+    themeName.value = newVal[0]?.toString() ?? NoOptionSelected
+  },
+  { immediate: true }
+)
 
 const breadcrumbList = computed(() => {
   const links: BreadcrumbItem[] = []
-  if (themeName.value !== NoOptionSelected) {
-    links.push({ text: 'Accueil', to: '/' })
+  links.push({ text: 'Accueil', to: '/' })
+  links.push({ text: 'Bouquets', to: '/bouquets' })
+  if (themeName.value !== NoOptionSelected && themeName.value !== '') {
     links.push({
       text: themeName.value,
-      to: `/bouquets?theme=${themeName.value}`
+      to: `/bouquets?theme=${themeName.value}&subtheme=${NoOptionSelected}`
     })
-    if (subthemeName.value !== NoOptionSelected) {
+    if (subthemeName.value !== NoOptionSelected && subthemeName.value !== '') {
       links.push({ text: subthemeName.value })
     }
   }
   return links
 })
-
-const classDependingOnBreadcrumb = computed(() => {
-  return breadcrumbList.value.length > 0
-    ? 'with_breadcrumb'
-    : 'without_breadcrumb'
-})
 </script>
 
 <template>
-  <div class="fr-container fr-mt-4w fr-mb-4w">
-    <DsfrBreadcrumb class="breadcrumb" :links="breadcrumbList" />
-    <div :class="classDependingOnBreadcrumb">
+  <div class="fr-container">
+    <DsfrBreadcrumb class="fr-mb-1v" :links="breadcrumbList" />
+  </div>
+  <div class="fr-container fr-mb-4w">
+    <h1 class="fr-mb-2v">Bouquets</h1>
+    <div class="fr-mt-2w">
       <div className="fr-grid-row topicListView">
         <nav
           className="fr-sidemenu fr-col-4"


### PR DESCRIPTION
Fix #274 
Fix #316 
Related #178 

- Corrige le breadcrumb sur la page bouquets
- Ajoute un titre "Bouquets" pour être cohérent avec les autres pages
- Corrige le style pour être cohérent avec les autres pages (espacement)
- Refactor deux composants en composition API #178 
- Nettoie un peu `HomeThemes` par opportunisme

<img width="1048" alt="Capture d’écran 2024-01-08 à 09 56 46" src="https://github.com/opendatateam/udata-front-kit/assets/119625/b0332b10-4332-4b40-a014-4ece263eaf4f">
