### PR TITLE
feat(bouquet): show user's owned drafts

### DIFF
--- a/src/custom/ecospheres/components/BouquetList.vue
+++ b/src/custom/ecospheres/components/BouquetList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ComputedRef } from 'vue'
-import { watch, computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useLoading } from 'vue-loading-overlay'
 import { useRouter, type RouteLocationRaw } from 'vue-router'
 
@@ -8,11 +8,8 @@ import Tile from '@/components/Tile.vue'
 import type { Topic } from '@/model'
 import { NoOptionSelected } from '@/model'
 import { useTopicStore } from '@/store/TopicStore'
-import { useUserStore } from '@/store/UserStore'
 
 const router = useRouter()
-const userStore = useUserStore()
-const loader = useLoading().show()
 
 const props = defineProps({
   themeName: {
@@ -92,18 +89,12 @@ const computeLink = (bouquet: Topic): RouteLocationRaw => {
   }
 }
 
-// launch topic fetch as soon as we have user infos
-watch(
-  () => userStore.isInited,
-  async (isInited) => {
-    if (isInited) {
-      const topicStore = useTopicStore()
-      await topicStore.loadTopicsForUniverse(userStore.isAdmin())
-      loader.hide()
-    }
-  },
-  { immediate: true }
-)
+onMounted(() => {
+  const loader = useLoading().show()
+  useTopicStore()
+    .loadTopicsForUniverse()
+    .then(() => loader.hide())
+})
 </script>
 
 <template>

--- a/src/custom/ecospheres/components/BouquetSearch.vue
+++ b/src/custom/ecospheres/components/BouquetSearch.vue
@@ -1,7 +1,6 @@
 <template>
   <div className="filterForm">
     <DsfrCheckbox
-      v-if="userStore.isAdmin()"
       v-model="showDrafts"
       label="Afficher les brouillons"
       name="show_drafts"
@@ -59,7 +58,6 @@ import { defineComponent } from 'vue'
 import { ConfigUtils } from '@/config'
 import { NoOptionSelected } from '@/model'
 import type { SelectOption, Theme } from '@/model'
-import { useUserStore } from '@/store/UserStore'
 
 export default defineComponent({
   name: 'BouquetSearch',
@@ -74,12 +72,6 @@ export default defineComponent({
     }
   },
   emits: ['update:showDrafts'],
-  setup() {
-    const userStore = useUserStore()
-    return {
-      userStore
-    }
-  },
   data: () => {
     return {
       showDrafts: false

--- a/src/store/UserStore.ts
+++ b/src/store/UserStore.ts
@@ -1,6 +1,7 @@
 import type { User } from '@etalab/data.gouv.fr-components'
 import type { AxiosError } from 'axios'
 import { defineStore } from 'pinia'
+import { watch } from 'vue'
 
 import type { WithOwned } from '@/model'
 import UserAPI from '@/services/api/resources/UserAPI'
@@ -59,6 +60,27 @@ export const useUserStore = defineStore('user', {
       }
       this.isInited = true
       return this.data
+    },
+    /**
+     * Promise around isInited
+     */
+    async waitForStoreInit(): Promise<void> {
+      await new Promise<void>((resolve) => {
+        if (this.isInited) {
+          resolve()
+        } else {
+          const unwatch = watch(
+            () => this.isInited,
+            (isInited: boolean) => {
+              if (isInited) {
+                unwatch()
+                resolve()
+              }
+            },
+            { immediate: true }
+          )
+        }
+      })
     },
     /**
      * Store user info after login


### PR DESCRIPTION
Related #344 

Permet aux utilisateurs connectés d'afficher _leurs_ brouillons.

La dépendance `TopicStore -> UserStore -> user.roles` est maintenant plus propre.

Fix https://github.com/ecolabdata/ecospheres/issues/88
Fix https://github.com/ecolabdata/ecospheres/issues/98