### PR TITLE
feat(dataset): filter by organization

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -102,6 +102,8 @@ website:
     topic:
       display: true
       create: true
+  datasets:
+    organization_filter: true
 
 themes:
   - name: Se loger
@@ -235,10 +237,6 @@ organizations:
   - 5a3b9453c751df6eff05e7fa
   # Direction régionale de l'Environnement, de l'Aménagement et du Logement de Normandie
   - 57275bd288ee387fd5a19f12
-  # Direction régionale de l'environnement, de l'aménagement et du logement de Normandie
-  - 63eba3458d114d860873c025
-  # Direction régionale et interdépartementale de l’Environnement, de l’Aménagement et des Transports
-  - 63d925a8734ac3600a5e31af
   # La Direction Régionale de l’Environnement, de l’Aménagement et du Logement Provence-Alpes-Côte d’Azur
   - 622f1234df654f029b10e77c
 
@@ -325,8 +323,6 @@ organizations:
   - 5883d4c488ee3809bb9b81a5
   # DDT de la Moselle
   - 5883d3d088ee38061b9b81a9
-  # DDT des Vosges
-  - 63da19abc971ec2c34618720
 
   ## QUERY=direction+departementale+territoire
   # DIRECTION DEPARTEMENTALE DES TERRITOIRES DE SAONE-ET-LOIRE (71)

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -120,6 +120,8 @@ website:
     topic:
       display: false
       create: false
+  datasets:
+    organization_filter: false
 
 # list of organisations' ids that should be handled by the portal
 # to find an id go to https://www.data.gouv.fr/fr/organizations/ministere-de-la-transition-ecologique/

--- a/src/model/api.ts
+++ b/src/model/api.ts
@@ -16,6 +16,7 @@ export interface RequestConfig {
   method: HttpMethod
   params?: object
   data?: object
+  headers?: object
 }
 
 export type URLParams = Record<string, string | number>

