### PR TITLE
feat(bouquet): collapse accordion on BouquetDetailView

### DIFF
--- a/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
@@ -24,6 +24,7 @@ const bouquet: Ref<Topic | null> = ref(null)
 const theme = ref()
 const subtheme = ref()
 const loading = useLoading()
+const isExpanded = ref({} as { [key: string]: boolean })
 
 const description = computed(() => descriptionFromMarkdown(bouquet))
 const showGoBack = computed(() => route.query.fromSearch !== undefined)
@@ -178,8 +179,8 @@ onMounted(() => {
             <DsfrAccordion
               :id="datasetProperties.id"
               :title="datasetProperties.title"
-              :expanded-id="datasetProperties.id"
-              @expand="datasetProperties.id = $event"
+              :expanded-id="isExpanded[idx]"
+              @expand="isExpanded[idx] = $event"
             >
               <BouquetDatasetAvailability
                 :dataset-properties="datasetProperties"


### PR DESCRIPTION
Fix #336 

Ferme l'accordéon par défaut sur la vue de détail d'un bouquet.

J'ai repris le comportement de la dernière étape de la création/édition de bouquet : on peut ouvrir en même temps plusieurs éléments de l'accordéon. Ce n'est pas le comportement standard d'un accordéon, cf [exemple du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/accordeon/). J'ai choisi de rester cohérent avec l'existant, mais la question mérite d'être posée. @martyKN 