### PR TITLE
feat: use tabs on bouquet detail

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -87,3 +87,8 @@ textarea {
   margin: 20px 0;
   height: 250px;
 }
+
+/* overload datagouv-components */
+.datagouv-components h3.fr-accordion__title {
+  margin-bottom: 0;
+}

--- a/src/custom/ecospheres/components/BouquetDatasetList.vue
+++ b/src/custom/ecospheres/components/BouquetDatasetList.vue
@@ -87,19 +87,19 @@ import BouquetDatasetAccordionTitle from './BouquetDatasetAccordionTitle.vue'
 import DatasetPropertiesFields from './forms/dataset/DatasetPropertiesFields.vue'
 
 export const getDatasetListTitle = function (
-  datasets: DatasetProperties[]
+  datasets: DatasetProperties[],
+  title: string = 'Composition du bouquet'
 ): string {
-  const title = 'Composition du bouquet '
   const numberOfDatasets = datasets.length
   switch (numberOfDatasets) {
     case 0: {
       return title
     }
     case 1: {
-      return title + '( 1 jeu de données )'
+      return `${title} ( 1 jeu de données )`
     }
     default: {
-      return title + `( ${numberOfDatasets} jeux de données )`
+      return `${title} ( ${numberOfDatasets} jeux de données )`
     }
   }
 }

--- a/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
@@ -46,13 +46,6 @@ const canEdit = computed(() => {
   return useUserStore().hasEditPermissions(bouquet.value as Topic)
 })
 
-const tabs = computed(() => {
-  return [
-    { title: 'Données', tabId: 'tab-0', panelId: 'tab-content-0' },
-    { title: 'Discussions', tabId: 'tab-1', panelId: 'tab-content-1' }
-  ]
-})
-
 const datasetsProperties = computed((): DatasetProperties[] => {
   return bouquet.value?.extras['ecospheres:datasets_properties'] ?? []
 })
@@ -207,9 +200,9 @@ onMounted(() => {
     </div>
 
     <DsfrTabs
-      class="fr-mt-2w bouquet-tabs"
+      class="fr-mt-2w"
       tab-list-name="Groupes d'attributs du bouquet"
-      :tab-titles="tabs"
+      :tab-titles="[{ title: 'Données' }, { title: 'Discussions' }]"
       :initial-selected-index="0"
       :selected-tab-index="selectedTabIndex"
       @select-tab="(idx: number) => (selectedTabIndex = idx)"
@@ -226,7 +219,7 @@ onMounted(() => {
       <!-- Discussions -->
       <DsfrTabContent
         panel-id="tab-content-1"
-        tab-id="tab-2"
+        tab-id="tab-1"
         :selected="selectedTabIndex === 1"
       >
         <DiscussionsList
@@ -254,14 +247,6 @@ onMounted(() => {
     display: flex;
     align-items: center;
     flex-flow: wrap;
-  }
-}
-</style>
-
-<style lang="scss">
-.bouquet-tabs {
-  .datagouv-components h3 {
-    margin-bottom: 0;
   }
 }
 </style>


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/140

- Ajoute l'affichage par onglets sur la page de détail d'un bouquet
- Mutualise l'affichage de la liste des données avec le parcours de création (such dette technique en moins)

NB: comme pour #361, on rentre dans l'univers graphique data.gouv.fr par le jeu des CSS, donc les boutons sont arrondis.