--- a/src/services/api/DatagouvfrAPI.ts
+++ b/src/services/api/DatagouvfrAPI.ts
@@ -40,12 +40,7 @@ export default class DatagouvfrAPI {
    * Make a `method` request to URL and optionnaly attach a toaster to the error
    */
   async request(config: RequestConfig): Promise<AxiosResponseData> {
-    const response = await axios({
-      url: config.url,
-      method: config.method,
-      params: config.params,
-      data: config.data
-    }).catch((error: AxiosError) => {
+    const response = await axios(config).catch((error: AxiosError) => {
       if (this.toasted) {
         toast(error.message, { type: 'error', autoClose: false })
       }
@@ -57,9 +52,13 @@ export default class DatagouvfrAPI {
   /**
    * Get an entity's detail from its id
    */
-  async get(entityId: string, params?: URLParams): Promise<AxiosResponseData> {
+  async get(
+    entityId: string,
+    params?: URLParams,
+    headers?: object
+  ): Promise<AxiosResponseData> {
     const url = `${this.url()}/${entityId}/`
-    return await this.request({ url, method: 'get', params })
+    return await this.request({ url, method: 'get', params, headers })
   }
 
   /**

--- a/src/store/OrganizationStore.js
+++ b/src/store/OrganizationStore.js
@@ -15,7 +15,9 @@ export const useOrganizationStore = defineStore('organization', {
     //     "orgs": []
     //   }, ...
     // ]
-    data: []
+    data: [],
+    // holds a non paginated lightweight-formatted list of all orgs
+    flatData: []
   }),
   actions: {
     /**
@@ -62,7 +64,19 @@ export const useOrganizationStore = defineStore('organization', {
       return this.getForPage(page)
     },
     /**
-     * Load multiple organisations to store
+     * Load multiple organizations in a lightweight format without pagination
+     * Used for e.g. for filtering
+     */
+    async loadFromConfigFlat() {
+      if (this.flatData.length > 0) return this.flatData
+      const promises = config.organizations.map(async (orgId) => {
+        return await orgApi.get(orgId, undefined, { 'x-fields': 'id,name' })
+      })
+      this.flatData = await Promise.all(promises)
+      return this.flatData
+    },
+    /**
+     * Load multiple organizations to store
      *
      * @param {Array<string>} org_ids
      * @param {number} page

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -34,13 +34,12 @@ export const useSearchStore = defineStore('search', {
     }
   },
   actions: {
-    async search(query, topic, page = 1) {
-      const args = { page_size: pageSize, page }
+    async search(query, topic, page = 1, args = {}) {
       const results = await searchAPI.search(
         query,
         topic || config.universe.topic_id,
         page,
-        args
+        { ...args, page_size: pageSize }
       )
       this.data = results
     }

--- a/src/views/datasets/DatasetsListView.vue
+++ b/src/views/datasets/DatasetsListView.vue
@@ -1,14 +1,16 @@
 <script setup>
 import { DatasetCard } from '@etalab/data.gouv.fr-components'
 import debounce from 'lodash/debounce'
-import { computed, onMounted, ref, watchEffect, watch } from 'vue'
+import { computed, onMounted, ref, watchEffect, watch, defineEmits } from 'vue'
 import { useLoading } from 'vue-loading-overlay'
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router'
 
 import config from '@/config'
+import { useOrganizationStore } from '@/store/OrganizationStore'
+import { useSearchStore } from '@/store/SearchStore'
+import { useTopicStore } from '@/store/TopicStore'
 
-import { useSearchStore } from '../../store/SearchStore'
-import { useTopicStore } from '../../store/TopicStore'
+defineEmits(['search'])
 
 const route = useRoute()
 const router = useRouter()
@@ -21,12 +23,15 @@ const loader = useLoading()
 const topicStore = useTopicStore()
 const topic = computed(() => route.query.topic)
 const selectedTopicId = ref(null)
+const selectedOrganizationId = ref(null)
 
 const datasets = computed(() => store.datasets)
 const pages = computed(() => store.pagination)
 
 const title = config.website.title
 const topicsConf = config.website.list_highlighted_topics
+const hasOrganizationFilter = config.website.datasets.organization_filter
+
 const topicOptions = computed(() => {
   if (!topicsConf?.length) return
   const topics = topicStore.$state.data
@@ -39,10 +44,22 @@ const topicOptions = computed(() => {
   return [{ value: '', text: 'Toutes les données' }, ...topics]
 })
 
+const organizationOptions = computed(() => [
+  { value: '', text: 'Toutes les organisations' },
+  ...useOrganizationStore().flatData.map((org) => {
+    return { value: org.id, text: org.name }
+  })
+])
+
 const links = [{ to: '/', text: 'Accueil' }, { text: 'Données' }]
 
 const onSelectTopic = (topicId) => {
   selectedTopicId.value = topicId
+  currentPage.value = 1
+}
+
+const onSelectOrganization = (orgId) => {
+  selectedOrganizationId.value = orgId
   currentPage.value = 1
 }
 
@@ -70,13 +87,6 @@ const getOrganizationPage = (id) => {
   return ''
 }
 
-onMounted(() => {
-  if (topicsConf?.length) {
-    topicStore.loadTopicsFromList(topicsConf)
-  }
-  query.value = originalQuery.value
-})
-
 // fill topic name when arriving on the page with a topic ID
 // TODO: topicId is not updated when selecting a topic
 watchEffect(() => {
@@ -90,24 +100,44 @@ watchEffect(() => {
 })
 
 const delayedSearch = debounce(
-  (currentQuery, currentTopicId, currentPageValue) => {
+  (currentQuery, currentTopicId, currentOrganizationId, currentPageValue) => {
     const loadingInstance = loader.show()
-    store.search(currentQuery, currentTopicId, currentPageValue).finally(() => {
-      loadingInstance.hide()
-    })
+    const args = currentOrganizationId
+      ? { organization: currentOrganizationId }
+      : {}
+    store
+      .search(currentQuery, currentTopicId, currentPageValue, args)
+      .finally(() => {
+        loadingInstance.hide()
+      })
   },
   400
 )
 
 watch(
-  [query, selectedTopicId, currentPage],
-  ([currentQuery, currentTopicId, currentPageValue]) => {
-    delayedSearch(currentQuery, currentTopicId, currentPageValue)
+  [query, selectedTopicId, selectedOrganizationId, currentPage],
+  ([currentQuery, currentTopicId, currentOrganizationId, currentPageValue]) => {
+    delayedSearch(
+      currentQuery,
+      currentTopicId,
+      currentOrganizationId,
+      currentPageValue
+    )
   },
   {
     immediate: true
   }
 )
+
+onMounted(() => {
+  if (topicsConf?.length) {
+    topicStore.loadTopicsFromList(topicsConf)
+  }
+  if (hasOrganizationFilter) {
+    useOrganizationStore().loadFromConfigFlat()
+  }
+  query.value = originalQuery.value
+})
 </script>
 
 <template>
@@ -118,14 +148,11 @@ watch(
     <h1 class="fr-mb-2v">Jeux de données</h1>
     <p v-if="query">Résultats de recherche pour "{{ query }}".</p>
     <p v-else>Parcourir tous les jeux de données présents sur {{ title }}.</p>
-    <div v-if="query && datasets?.length === 0" class="fr-mb-4w">
-      Aucun résultat pour cette recherche.
-    </div>
     <div class="fr-col-md-12 fr-mb-2w">
       <DsfrSearchBar
+        v-model="query"
         label="Recherche"
         placeholder="Rechercher des données"
-        v-model="query"
         @update:model-value="search()"
         @search="$emit('search', $event)"
       />
@@ -139,6 +166,19 @@ watch(
       >
         <template #label>Thématiques</template>
       </DsfrSelect>
+    </div>
+    <div v-if="hasOrganizationFilter" class="fr-col-md-12 fr-mb-2w">
+      <DsfrSelect
+        :model-value="selectedOrganizationId"
+        :options="organizationOptions"
+        default-unselected-text="Toutes les organisations"
+        @update:model-value="onSelectOrganization"
+      >
+        <template #label>Filtrer par organisation</template>
+      </DsfrSelect>
+    </div>
+    <div v-if="datasets?.length === 0" class="fr-mb-4w">
+      Aucun résultat pour cette recherche.
     </div>
     <div class="datagouv-components fr-col-md-12">
       <DatasetCard


### PR DESCRIPTION
Ajoute la possibilité de filtrer par organisation sur la page jeux de données. 

- La liste des organisations provient du fichier de configuration (et triée dans cet ordre)
- La fonctionnalité est derrière un feature flag dans la conf.
- Le layout est cohérent avec le filtre par topic de meteo.data.gouv.fr.
- Des organisations en 404 ont été supprimées du fichier de configuration

Fix https://github.com/ecolabdata/ecospheres/issues/104

<img width="984" alt="Capture d’écran 2024-02-29 à 17 37 14" src="https://github.com/opendatateam/udata-front-kit/assets/119625/9a5edf8a-731d-4857-9c5b-9b6ababd35b1">


