### PR TITLE
feat: add dataset to bouquet from dataset page

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -129,6 +129,7 @@ website:
       create: true
   datasets:
     organization_filter: true
+    add_to_bouquet: true
 
 themes:
   - name: Se loger

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -128,6 +128,7 @@ website:
       create: false
   datasets:
     organization_filter: false
+    add_to_bouquet: false
 
 # list of organisations' ids that should be handled by the portal
 # to find an id go to https://www.data.gouv.fr/fr/organizations/ministere-de-la-transition-ecologique/

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -14,6 +14,8 @@
   --blue-france-975-sun-113: var(--blue-cumulus-975-75);
   --blue-france-main-525: var(--blue-cumulus-main-526);
   --blue-france-850-200: var(--blue-cumulus-850-200);
+  /* toastify */
+  --toastify-color-success: #1f8d49; /* --success-main-525 (unavailable to date) */
 }
 
 @font-face {

--- a/src/custom/ecospheres/components/datasets/DatasetAddToBouquetModal.vue
+++ b/src/custom/ecospheres/components/datasets/DatasetAddToBouquetModal.vue
@@ -1,0 +1,141 @@
+<script setup lang="ts">
+import type { DatasetV2 } from '@etalab/data.gouv.fr-components'
+import { ref, onMounted, computed } from 'vue'
+import { toast } from 'vue3-toastify'
+import { useLoading } from 'vue-loading-overlay'
+
+import Tooltip from '@/components/TooltipWrapper.vue'
+import { Availability, type DatasetProperties, type Topic } from '@/model'
+import { useTopicStore } from '@/store/TopicStore'
+
+import DatasetPropertiesTextFields from '../forms/dataset/DatasetPropertiesTextFields.vue'
+
+const props = defineProps({
+  show: {
+    type: Boolean,
+    default: false
+  },
+  dataset: {
+    type: Object as () => DatasetV2,
+    required: true
+  }
+})
+
+const emit = defineEmits(['update:show'])
+const loader = useLoading()
+const topicStore = useTopicStore()
+
+const bouquets = topicStore.userTopics
+const datasetProperties = ref<DatasetProperties>({
+  title: '',
+  purpose: '',
+  id: props.dataset.id,
+  uri: `/datasets/${props.dataset.id}`,
+  availability: Availability.LOCAL_AVAILABLE
+})
+const selectedBouquetId = ref(null)
+
+const bouquetOptions = computed(() => {
+  // sort on a copy to avoid modifying bouquets.value in a computed property
+  const sortedBouquets = [...bouquets.value].sort((a, b) => {
+    return (
+      new Date(b.last_modified).getTime() - new Date(a.last_modified).getTime()
+    )
+  })
+  return sortedBouquets.map((bouquet) => {
+    return {
+      value: bouquet.id,
+      text: bouquet.name,
+      disabled: isDatasetInBouquet(bouquet)
+    }
+  })
+})
+
+const isValid = computed(() => {
+  return (
+    datasetProperties.value.title.trim() !== '' &&
+    datasetProperties.value.purpose.trim() !== '' &&
+    !!selectedBouquetId.value
+  )
+})
+
+const modalActions = computed(() => {
+  return [
+    {
+      label: 'Valider',
+      disabled: !isValid.value,
+      onClick: () => submit()
+    },
+    {
+      label: 'Annuler',
+      secondary: true,
+      onClick: () => closeModal()
+    }
+  ]
+})
+
+const isDatasetInBouquet = (bouquet: Topic): boolean => {
+  const datasetsProperties =
+    bouquet.extras['ecospheres:datasets_properties'] || []
+  return datasetsProperties.some(
+    (datasetProps) => datasetProps.id === props.dataset.id
+  )
+}
+
+const submit = async () => {
+  if (selectedBouquetId.value === null) {
+    throw Error('Trying to attach to bouquet without id')
+  }
+  const bouquet = topicStore.get(selectedBouquetId.value)
+  if (bouquet === undefined) {
+    throw Error('Bouquet not in store')
+  }
+  const newDatasetsProperties =
+    bouquet.extras['ecospheres:datasets_properties'] || []
+  newDatasetsProperties.push(datasetProperties.value)
+  bouquet.extras['ecospheres:datasets_properties'] = newDatasetsProperties
+  await topicStore.update(bouquet.id, {
+    id: bouquet.id,
+    tags: bouquet.tags,
+    extras: bouquet.extras
+  })
+  toast('Jeu de données ajouté avec succès', { type: 'success' })
+  closeModal()
+}
+
+const closeModal = () => {
+  emit('update:show', false)
+}
+
+onMounted(() => {
+  const loading = loader.show()
+  topicStore.loadTopicsForUniverse().then(() => loading.hide())
+})
+</script>
+
+<template>
+  <DsfrModal
+    v-if="show"
+    size="lg"
+    title="Ajouter le jeu de données à un bouquet"
+    :opened="show"
+    :actions="modalActions"
+    @close="closeModal"
+  >
+    <DsfrSelect
+      v-model="selectedBouquetId"
+      :options="bouquetOptions"
+      default-unselected-text="Choisissez un bouquet"
+    >
+      <template #label>
+        Bouquet à associer <span class="required">&nbsp;*</span>
+        <Tooltip
+          text="Choisissez parmi les bouquets dont vous êtes l'auteur. Si un bouquet apparait désactivé, c'est que le jeu de données y est déjà associé."
+        />
+      </template>
+    </DsfrSelect>
+    <DatasetPropertiesTextFields
+      v-model:dataset-properties="datasetProperties"
+    />
+  </DsfrModal>
+</template>

--- a/src/custom/ecospheres/components/forms/dataset/DatasetPropertiesFields.vue
+++ b/src/custom/ecospheres/components/forms/dataset/DatasetPropertiesFields.vue
@@ -3,7 +3,6 @@ import { type DatasetV2 } from '@etalab/data.gouv.fr-components'
 import Multiselect from '@vueform/multiselect'
 import { ref, computed, watch, type PropType } from 'vue'
 
-import Tooltip from '@/components/TooltipWrapper.vue'
 import config from '@/config'
 import {
   Availability,
@@ -11,6 +10,8 @@ import {
   type DatasetProperties
 } from '@/model'
 import SearchAPI from '@/services/api/SearchAPI'
+
+import DatasetPropertiesTextFields from './DatasetPropertiesTextFields.vue'
 
 const emit = defineEmits(['update:datasetProperties', 'updateValidation'])
 
@@ -123,38 +124,7 @@ watch(
 </script>
 
 <template>
-  <div class="fr-mt-1w fr-mb-4w">
-    <label class="fr-label" for="label"
-      >Libellé de la donnée <span class="required">&nbsp;*</span></label
-    >
-    <input
-      id="label"
-      v-model="datasetProperties.title"
-      class="fr-input"
-      type="text"
-    />
-  </div>
-  <div class="fr-mt-1w fr-mb-4w">
-    <div class="container">
-      Raison d'utilisation dans ce bouquet
-      <span class="required">&nbsp;*</span>
-      <Tooltip
-        text="Ajoutez ici l'ensemble des informations nécessaires à la compréhension, l'objectif et l'utilisation du bouquet. N'hésitez pas à indiquer la réglementation ou une documentation liée au bouquet."
-      />
-    </div>
-    <div class="container">
-      Utilisez du markdown pour mettre en forme votre texte
-      <Tooltip
-        text="* simple astérisque pour italique *<br/> ** double astérisque pour gras **<br/> # un dièse pour titre 1<br/> ## deux dièses pour titre 2<br/> *  astérisque pour une liste<br/> lien : [[https://exemple.fr]]"
-      />
-    </div>
-    <textarea
-      id="purpose"
-      v-model="datasetProperties.purpose"
-      class="fr-input"
-      type="text"
-    />
-  </div>
+  <DatasetPropertiesTextFields v-model:dataset-properties="datasetProperties" />
   <div class="fr-mt-1w fr-mb-4w">
     <label class="fr-label" for="source">Retrouver la donnée via</label>
     <fieldset id="source" class="fr-fieldset">

--- a/src/custom/ecospheres/components/forms/dataset/DatasetPropertiesTextFields.vue
+++ b/src/custom/ecospheres/components/forms/dataset/DatasetPropertiesTextFields.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import Tooltip from '@/components/TooltipWrapper.vue'
+import type { DatasetProperties } from '@/model'
+
+const props = defineProps({
+  datasetProperties: {
+    type: Object as () => DatasetProperties,
+    required: true
+  }
+})
+
+const emit = defineEmits(['update:datasetProperties'])
+
+const updateDatasetProperties = (
+  field: keyof DatasetProperties,
+  value: string
+) => {
+  emit('update:datasetProperties', {
+    ...props.datasetProperties,
+    [field]: value
+  })
+}
+</script>
+
+<template>
+  <div class="fr-mt-1w fr-mb-4w">
+    <label class="fr-label" for="label"
+      >Libellé de la donnée <span class="required">&nbsp;*</span></label
+    >
+    <input
+      id="label"
+      class="fr-input"
+      type="text"
+      :value="props.datasetProperties.title"
+      @input="
+        updateDatasetProperties(
+          'title',
+          ($event.target as HTMLInputElement).value
+        )
+      "
+    />
+  </div>
+  <div class="fr-mt-1w fr-mb-4w">
+    <div class="container">
+      Raison d'utilisation dans ce bouquet
+      <span class="required">&nbsp;*</span>
+      <Tooltip
+        text="Ajoutez ici l'ensemble des informations nécessaires à la compréhension, l'objectif et l'utilisation du bouquet. N'hésitez pas à indiquer la réglementation ou une documentation liée au bouquet."
+      />
+    </div>
+    <textarea
+      id="purpose"
+      class="fr-input"
+      type="text"
+      :value="props.datasetProperties.purpose"
+      @input="
+        updateDatasetProperties(
+          'purpose',
+          ($event.target as HTMLTextAreaElement).value
+        )
+      "
+    />
+  </div>
+</template>
+
+<style scoped lang="scss">
+textarea {
+  height: 150px;
+}
+</style>

--- a/src/icons.js
+++ b/src/icons.js
@@ -4,5 +4,6 @@ export {
   RiPencilLine,
   RiLightbulbLine,
   RiClipboardLine,
-  RiDragMove2Fill
+  RiDragMove2Fill,
+  RiFileAddLine
 } from 'oh-vue-icons/icons/ri/index.js'

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -78,6 +78,7 @@ type Topic = Owned & {
   name: string
   description: string
   created_at: string
+  last_modified: string
   extras: TopicExtras
   featured: boolean
   id: string

--- a/src/store/TopicStore.ts
+++ b/src/store/TopicStore.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { computed } from 'vue'
 
 import config from '@/config'
 import type { Topic } from '@/model'
@@ -20,6 +21,18 @@ export const useTopicStore = defineStore('topic', {
     // flag for initial/remote loading of data
     isLoaded: false
   }),
+  getters: {
+    // Computed property to get topics owned by the current user
+    userTopics: (state) => {
+      const userStore = useUserStore()
+      return computed(() => {
+        if (!userStore.isLoggedIn) return []
+        return state.data.filter(
+          (topic) => topic.owner?.id === userStore.data?.id
+        )
+      })
+    }
+  },
   actions: {
     /**
      * Load topics to store from a list of ids and API

--- a/src/views/datasets/DatasetDetailView.vue
+++ b/src/views/datasets/DatasetDetailView.vue
@@ -13,6 +13,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useLoading } from 'vue-loading-overlay'
 
 import config from '@/config'
+import DatasetAddToBouquetModal from '@/custom/ecospheres/components/datasets/DatasetAddToBouquetModal.vue'
 
 import ChartData from '../../components/ChartData.vue'
 import DiscussionsList from '../../components/DiscussionsList.vue'
@@ -21,6 +22,7 @@ import { useRouteParamsAsString } from '../../router/utils'
 import { useDatasetStore } from '../../store/DatasetStore'
 import { useResourceStore } from '../../store/ResourceStore'
 import { useReuseStore } from '../../store/ReuseStore'
+import { useUserStore } from '../../store/UserStore'
 import { descriptionFromMarkdown, formatDate } from '../../utils'
 
 const route = useRouteParamsAsString()
@@ -29,6 +31,7 @@ const datasetId = route.params.did
 const datasetStore = useDatasetStore()
 const resourceStore = useResourceStore()
 const reuseStore = useReuseStore()
+const userStore = useUserStore()
 
 const dataset = computed(() => datasetStore.get(datasetId))
 const reuses = ref([])
@@ -37,6 +40,8 @@ const resources = ref<Record<string, ResourceData>>({})
 const selectedTabIndex = ref(0)
 const license = ref<License>()
 const types = ref([])
+const showAddToBouquetModal = ref(false)
+
 const pageSize = config.website.pagination_sizes.files_list
 const showDiscussions = config.website.discussions.dataset.display
 
@@ -227,9 +232,12 @@ watch(
           <div v-html="description"></div>
         </ReadMore>
       </div>
-      <div v-if="dataset.organization" class="fr-col-12 fr-col-md-4">
+      <div class="fr-col-12 fr-col-md-4">
         <h2 id="producer" class="subtitle fr-mb-1v">Producteur</h2>
-        <div class="fr-grid-row fr-grid-row--middle">
+        <div
+          v-if="dataset.organization"
+          class="fr-grid-row fr-grid-row--middle"
+        >
           <div class="fr-col-auto">
             <div class="border fr-p-1-5v fr-mr-1-5v">
               <img :src="dataset.organization.logo" height="32" />
@@ -259,6 +267,22 @@ watch(
           v-if="config.website.show_quality_component"
           :quality="dataset.quality"
         />
+        <div
+          v-if="config.website.datasets.add_to_bouquet && userStore.isLoggedIn"
+        >
+          <DsfrButton
+            class="fr-mt-2w"
+            size="md"
+            label="Ajouter à un bouquet"
+            icon="ri-file-add-line"
+            @click="showAddToBouquetModal = true"
+          />
+          <DatasetAddToBouquetModal
+            v-if="showAddToBouquetModal"
+            v-model:show="showAddToBouquetModal"
+            :dataset="dataset"
+          />
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/144

Ajoute la possibilité d'associer un jeu de données à un bouquet depuis la page du jeu de données.

- Le bouton "Ajouter à un bouquet" apparait sur la page d'un jeu de données quand la configuration le permet et que l'utilisateur est connecté
- Une modale permet de qualifier l'association jdd <-> bouquet
- La liste des bouquets est constituée de ceux dont l'utilisateur connecté est l'auteur, triée par date de modification décroissante
- Si le jeu de données courant est déjà associé à un bouquet de la liste, il apparait désactivé
- Un toast indique que le jeu de données a bien été ajouté

<img width="1057" alt="Capture d’écran 2024-03-19 à 09 24 23" src="https://github.com/opendatateam/udata-front-kit/assets/119625/2ecb7972-b7aa-4780-a360-3cfd9e8df4d0">

<img width="734" alt="Capture d’écran 2024-03-19 à 09 24 31" src="https://github.com/opendatateam/udata-front-kit/assets/119625/9c087c85-0ba0-4b51-9b85-ffbc5e5ec6a6">

<img width="741" alt="Capture d’écran 2024-03-19 à 09 24 46" src="https://github.com/opendatateam/udata-front-kit/assets/119625/c0dd8e91-96d1-4d39-a910-ad88d04c9bb1">

<img width="373" alt="Capture d’écran 2024-03-19 à 09 24 51" src="https://github.com/opendatateam/udata-front-kit/assets/119625/673b5643-dc89-42b1-ad89-7712933b18eb">
