### PR TITLE
chore: remove vscode reco ts-vue-plugin

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+  "recommendations": ["Vue.volar"]
 }


### PR DESCRIPTION
Deprecated extension, Volar is enough now.

<img width="655" alt="Capture d’écran 2024-03-11 à 12 00 24" src="https://github.com/opendatateam/udata-front-kit/assets/119625/7abb464f-95b5-4f92-8a95-8615fac1a26e">
