### PR TITLE
fix(bouquets): handle required fields on DatasetPropertiesForm

### DIFF
--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -1,12 +1,12 @@
 <script setup>
-const props = defineProps(['title', 'name', 'show', 'text'])
+const props = defineProps(['title', 'name', 'show', 'text', 'optional'])
 </script>
 
 <template>
   <div class="container">
     <div>
       {{ title }}
-      <span class="required">&nbsp;*</span>
+      <span v-if="!props.optional" class="required">&nbsp;*</span>
     </div>
     <button
       @mouseover="show = true"

--- a/src/custom/ecospheres/components/forms/dataset/DatasetPropertiesForm.vue
+++ b/src/custom/ecospheres/components/forms/dataset/DatasetPropertiesForm.vue
@@ -4,7 +4,9 @@
       <h5>Ajouter un jeu de données</h5>
 
       <div class="fr-mt-1w fr-mb-4w">
-        <label class="fr-label" for="label">Libellé de la donnée</label>
+        <label class="fr-label" for="label"
+          >Libellé de la donnée <span class="required">&nbsp;*</span></label
+        >
         <input id="label" v-model="title" class="fr-input" type="text" />
       </div>
       <div class="fr-mt-1w fr-mb-4w">
@@ -17,6 +19,7 @@
           title="Utilisez du markdown pour mettre en forme votre texte"
           name="tooltip__markdown"
           text="* simple astérisque pour italique *<br/> ** double astérisque pour gras **<br/> # un dièse pour titre 1<br/> ## deux dièses pour titre 2<br/> *  astérisque pour une liste<br/> lien : [[https://exemple.fr]]"
+          :optional="true"
         />
         <textarea id="purpose" v-model="purpose" class="fr-input" type="text" />
       </div>
@@ -121,8 +124,15 @@ export default {
     availabilityEnum() {
       return Availability
     },
+    hasMandatoryFields() {
+      return !!this.title.trim() && !!this.purpose.trim()
+    },
     isValidDataset() {
-      return this.isValidEcosphereDataset && this.isValidUrlDataset
+      return (
+        this.hasMandatoryFields &&
+        this.isValidEcosphereDataset &&
+        this.isValidUrlDataset
+      )
     },
     isValidEcosphereDataset(): boolean {
       if (this.availability === Availability.LOCAL_AVAILABLE) {


### PR DESCRIPTION
Fix #285 

- désactive "Ajouter le jeu de données" tant que `title` et `purpose` sont vides
- enlève l'astérisque derrière "Utilisez du markdown"
- ajoute une astérisque derrière "Libellé de la donnée"