### PR TITLE
Upgrade vite and @vitejs/plugin-vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/node": "^20.9.1",
         "@typescript-eslint/eslint-plugin": "^6.11.0",
         "@typescript-eslint/parser": "^6.11.0",
-        "@vitejs/plugin-vue": "^4.2.3",
+        "@vitejs/plugin-vue": "^4.6.1",
         "@vue/eslint-config-standard": "^8.0.1",
         "@vue/eslint-config-typescript": "^12.0.0",
         "@vue/tsconfig": "^0.4.0",
@@ -54,7 +54,7 @@
         "prettier-config-standard": "^7.0.0",
         "sass": "^1.63.6",
         "typescript": "^5.2.2",
-        "vite": "^4.5.1",
+        "vite": "^4.5.2",
         "vite-plugin-dynamic-import": "^1.5.0",
         "vitest": "^0.34.6"
       },
@@ -1633,9 +1633,9 @@
       "dev": true
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.2.tgz",
-      "integrity": "sha512-UGR3DlzLi/SaVBPX0cnSyE37vqxU3O6chn8l0HJNzQzDia6/Au2A4xKv+iIJW8w2daf80G7TYHhi1pAUjdZ0bQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.6.1.tgz",
+      "integrity": "sha512-4JG1b1SPQpviIXkp4cwUaHluU0KCgjLprdyYaw4cq6OkJzqFXuao5CefsOaftcRpw8rlMQVwmHEurK+1zIzTlA==",
       "dev": true,
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -7742,9 +7742,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^20.9.1",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.11.0",
-    "@vitejs/plugin-vue": "^4.2.3",
+    "@vitejs/plugin-vue": "^4.6.1",
     "@vue/eslint-config-standard": "^8.0.1",
     "@vue/eslint-config-typescript": "^12.0.0",
     "@vue/tsconfig": "^0.4.0",
@@ -64,7 +64,7 @@
     "prettier-config-standard": "^7.0.0",
     "sass": "^1.63.6",
     "typescript": "^5.2.2",
-    "vite": "^4.5.1",
+    "vite": "^4.5.2",
     "vite-plugin-dynamic-import": "^1.5.0",
     "vitest": "^0.34.6"
   },


### PR DESCRIPTION
- Corrige une vulnérabilité en upgradant `vite` https://github.com/opendatateam/udata-front-kit/security/dependabot/3
- Corrige le warning suivant (en local) en upgradant `@vite/plugin-vue`, qui est [responsable de l'injection de ces variables](https://vuejs.org/api/compile-time-flags#vite)


> Feature flag __VUE_PROD_HYDRATION_MISMATCH_DETAILS__ is not explicitly defined. You are running the esm-bundler build of Vue, which expects these compile-time feature flags to be globally injected via the bundler config in order to get better tree-shaking in the production bundle.