### PR TITLE
feat(bouquet): show owner and date

### DIFF
--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,0 +1,19 @@
+import { type Owned } from '@etalab/data.gouv.fr-components'
+
+import config from '@/config'
+
+/**
+ *
+ */
+export const getOwnerAvatar = (
+  object: Partial<Owned>,
+  size: number = 32
+): string => {
+  if (
+    object.owner?.avatar_thumbnail !== null &&
+    object.owner?.avatar_thumbnail !== undefined
+  ) {
+    return object.owner.avatar_thumbnail
+  }
+  return `${config.datagouvfr.base_url}/api/1/avatars/${object.owner?.id}/${size}`
+}


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/91

Affiche le propriétaire du bouquet et sa date de création, de la même manière que pour un jeu de données

- Toute la partie haute de la page a été retravaillée pour coller au gabarit de la page jeu de données (et ainsi converger vers data.gouv.fr) et profiter de certaines améliorations (e.g. "Voir plus")
- Le bouton "Editer le bouquet" prend naturellement le style data.gouv.fr (bords arrondis)
- L'organisation s'affichera si le bouquet y est rattaché (future proofing)
- Le bas de la page n'a pas été retravaillé à date (TODO : onglets ?)
- Fun fact : on n'a pas de date de dernière modification sur un Topic, donc je n'affiche que la date de création. Je propose de le rajouter côté data.gouv.fr plutôt qu'en extra : investissement initial ~ égal et à long terme un extra en moins à gérer.

NB : le bouton "Revenir aux résultats" me parait peu utile (c'est juste un "back" navigateur), prend de la place, pollue l'URL (fixable) et n'existe pas sur les jeux de données. A voir si on ne le supprime pas ?

![ecologie-data-gouv-fr (2)](https://github.com/opendatateam/udata-front-kit/assets/119625/f9781cc1-7115-42b6-b72a-e9a2865e9ceb)
---
![ecologie-data-gouv-fr (1)](https://github.com/opendatateam/udata-front-kit/assets/119625/469151dc-5e25-4d04-89c1-f0e7857a8f9f)
---
<img src="https://github.com/opendatateam/udata-front-kit/assets/119625/6802b7c6-1230-4170-88af-a3ec7adeb6dc" width="320">