### PR TITLE
fix(router): scroll to top by default on page change

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,7 +6,15 @@ const routerFetch = new RouterFetch()
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
-  routes: routerFetch.generateRouteItems()
+  routes: routerFetch.generateRouteItems(),
+  // scroll to top by default, unless back/forward from browser
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition
+    } else {
+      return { top: 0 }
+    }
+  }
 })
 
 export default router


### PR DESCRIPTION
On scrolle désormais par défaut vers le haut de la page au changement de page, sauf dans le cas où on utilise les fonctions back ou forward du navigateur.

Fix #319 

Cf https://router.vuejs.org/guide/advanced/scroll-behavior