### PR TITLE
feat(bouquet): allow delete

### DIFF
--- a/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
@@ -18,7 +18,6 @@ const route = useRouteParamsAsString()
 const router = useRouter()
 
 const store = useTopicStore()
-const userStore = useUserStore()
 
 const bouquet: Ref<Topic | null> = ref(null)
 const theme = ref()
@@ -76,11 +75,7 @@ const getSelectedThemeColor = (themed: string) => {
 }
 
 const canEdit = computed(() => {
-  return (
-    userStore.isAdmin() ||
-    (userStore.$state.isLoggedIn &&
-      bouquet.value?.owner?.id === userStore.$state.data?.id)
-  )
+  return useUserStore().hasEditPermissions(bouquet.value as Topic)
 })
 
 onMounted(() => {
@@ -150,6 +145,7 @@ onMounted(() => {
       </div>
       <DsfrButton
         v-if="canEdit"
+        size="md"
         label="Editer le bouquet"
         icon="ri-pencil-line"
         @click="goToEdit"

--- a/src/custom/ecospheres/views/bouquets/BouquetEditView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetEditView.vue
@@ -12,6 +12,7 @@ import BouquetThemeFieldGroup from '@/custom/ecospheres/components/forms/bouquet
 import type { Bouquet, BouquetCreationData, Topic } from '@/model'
 import { useRouteParamsAsString } from '@/router/utils'
 import { useTopicStore } from '@/store/TopicStore'
+import { useUserStore } from '@/store/UserStore'
 
 const route = useRouteParamsAsString()
 const router = useRouter()
@@ -68,6 +69,20 @@ const updateTopic = async () => {
   return useTopicStore().update(bouquet.value.id, bouquetCreationData.value)
 }
 
+const canDelete = computed(() => {
+  return useUserStore().hasEditPermissions(bouquet.value as Bouquet)
+})
+
+const doDelete = async () => {
+  if (bouquet.value?.id === undefined) {
+    throw Error('Trying to delete topic without topic id')
+  }
+  if (window.confirm('Etes-vous sûr de vouloir supprimer ce bouquet ?')) {
+    await useTopicStore().delete(bouquet.value.id)
+    router.push({ name: 'bouquets' })
+  }
+}
+
 const isStepValid = (step: number): boolean => {
   if (step > stepsValidation.value.length) return true
   return stepsValidation.value[step - 1]
@@ -110,8 +125,10 @@ const fillBouquetFromTopic = (topic: Topic): Bouquet => {
     description: topic.description,
     theme: getInfoFromExtras('theme', topic),
     subtheme: getInfoFromExtras('subtheme', topic),
-    datasetsProperties: topic.extras['ecospheres:datasets_properties'] ?? []
-  }
+    datasetsProperties: topic.extras['ecospheres:datasets_properties'] ?? [],
+    owner: topic.owner,
+    organization: topic.organization
+  } as Bouquet
 }
 
 /**
@@ -170,11 +187,20 @@ onMounted(() => {
         :bouquet="bouquet"
         @update-step="(step: number) => (currentStep = step)"
       />
-      <div class="fit fr-mt-3w fr-ml-auto">
+      <div class="flex align-start fr-mt-3w">
+        <DsfrButton
+          v-if="canDelete"
+          type="button"
+          label="Supprimer le bouquet"
+          class="fr-mt-2w fr-mr-2w"
+          icon="ri-delete-bin-line"
+          secondary
+          @click="doDelete"
+        />
         <DsfrButton
           v-if="currentStep > 1"
           type="button"
-          class="fr-mt-2w fr-mr-2w"
+          class="fr-mt-2w fr-mr-2w fr-ml-auto"
           label="Précédent"
           @click.prevent="goToPreviousPage"
         />

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,5 +1,7 @@
 import type { Owned } from '@etalab/data.gouv.fr-components'
 
+type WithOwned<T> = T & Owned
+
 interface DatasetProperties {
   title: string
   purpose: string
@@ -43,7 +45,7 @@ interface BreadcrumbItem {
   to?: string
 }
 
-interface Bouquet {
+type Bouquet = Owned & {
   id: string
   name: string
   description: string
@@ -100,5 +102,6 @@ export type {
   Bouquet,
   DatasetProperties,
   BouquetCreationData,
-  BouquetEditionData
+  BouquetEditionData,
+  WithOwned
 }

--- a/src/store/TopicStore.ts
+++ b/src/store/TopicStore.ts
@@ -88,6 +88,14 @@ export const useTopicStore = defineStore('topic', {
       const idx = this.data.findIndex((b) => b.id === topicId)
       this.data[idx] = res
       return res
+    },
+    /**
+     * Delete a topic
+     */
+    async delete(topicId: string) {
+      await topicsAPI.delete(topicId)
+      const idx = this.data.findIndex((b) => b.id === topicId)
+      this.data.splice(idx, 1)
     }
   }
 })

--- a/src/store/UserStore.ts
+++ b/src/store/UserStore.ts
@@ -1,6 +1,8 @@
 import type { User } from '@etalab/data.gouv.fr-components'
 import { defineStore } from 'pinia'
 
+import type { WithOwned } from '@/model'
+
 // FIXME: we cant use UserAPI here (circular dep?)
 // maybe try to use the service that will use the API
 
@@ -62,6 +64,15 @@ export const useUserStore = defineStore('user', {
      */
     isAdmin() {
       return this.isLoggedIn && this.data?.roles?.includes('admin')
+    },
+    /**
+     * Has current user edit permissions on given object?
+     */
+    hasEditPermissions<T>(object: WithOwned<T> | null): boolean {
+      if (object === null) return false
+      if (!this.isLoggedIn) return false
+      if (this.isAdmin() === true) return true
+      return object.owner?.id === this.data?.id
     }
   }
 })


### PR DESCRIPTION
Permet la suppression d'un bouquet pour un propriétaire ou un admin (depuis l'interface d'édition).

La logique de vérification des permissions est centralisée dans le UserStore, afin de faciliter une gestion de droits plus complexe.

<img width="971" alt="Capture d’écran 2024-02-27 à 20 25 11" src="https://github.com/opendatateam/udata-front-kit/assets/119625/6dc5cedb-2fe5-48b6-a63c-391b3f7298d4">
