### PR TITLE
feat: bouquet edit

### DIFF
--- a/src/custom/ecospheres/components/BouquetList.vue
+++ b/src/custom/ecospheres/components/BouquetList.vue
@@ -113,7 +113,7 @@ onMounted(() => {
         class="fr-col-12 fr-col-lg-6"
       >
         <Tile
-          :link="`/bouquets/${bouquet.slug}`"
+          :link="`/bouquets/${bouquet.slug}?fromSearch=1`"
           :title="bouquet.name"
           :description="bouquet.description"
           :is-markdown="true"

--- a/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
@@ -26,6 +26,7 @@ const subtheme = ref()
 const loading = useLoading()
 
 const description = computed(() => descriptionFromMarkdown(bouquet))
+const showGoBack = computed(() => route.query.fromSearch !== undefined)
 
 const breadcrumbLinks = ref([
   {
@@ -38,8 +39,8 @@ const url = window.location.href
 
 const showDiscussions = config.website.discussions.topic.display
 
-const goToCreate = () => {
-  router.push({ name: 'bouquet_add' })
+const goToEdit = () => {
+  router.push({ name: 'bouquet_edit', params: { bid: bouquet.value?.id } })
 }
 
 const goBack = () => {
@@ -73,7 +74,7 @@ const getSelectedThemeColor = (themed: string) => {
   return getThemeColor(selectedTheme.value)
 }
 
-const canCreate = computed(() => {
+const canEdit = computed(() => {
   return (
     userStore.isAdmin() ||
     (userStore.$state.isLoggedIn &&
@@ -114,6 +115,7 @@ onMounted(() => {
   <div class="fr-container fr-mt-4w fr-mb-4w">
     <DsfrBreadcrumb :links="breadcrumbLinks" class="fr-mb-2w" />
     <DsfrButton
+      v-if="showGoBack"
       class="backToPage fr-pl-0 fr-mb-2w"
       :tertiary="true"
       :no-outline="true"
@@ -146,10 +148,10 @@ onMounted(() => {
         />
       </div>
       <DsfrButton
-        v-if="canCreate"
-        label="Créer un bouquet"
+        v-if="canEdit"
+        label="Editer le bouquet"
         icon="ri-pencil-line"
-        @click="goToCreate"
+        @click="goToEdit"
       />
     </div>
     <div class="bouquet__container fr-p-6w fr-mb-6w">


### PR DESCRIPTION
Fix #225 
Fix #318 (opportunisme)

Utilise #321 pour proposer l'édition d'un bouquet (si on en est propriétaire ou admin) depuis l'interface de visualisation d'un bouquet.

La navigation via "Suivant" dans les différentes étapes de création d'un bouquet remet le bouquet en mode brouillon, jusqu'à ce que qu'on revienne à "Publier". A voir si ce comportement est souhaitable.

<img width="1062" alt="Capture d’écran 2024-01-10 à 13 42 10" src="https://github.com/opendatateam/udata-front-kit/assets/119625/793a5dbc-39d2-4c6a-b239-f7e5f438c476">
