### PR TITLE
feat(bouquet): reorder datasets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "vite-plugin-html": "^3.2.0",
         "vue": "^3.4.11",
         "vue-chartjs": "^5.2.0",
+        "vue-draggable-next": "^2.2.1",
         "vue-loading-overlay": "^6.0.3",
         "vue-matomo": "^4.2.0",
         "vue-router": "^4.2.2",
@@ -7112,6 +7113,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/sortablejs": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.2.tgz",
+      "integrity": "sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA==",
+      "peer": true
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8042,6 +8049,15 @@
       "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-1.8.27.tgz",
       "integrity": "sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==",
       "dev": true
+    },
+    "node_modules/vue-draggable-next": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vue-draggable-next/-/vue-draggable-next-2.2.1.tgz",
+      "integrity": "sha512-EAMS1IRHF0kZO0o5PMOinsQsXIqsrKT1hKmbICxG3UEtn7zLFkLxlAtajcCcUTisNvQ6TtCB5COjD9a1raNADw==",
+      "peerDependencies": {
+        "sortablejs": "^1.14.0",
+        "vue": "^3.2.2"
+      }
     },
     "node_modules/vue-eslint-parser": {
       "version": "9.3.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "vite-plugin-html": "^3.2.0",
     "vue": "^3.4.11",
     "vue-chartjs": "^5.2.0",
+    "vue-draggable-next": "^2.2.1",
     "vue-loading-overlay": "^6.0.3",
     "vue-matomo": "^4.2.0",
     "vue-router": "^4.2.2",

--- a/src/custom/ecospheres/components/BouquetDatasetList.vue
+++ b/src/custom/ecospheres/components/BouquetDatasetList.vue
@@ -4,48 +4,62 @@
   </div>
   <div v-else>
     <DsfrAccordionsGroup>
-      <li v-for="(dataset, index) in datasets" :key="index">
-        <DsfrAccordion
-          :id="getAccordeonId(index)"
-          :title="dataset.title"
-          :expanded-id="isExpanded[getAccordeonId(index)]"
-          @expand="isExpanded[getAccordeonId(index)] = $event"
-        >
-          <BouquetDatasetAvailability :dataset-properties="dataset" />
-          <!-- eslint-disable-next-line vue/no-v-html -->
-          <div v-html="markdown(dataset.purpose)"></div>
-          <div class="button__wrapper">
-            <DsfrButton
-              v-if="isEdit"
-              icon="ri-pencil-line"
-              label="Éditer"
-              class="fr-mr-2w"
-              @click.prevent="editDataset(dataset, index)"
-            />
-            <DsfrButton
-              v-if="isEdit"
-              icon="ri-delete-bin-line"
-              label="Retirer de la section"
-              class="fr-mr-2w"
-              @click.prevent="$emit('removeDataset', index)"
-            />
-            <a
-              v-if="!isAvailable(dataset)"
-              class="fr-btn fr-btn--secondary inline-flex"
-              :href="`mailto:${email}`"
-            >
-              Aidez-nous à trouver la donnée</a
-            >
-            <a
-              v-if="dataset.uri"
-              class="fr-btn fr-btn--secondary inline-flex"
-              :href="dataset.uri"
-              target="_blank"
-              >Accéder au catalogue</a
-            >
-          </div>
-        </DsfrAccordion>
-      </li>
+      <!-- conditionnal draggable wrapper component -->
+      <component
+        :is="isEdit ? 'draggable' : 'div'"
+        :list="isEdit ? datasets : null"
+        :ghost-class="isEdit ? 'ghost' : null"
+      >
+        <li v-for="(dataset, index) in datasets" :key="index">
+          <DsfrAccordion
+            :id="getAccordeonId(index)"
+            :expanded-id="isExpanded[getAccordeonId(index)]"
+            :class="{ draggable: isEdit }"
+            @expand="isExpanded[getAccordeonId(index)] = $event"
+          >
+            <template #title>
+              <span v-if="!isEdit">{{ dataset.title }}</span>
+              <span v-else>
+                <VIcon name="ri-drag-move-2-fill" />
+                <span class="fr-ml-2w">{{ dataset.title }}</span>
+              </span>
+            </template>
+            <BouquetDatasetAvailability :dataset-properties="dataset" />
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <div v-html="markdown(dataset.purpose)"></div>
+            <div class="button__wrapper">
+              <DsfrButton
+                v-if="isEdit"
+                icon="ri-pencil-line"
+                label="Éditer"
+                class="fr-mr-2w"
+                @click.prevent="editDataset(dataset, index)"
+              />
+              <DsfrButton
+                v-if="isEdit"
+                icon="ri-delete-bin-line"
+                label="Retirer de la section"
+                class="fr-mr-2w"
+                @click.prevent="$emit('removeDataset', index)"
+              />
+              <a
+                v-if="!isAvailable(dataset)"
+                class="fr-btn fr-btn--secondary inline-flex"
+                :href="`mailto:${email}`"
+              >
+                Aidez-nous à trouver la donnée</a
+              >
+              <a
+                v-if="dataset.uri"
+                class="fr-btn fr-btn--secondary inline-flex"
+                :href="dataset.uri"
+                target="_blank"
+                >Accéder au catalogue</a
+              >
+            </div>
+          </DsfrAccordion>
+        </li>
+      </component>
     </DsfrAccordionsGroup>
     <DsfrModal
       v-if="isEdit && isModalOpen && editedDataset.data"
@@ -65,6 +79,8 @@
 </template>
 
 <script lang="ts">
+import { VueDraggableNext } from 'vue-draggable-next'
+
 import config from '@/config'
 import { type DatasetProperties, isAvailable as isAvailableTest } from '@/model'
 import { fromMarkdown } from '@/utils'
@@ -92,7 +108,11 @@ export const getDatasetListTitle = function (
 
 export default {
   name: 'BouquetDatasetList',
-  components: { BouquetDatasetAvailability, DatasetPropertiesFields },
+  components: {
+    BouquetDatasetAvailability,
+    DatasetPropertiesFields,
+    draggable: VueDraggableNext
+  },
   props: {
     datasets: {
       type: Array<DatasetProperties>,
@@ -164,3 +184,9 @@ export default {
   }
 }
 </script>
+
+<style scoped lang="scss">
+.ghost {
+  background-color: #bbb;
+}
+</style>

--- a/src/icons.js
+++ b/src/icons.js
@@ -3,5 +3,6 @@ export {
   RiAddCircleLine,
   RiPencilLine,
   RiLightbulbLine,
-  RiClipboardLine
+  RiClipboardLine,
+  RiDragMove2Fill
 } from 'oh-vue-icons/icons/ri/index.js'


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/93

Permet de réordonner les jeux de données dans un bouquet (via l'interface d'édition de ce step).

⚠️ L'orde est sauvegardé après avoir cliqué sur suivant (cohérent avec le reste de l'édition).

<img width="938" alt="Capture d’écran 2024-03-07 à 19 42 51" src="https://github.com/opendatateam/udata-front-kit/assets/119625/7f6405fc-7c58-4928-b78f-61e7c57fe5eb">
