### PR TITLE
feat: add topic.last_modifed support

### DIFF
--- a/src/custom/ecospheres/components/BouquetList.vue
+++ b/src/custom/ecospheres/components/BouquetList.vue
@@ -11,6 +11,7 @@ import { useTopicStore } from '@/store/TopicStore'
 
 const router = useRouter()
 const route = useRoute()
+const topicStore = useTopicStore()
 
 const props = defineProps({
   themeName: {
@@ -27,7 +28,7 @@ const props = defineProps({
 })
 
 const bouquets: ComputedRef<Topic[]> = computed(() => {
-  const allTopics = useTopicStore().$state.data.filter((bouquet) => {
+  const allTopics = topicStore.sortedByLastModifiedDesc.filter((bouquet) => {
     return !props.showDrafts ? !bouquet.private : true
   })
   if (props.themeName === NoOptionSelected) {
@@ -89,9 +90,7 @@ const computeLink = (bouquet: Topic): RouteLocationRaw => {
 
 onMounted(() => {
   const loader = useLoading().show()
-  useTopicStore()
-    .loadTopicsForUniverse()
-    .then(() => loader.hide())
+  topicStore.loadTopicsForUniverse().then(() => loader.hide())
 })
 </script>
 

--- a/src/custom/ecospheres/components/datasets/DatasetAddToBouquetModal.vue
+++ b/src/custom/ecospheres/components/datasets/DatasetAddToBouquetModal.vue
@@ -36,13 +36,7 @@ const datasetProperties = ref<DatasetProperties>({
 const selectedBouquetId = ref(null)
 
 const bouquetOptions = computed(() => {
-  // sort on a copy to avoid modifying bouquets.value in a computed property
-  const sortedBouquets = [...bouquets.value].sort((a, b) => {
-    return (
-      new Date(b.last_modified).getTime() - new Date(a.last_modified).getTime()
-    )
-  })
-  return sortedBouquets.map((bouquet) => {
+  return bouquets.value.map((bouquet) => {
     return {
       value: bouquet.id,
       text: bouquet.name,
@@ -99,7 +93,9 @@ const submit = async () => {
     tags: bouquet.tags,
     extras: bouquet.extras
   })
-  toast(`Jeu de données ajouté avec succès au bouquet "${bouquet.name}"`, { type: 'success' })
+  toast(`Jeu de données ajouté avec succès au bouquet "${bouquet.name}"`, {
+    type: 'success'
+  })
   closeModal()
 }
 

--- a/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
@@ -166,8 +166,10 @@ onMounted(() => {
             {{ bouquet.owner.first_name }} {{ bouquet.owner.last_name }}
           </p>
         </div>
-        <h2 class="subtitle fr-mt-3v fr-mb-1v">Date de création</h2>
+        <h2 class="subtitle fr-mt-3v fr-mb-1v">Création</h2>
         <p>{{ formatDate(bouquet.created_at) }}</p>
+        <h2 class="subtitle fr-mt-3v fr-mb-1v">Dernière mise à jour</h2>
+        <p>{{ formatDate(bouquet.last_modified) }}</p>
         <DsfrButton
           v-if="canEdit"
           size="md"

--- a/src/store/TopicStore.ts
+++ b/src/store/TopicStore.ts
@@ -31,6 +31,13 @@ export const useTopicStore = defineStore('topic', {
           (topic) => topic.owner?.id === userStore.data?.id
         )
       })
+    },
+    sortedByLastModifiedDesc: (state) => {
+      return [...state.data].sort((a, b) => {
+        const dateA = new Date(a.last_modified)
+        const dateB = new Date(b.last_modified)
+        return dateB.getTime() - dateA.getTime()
+      })
     }
   },
   actions: {

--- a/src/store/TopicStore.ts
+++ b/src/store/TopicStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { computed } from 'vue'
+import { computed, type ComputedRef } from 'vue'
 
 import config from '@/config'
 import type { Topic } from '@/model'
@@ -22,13 +22,13 @@ export const useTopicStore = defineStore('topic', {
     isLoaded: false
   }),
   getters: {
-    // Computed property to get topics owned by the current user
-    userTopics: (state) => {
+    // Computed property to get topics owned by the current user sorted by last_modified
+    userTopics(): ComputedRef<Topic[]> {
       const userStore = useUserStore()
       return computed(() => {
         if (!userStore.isLoggedIn) return []
-        return state.data.filter(
-          (topic) => topic.owner?.id === userStore.data?.id
+        return this.sortedByLastModifiedDesc.filter(
+          (topic: Topic) => topic.owner?.id === userStore.data?.id
         )
       })
     },


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/133

- Ajoute la date de modification sur la page de détails d'un bouquet
- Trie les bouquets par date de dernière modification sur la page de liste des bouquets (à discuter ?)
- Utilise le tri du store par date de dernière modification pour calculer les `userTopics`

NB 1 : la date de modification ne sera disponible en prod sur data.gouv.fr que demain au plus tôt
NB 2 : tant qu'un bouquet n'a pas été sauvegardé depuis l'ajout de la date de modification sur data.gouv.fr, sa date de dernière modification est `now()`