### PR TITLE
fix: custom component in import

### DIFF
--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -53,7 +53,8 @@ website:
       id: 'FormMF'
       linkPage: '/form'
       type: 'custom'
-      path: '../custom/meteo/views/FormMF.vue'
+      custom_folder: 'meteo'
+      custom_component: 'FormMF'
       display_menu: true
     # - name: 'Portail des API Météo-France'
     #   id: 'portailapi'

--- a/src/services/routerUtils.js
+++ b/src/services/routerUtils.js
@@ -97,7 +97,10 @@ export default class RouterFetch {
         items.push({
           path: item.linkPage,
           name: item.id,
-          component: () => import(item.path /* @vite-ignore */)
+          component: () =>
+            import(
+              `@/custom/${item.custom_folder}/views/${item.custom_component}.vue`
+            )
         })
       }
     })


### PR DESCRIPTION
L'import dynamique ne marchait pas lors du build. On fait actuellement [un hack très moche](https://github.com/opendatateam/udata-front-kit/commit/96ebd45adf93f332585e1a141cae2371066ff002) pour que ça marche. 

C'est la solution que j'ai trouvé pour que ça fonctionne tout en restant suffisamment configurable. On est donc obligé de passer par deux variables (une localisant le sous-dossier custom, l'autre indiquant le composant view). Je n'arrive pas à le faire marcher si j'ajoute l'ensemble du path en variable. Preneur d'autres solutions si vous avez une idée, en tout cas cette solution permet que cela fonctionne.