### PR TITLE
feat: bouquet en mode brouillon (private)

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -152,6 +152,13 @@ themes:
       - name: La transition juste et les mesures d’accompagnement, pour ne laisser personne au bord du chemin
       - name: La sobriété des usages et des ressources
 
+bouquets:
+  steps:
+    - Description du bouquet de données
+    - Informations du bouquet de données
+    - Composition du bouquet de données
+    - Récapitulatif du bouquet de données
+
 # FIXME: Obsolete. Kept as a reference used to populate our universe.
 # list of organisations' ids that should be handled by the portal
 # to find an id go to https://www.data.gouv.fr/fr/organizations/ministere-de-la-transition-ecologique/

--- a/src/custom/ecospheres/components/forms/bouquet/BouquetContentFieldGroup.vue
+++ b/src/custom/ecospheres/components/forms/bouquet/BouquetContentFieldGroup.vue
@@ -42,8 +42,11 @@ export default {
     }
   },
   watch: {
-    isValid(newValue) {
-      this.$emit('updateValidation', newValue)
+    isValid: {
+      handler(newValue) {
+        this.$emit('updateValidation', newValue)
+      },
+      immediate: true
     }
   },
   methods: {

--- a/src/custom/ecospheres/components/forms/bouquet/BouquetPropertiesFieldGroup.vue
+++ b/src/custom/ecospheres/components/forms/bouquet/BouquetPropertiesFieldGroup.vue
@@ -68,8 +68,11 @@ export default {
     }
   },
   watch: {
-    isValid(newValue) {
-      this.$emit('updateValidation', newValue)
+    isValid: {
+      handler(newValue) {
+        this.$emit('updateValidation', newValue)
+      },
+      immediate: true
     }
   }
 }

--- a/src/custom/ecospheres/components/forms/bouquet/BouquetThemeFieldGroup.vue
+++ b/src/custom/ecospheres/components/forms/bouquet/BouquetThemeFieldGroup.vue
@@ -84,8 +84,11 @@ export default {
     }
   },
   watch: {
-    isValid(newValue) {
-      this.$emit('updateValidation', newValue)
+    isValid: {
+      handler(newValue) {
+        this.$emit('updateValidation', newValue)
+      },
+      immediate: true
     }
   },
   methods: {

--- a/src/custom/ecospheres/components/forms/bouquet/BouquetThemeFieldGroup.vue
+++ b/src/custom/ecospheres/components/forms/bouquet/BouquetThemeFieldGroup.vue
@@ -91,6 +91,7 @@ export default {
   methods: {
     switchTheme(event: Event) {
       this.$emit('update:theme', (event.target as HTMLSelectElement).value)
+      this.$emit('update:subtheme', NoOptionSelected)
     },
     switchSubtheme(event: Event) {
       this.$emit('update:subtheme', (event.target as HTMLSelectElement).value)

--- a/src/custom/ecospheres/views/bouquets/BouquetAddView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetAddView.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import type { Ref, ComputedRef } from 'vue'
+import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
+
+import config from '@/config'
+import BouquetPropertiesFieldGroup from '@/custom/ecospheres/components/forms/bouquet/BouquetPropertiesFieldGroup.vue'
+import type { Bouquet, BouquetCreationData } from '@/model'
+import { useTopicStore } from '@/store/TopicStore'
+
+const router = useRouter()
+
+const bouquet: Ref<Partial<Bouquet>> = ref({})
+const isStepValid: Ref<boolean> = ref(false)
+const errorMsg: Ref<string | null> = ref(null)
+const steps = config.bouquets.steps
+
+const bouquetCreationData: ComputedRef<BouquetCreationData> = computed(() => {
+  return {
+    name: bouquet.value.name ?? '',
+    description: bouquet.value.description ?? '',
+    tags: [config.universe.name],
+    private: true
+  }
+})
+
+const createTopic = async () => {
+  return useTopicStore().create(bouquetCreationData.value)
+}
+
+// TODO: catch errors
+const submit = () => {
+  createTopic().then((response) => {
+    router.push({
+      name: 'bouquet_edit',
+      params: { bid: response.id }
+    })
+  })
+}
+</script>
+
+<template>
+  <div class="fr-container fr-mt-4w fr-mb-4w">
+    <form class="fr-col-12 fr-col-lg-7">
+      <div class="fr-grid-row">
+        <DsfrStepper :steps="steps" :current-step="1" />
+      </div>
+      <div class="fr-mt-4v">
+        <DsfrAlert v-if="errorMsg" type="warning" :title="errorMsg" />
+      </div>
+      <BouquetPropertiesFieldGroup
+        v-model:bouquetName="bouquet.name"
+        v-model:bouquetDescription="bouquet.description"
+        @update-validation="(isValid: boolean) => isStepValid = isValid"
+      />
+      <div class="fit fr-mt-3w fr-ml-auto">
+        <DsfrButton
+          type="button"
+          class="fr-mt-2w"
+          label="Suivant"
+          :disabled="!isStepValid"
+          @click.prevent="submit()"
+        />
+      </div>
+    </form>
+  </div>
+</template>

--- a/src/custom/ecospheres/views/bouquets/BouquetAddView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetAddView.vue
@@ -28,7 +28,6 @@ const createTopic = async () => {
   return useTopicStore().create(bouquetCreationData.value)
 }
 
-// TODO: catch errors
 const submit = () => {
   createTopic()
     .then((response) => {

--- a/src/custom/ecospheres/views/bouquets/BouquetAddView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetAddView.vue
@@ -30,12 +30,16 @@ const createTopic = async () => {
 
 // TODO: catch errors
 const submit = () => {
-  createTopic().then((response) => {
-    router.push({
-      name: 'bouquet_edit',
-      params: { bid: response.id }
+  createTopic()
+    .then((response) => {
+      router.push({
+        name: 'bouquet_edit',
+        params: { bid: response.id }
+      })
     })
-  })
+    .catch((error) => {
+      errorMsg.value = `Quelque chose s'est mal passé, merci de réessayer. (${error.code})`
+    })
 }
 </script>
 

--- a/src/custom/ecospheres/views/bouquets/BouquetEditView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetEditView.vue
@@ -26,13 +26,7 @@ const stepsValidation: Ref<[boolean, boolean, boolean]> = ref([
 ])
 const errorMsg: Ref<string | null> = ref(null)
 const bouquetId: Ref<string | null> = ref(null)
-
-const steps = [
-  'Description du bouquet de données',
-  'Informations du bouquet de données',
-  'Composition du bouquet de données',
-  'Récapitulatif du bouquet de données'
-]
+const steps = config.bouquets.steps
 
 const bouquetCreationData: ComputedRef<BouquetCreationData> = computed(() => {
   // we coalesce to empty string to satisfy typing but empty strings should not be allowed

--- a/src/custom/ecospheres/views/bouquets/BouquetEditView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetEditView.vue
@@ -34,9 +34,7 @@ const bouquetCreationData: ComputedRef<BouquetCreationData> = computed(() => {
     description: bouquet.value.description ?? '',
     datasets: datasetsId.value,
     tags: [config.universe.name],
-    private:
-      !allStepAreValid.value ||
-      currentStep.value <= stepsValidation.value.length,
+    private: currentStep.value <= stepsValidation.value.length,
     extras: {
       'ecospheres:informations': [
         {

--- a/src/custom/ecospheres/views/bouquets/BouquetEditView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetEditView.vue
@@ -57,15 +57,6 @@ const datasetsId: ComputedRef<string[]> = computed(() => {
   return datasetsId
 })
 
-const allStepAreValid: ComputedRef<boolean> = computed(() => {
-  for (const step of stepsValidation.value) {
-    if (step === false) {
-      return false
-    }
-  }
-  return true
-})
-
 const goToPreviousPage = () => {
   currentStep.value--
 }

--- a/src/custom/ecospheres/views/bouquets/BouquetEditView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetEditView.vue
@@ -19,7 +19,7 @@ const router = useRouter()
 const bouquet: Ref<Partial<Bouquet>> = ref({})
 const currentStep: Ref<number> = ref(2)
 const stepsValidation: Ref<[boolean, boolean, boolean]> = ref([
-  true,
+  false,
   false,
   false
 ])
@@ -126,13 +126,26 @@ const fillBouquetFromTopic = (topic: Topic): Bouquet => {
   }
 }
 
-// TODO: choose the right step from loaded bouquet or read it from URL
+/**
+ * Depending on topic state, infer the step we should be on
+ */
+const inferStepFromTopic = (topic: Topic): number => {
+  if (topic.extras['ecospheres:datasets_properties']?.length > 0) {
+    return 4
+  } else if (topic.extras['ecospheres:informations'] !== undefined) {
+    return 3
+  } else {
+    return 2
+  }
+}
+
 onMounted(() => {
   const loader = useLoading().show()
   useTopicStore()
     .load(route.params.bid)
     .then((topic) => {
       bouquet.value = fillBouquetFromTopic(topic)
+      currentStep.value = inferStepFromTopic(topic)
     })
     .finally(() => loader.hide())
 })

--- a/src/custom/ecospheres/views/bouquets/BouquetEditView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetEditView.vue
@@ -79,8 +79,8 @@ const updateTopic = async () => {
   return useTopicStore().update(bouquet.value.id, bouquetCreationData.value)
 }
 
-const isStepValid = (step: number) => {
-  if (step > stepsValidation.value.length) return allStepAreValid.value
+const isStepValid = (step: number): boolean => {
+  if (step > stepsValidation.value.length) return true
   return stepsValidation.value[step - 1]
 }
 
@@ -88,22 +88,21 @@ const updateStepValidation = (step: number, isValid: boolean) => {
   stepsValidation.value[step - 1] = isValid
 }
 
-// TODO: catch errors
 const goToNextStep = () => {
-  // this is a failsafe that should never be triggered
-  if (!isStepValid(currentStep.value)) {
-    throw Error(`Invalid step ${currentStep.value}, can not proceed`)
-  }
-  updateTopic().then((response) => {
-    if (currentStep.value > stepsValidation.value.length) {
-      router.push({
-        name: 'bouquet_detail',
-        params: { bid: response.slug }
-      })
-    } else {
-      currentStep.value++
-    }
-  })
+  updateTopic()
+    .then((response) => {
+      if (currentStep.value > stepsValidation.value.length) {
+        router.push({
+          name: 'bouquet_detail',
+          params: { bid: response.slug }
+        })
+      } else {
+        currentStep.value++
+      }
+    })
+    .catch((error) => {
+      errorMsg.value = `Quelque chose s'est mal passé, merci de réessayer. (${error.code})`
+    })
 }
 
 const fillBouquetFromTopic = (topic: Topic): Bouquet => {
@@ -193,7 +192,7 @@ onMounted(() => {
         <DsfrButton
           type="button"
           class="fr-mt-2w"
-          label="Suivant"
+          :label="currentStep === 4 ? 'Publier' : 'Suivant'"
           :disabled="!isStepValid(currentStep)"
           @click.prevent="goToNextStep()"
         />

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -54,8 +54,12 @@ interface Bouquet {
 interface BouquetCreationData {
   name: string
   description: string
-  datasets: string[] // list of ids (for the dataset which have one)
+  private: boolean
   tags: string[]
+}
+
+interface BouquetEditionData extends BouquetCreationData {
+  datasets: string[] // list of ids (for the dataset which have one)
   extras: TopicExtras
 }
 
@@ -94,5 +98,6 @@ export type {
   Topic,
   Bouquet,
   DatasetProperties,
-  BouquetCreationData
+  BouquetCreationData,
+  BouquetEditionData
 }

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -44,6 +44,7 @@ interface BreadcrumbItem {
 }
 
 interface Bouquet {
+  id: string
   name: string
   description: string
   theme: string | undefined

--- a/src/services/routerUtils.js
+++ b/src/services/routerUtils.js
@@ -1,4 +1,5 @@
 import config from '@/config'
+import BouquetAddView from '@/custom/ecospheres/views/bouquets/BouquetAddView.vue'
 import BouquetDetailView from '@/custom/ecospheres/views/bouquets/BouquetDetailView.vue'
 import BouquetEditView from '@/custom/ecospheres/views/bouquets/BouquetEditView.vue'
 import BouquetsListView from '@/custom/ecospheres/views/bouquets/BouquetsListView.vue'
@@ -69,7 +70,7 @@ export default class RouterFetch {
         items.push({
           path: `/admin/${item.id}/add`,
           name: 'bouquet_add',
-          component: BouquetEditView,
+          component: BouquetAddView,
           meta: { requiresAuth: true }
         })
         /** protected / admin route  **/

--- a/src/store/TopicStore.ts
+++ b/src/store/TopicStore.ts
@@ -77,7 +77,7 @@ export const useTopicStore = defineStore('topic', {
     /**
      * Update a topic
      */
-    async update(topicId: string, data: Topic): Promise<Topic> {
+    async update(topicId: string, data: any): Promise<Topic> {
       const res = await topicsAPI.update(topicId, data)
       const idx = this.data.findIndex((b) => b.id === topicId)
       this.data[idx] = res

--- a/src/store/TopicStore.ts
+++ b/src/store/TopicStore.ts
@@ -28,21 +28,27 @@ export const useTopicStore = defineStore('topic', {
       }
     },
     /**
-     * Filter a list of topics related to the current universe
+     * Filter a list of topics related to the current universe and private or not
      */
-    filter(topics: Topic[]) {
-      return topics.filter((topic) => topic.id !== config.universe.topic_id)
+    filter(topics: Topic[], withPrivate: boolean = false) {
+      return topics.filter((topic) => {
+        return topic.id !== config.universe.topic_id && withPrivate
+          ? true
+          : !topic.private
+      })
     },
     /**
      * Load universe related topics from API
      */
-    async loadTopicsForUniverse(): Promise<Topic[]> {
+    async loadTopicsForUniverse(
+      withPrivate: boolean = false
+    ): Promise<Topic[]> {
       if (this.data.length > 0) return this.data
       let response = await topicsAPIv2.list({
         page_size: config.website.pagination_sizes.topics_list,
         tag: config.universe.name
       })
-      this.data = this.filter(response.data)
+      this.data = this.filter(response.data, withPrivate)
       while (response.next_page !== null) {
         response = await topicsAPIv2.request({
           url: response.next_page,


### PR DESCRIPTION
Fix #280 
Related #225 
Related #178 

## Fonctionnalité principale

- Crée un bouquet avec `private: true` jusqu'à la dernière étape (Résumé -> Publier -> `private: false`), aka mode brouillon
- Filtre la liste principale des bouquets en masquant les bouquets en mode brouillon (la vue d'affichage n'est pas compatible avec un bouquet incomplet)

## Détails

- Ajoute une vue `BouquetAddView` pour la création du bouquet (étape 1), qui redirige ensuite vers l'édition du bouquet pour les étapes suivantes, via une URL de la forme `/admin/bouquets/edit/{id-tech-du-bouquet}`
- La vue `BouquetEditView` tente d'afficher la bonne étape en fonction de la complétion du bouquet, il est ainsi possible de reprendre l'édition en revenant sur l'URL
- La dernière étape publie le bouquet (private: false)
- Il est possible de naviguer entre les différentes étapes (boutons précédent <> suivant)

## Autre 

- refactor `BouquetEditView` en composition API

## A suivre

- L'édition de bouquet #225 devrait être triviale sur la base de cette PR
- Voir où et comment afficher les bouquets en mode brouillon, #181 est une piste