### PR TITLE
fix(auth): store last route instead of last path

### DIFF
--- a/src/components/DiscussionsList.vue
+++ b/src/components/DiscussionsList.vue
@@ -4,6 +4,8 @@ import type { ComputedRef, Ref } from 'vue'
 import { ref, watchEffect, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
+import LocalStorageService from '@/services/LocalStorageService'
+
 import config from '../config'
 import type {
   DiscussionResponse,
@@ -79,7 +81,7 @@ const getUserAvatar = (post: Post) => {
 }
 
 const triggerLogin = () => {
-  localStorage.setItem('lastPath', route.path)
+  LocalStorageService.setItem('lastRoute', route)
   router.push({ name: 'login' })
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,17 +1,18 @@
+// Vue.js and related libraries
+
 import { setupI18n } from '@etalab/data.gouv.fr-components'
+// Project-specific styles and assets
 import '@etalab/data.gouv.fr-components/dist/style.css'
 import '@gouvfr/dsfr/dist/dsfr.min.css'
 import '@gouvfr/dsfr/dist/utility/utility.min.css'
 import VueDsfr from '@gouvminint/vue-dsfr'
-// Import des styles du DSFR
 import '@gouvminint/vue-dsfr/styles'
 import '@vueform/multiselect/themes/default.css'
-// api and user related stuf
+// Third-party libraries
 import axios from 'axios'
 import { createPinia } from 'pinia'
 import { createApp, markRaw } from 'vue'
 import TextClamp from 'vue3-text-clamp'
-// Import des styles globaux propre à VueDSFR
 import 'vue3-toastify/dist/index.css'
 import { LoadingPlugin } from 'vue-loading-overlay'
 import 'vue-loading-overlay/dist/css/index.css'
@@ -19,11 +20,12 @@ import VueMatomo from 'vue-matomo'
 
 import config from '@/config'
 
-// Import (par défaut) de la bibliothèque
 import App from './App.vue'
 import './assets/main.css'
 import * as icons from './icons.js'
+// Local imports
 import router from './router'
+import LocalStorageService from './services/LocalStorageService'
 import { useUserStore } from './store/UserStore'
 
 const app = createApp(App)
@@ -70,7 +72,7 @@ axios.interceptors.request.use(
 router.beforeEach((to) => {
   const store = useUserStore()
   if (to.meta.requiresAuth && !store.$state.isLoggedIn) {
-    localStorage.setItem('lastPath', to.path)
+    LocalStorageService.setItem('lastRoute', to)
     router.push({ name: 'login' })
   }
 })

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,10 @@
-// Vue.js and related libraries
-
 import { setupI18n } from '@etalab/data.gouv.fr-components'
-// Project-specific styles and assets
 import '@etalab/data.gouv.fr-components/dist/style.css'
 import '@gouvfr/dsfr/dist/dsfr.min.css'
 import '@gouvfr/dsfr/dist/utility/utility.min.css'
 import VueDsfr from '@gouvminint/vue-dsfr'
 import '@gouvminint/vue-dsfr/styles'
 import '@vueform/multiselect/themes/default.css'
-// Third-party libraries
 import axios from 'axios'
 import { createPinia } from 'pinia'
 import { createApp, markRaw } from 'vue'
@@ -23,7 +19,6 @@ import config from '@/config'
 import App from './App.vue'
 import './assets/main.css'
 import * as icons from './icons.js'
-// Local imports
 import router from './router'
 import LocalStorageService from './services/LocalStorageService'
 import { useUserStore } from './store/UserStore'

--- a/src/services/LocalStorageService.ts
+++ b/src/services/LocalStorageService.ts
@@ -1,0 +1,22 @@
+export default {
+  setItem(key: string, value: object | string) {
+    if (typeof value === 'object') {
+      localStorage.setItem(key, JSON.stringify(value))
+    } else {
+      localStorage.setItem(key, value)
+    }
+  },
+  getItem(key: string) {
+    const item = localStorage.getItem(key)
+    if (item !== null) {
+      try {
+        return JSON.parse(item)
+      } catch (e) {
+        return item
+      }
+    }
+  },
+  removeItem(key: string) {
+    localStorage.removeItem(key)
+  }
+}

--- a/src/store/UserStore.ts
+++ b/src/store/UserStore.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia'
 import { watch } from 'vue'
 
 import type { WithOwned } from '@/model'
+import LocalStorageService from '@/services/LocalStorageService'
 import UserAPI from '@/services/api/resources/UserAPI'
 
 const STORAGE_KEY = 'token'
@@ -46,9 +47,9 @@ export const useUserStore = defineStore('user', {
           // keep the current route and redirect to the login flow
           if ((err as AxiosError).response?.status === 401) {
             this.logout()
-            localStorage.setItem(
-              'lastPath',
-              this.$router.currentRoute.value.path
+            LocalStorageService.setItem(
+              'lastRoute',
+              this.$router.currentRoute.value
             )
             await this.$router.push({ name: 'login' })
           }

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -2,9 +2,10 @@
 import { onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
-import AuthService from '../services/AuthService'
-import UserAPI from '../services/api/resources/UserAPI'
-import { useUserStore } from '../store/UserStore'
+import AuthService from '@/services/AuthService'
+import LocalStorageService from '@/services/LocalStorageService'
+import UserAPI from '@/services/api/resources/UserAPI'
+import { useUserStore } from '@/store/UserStore'
 
 const route = useRoute()
 const router = useRouter()
@@ -25,9 +26,9 @@ onMounted(() => {
       api.list().then((data) => {
         store.storeInfo(data)
       })
-      const lastPath = localStorage.getItem('lastPath')
-      const next = lastPath ? { path: lastPath } : { name: 'home' }
-      localStorage.removeItem('lastPath')
+      const lastRoute = LocalStorageService.getItem('lastRoute')
+      const next = lastRoute ?? { name: 'home' }
+      LocalStorageService.removeItem('lastRoute')
       router.push(next)
     })
   } else {


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/117

- Dans le flow d'authentification, stocke la route complète en localStorage plutôt que seulement le chemin, notamment pour préserver la query
- Réordonne les imports chaotiques de main.js
- Introduit un service pour la gestion du localStorage