### PR TITLE
fix(bouquet): logout cache and anon draft button

### DIFF
--- a/src/custom/ecospheres/components/BouquetSearch.vue
+++ b/src/custom/ecospheres/components/BouquetSearch.vue
@@ -1,6 +1,7 @@
 <template>
   <div className="filterForm">
     <DsfrCheckbox
+      v-if="userStore.isLoggedIn"
       v-model="showDrafts"
       label="Afficher les brouillons"
       name="show_drafts"
@@ -58,6 +59,7 @@ import { defineComponent } from 'vue'
 import { ConfigUtils } from '@/config'
 import { NoOptionSelected } from '@/model'
 import type { SelectOption, Theme } from '@/model'
+import { useUserStore } from '@/store/UserStore'
 
 export default defineComponent({
   name: 'BouquetSearch',
@@ -74,7 +76,8 @@ export default defineComponent({
   emits: ['update:showDrafts'],
   data: () => {
     return {
-      showDrafts: false
+      showDrafts: false,
+      userStore: useUserStore()
     }
   },
   computed: {

--- a/src/views/LogoutView.vue
+++ b/src/views/LogoutView.vue
@@ -15,7 +15,8 @@ onMounted(() => {
     auth.logout(token.value).then(() => {
       store.logout()
       console.log('Logged out')
-      router.push({ name: 'home' })
+      // reload to clean up stores
+      location.reload()
     })
   } else {
     router.push({ name: 'home' })


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/120

- Force un rafraîchissement de la page au logout, afin d'être sûr de réinitialiser le state (inc. les brouillons)
- Cache le toggle "Afficher les brouillons" pour un utilisateur non connecté (inutile)