### PR TITLE
feat(bouquets): add sort on list

### DIFF
--- a/src/custom/ecospheres/components/BouquetList.vue
+++ b/src/custom/ecospheres/components/BouquetList.vue
@@ -28,7 +28,7 @@ const props = defineProps({
 })
 
 const bouquets: ComputedRef<Topic[]> = computed(() => {
-  const allTopics = topicStore.sortedByLastModifiedDesc.filter((bouquet) => {
+  const allTopics = topicStore.sorted.filter((bouquet) => {
     return !props.showDrafts ? !bouquet.private : true
   })
   if (props.themeName === NoOptionSelected) {
@@ -95,15 +95,25 @@ onMounted(() => {
 </script>
 
 <template>
-  <div v-if="bouquets.length > 0">
-    <p>{{ numberOfResultMsg }}</p>
-    <div class="fr-grid-row fr-mb-1w">
-      <DsfrButton
-        class="fr-mb-1w"
-        label="Ajouter un bouquet"
-        icon="ri-add-circle-line"
-        @click="goToCreate"
-      />
+  <div
+    v-if="bouquets.length > 0"
+    class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle justify-between fr-pb-1w"
+  >
+    <p class="fr-col-auto fr-my-0">{{ numberOfResultMsg }}</p>
+    <div class="fr-col-auto fr-grid-row fr-grid-row--middle">
+      <label for="sort-search" class="fr-col-auto fr-text--sm fr-m-0 fr-mr-1w"
+        >Trier par :</label
+      >
+      <div class="fr-col">
+        <DsfrSelect
+          v-model="topicStore.sort"
+          :options="[
+            { value: '-created_at', text: 'Les plus récemment créés' },
+            { value: '-last_modified', text: 'Les plus récemment modifiés' },
+            { value: 'name', text: 'Titre' }
+          ]"
+        ></DsfrSelect>
+      </div>
     </div>
   </div>
   <div
@@ -117,7 +127,7 @@ onMounted(() => {
       <a href="#" @click.stop.prevent="goToCreate()">en créant un</a>
     </p>
   </div>
-  <div class="fr-container fr-mt-4w fr-mb-4w">
+  <div class="fr-container--fluid fr-mt-2w fr-mb-4w">
     <ul class="fr-grid-row fr-grid-row--gutters es__tiles__list fr-mt-1w">
       <li
         v-for="bouquet in bouquets"

--- a/src/custom/ecospheres/views/bouquets/BouquetsListView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetsListView.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 
 import BouquetList from '@/custom/ecospheres/components/BouquetList.vue'
 import BouquetSearch from '@/custom/ecospheres/components/BouquetSearch.vue'
 import { type BreadcrumbItem, NoOptionSelected } from '@/model'
 
 const route = useRoute()
+const router = useRouter()
 
 const themeName = ref(NoOptionSelected)
 const subthemeName = ref(NoOptionSelected)
@@ -46,6 +47,10 @@ const breadcrumbList = computed(() => {
   }
   return links
 })
+
+const goToCreate = () => {
+  router.push({ name: 'bouquet_add', query: route.query })
+}
 </script>
 
 <template>
@@ -53,7 +58,20 @@ const breadcrumbList = computed(() => {
     <DsfrBreadcrumb class="fr-mb-1v" :links="breadcrumbList" />
   </div>
   <div class="fr-container fr-mb-4w">
-    <h1 class="fr-mb-2v">Bouquets</h1>
+    <div
+      class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle justify-between fr-pb-1w"
+    >
+      <h1 class="fr-col-auto fr-mb-2v">Bouquets</h1>
+      <div class="fr-col-auto fr-grid-row fr-grid-row--middle">
+        <DsfrButton
+          secondary
+          class="fr-mb-1w"
+          label="Ajouter un bouquet"
+          icon="ri-add-circle-line"
+          @click="goToCreate"
+        />
+      </div>
+    </div>
     <div class="fr-mt-2w">
       <div className="fr-grid-row">
         <nav


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/168

Ajoute un tri sur la liste des bouquets

- Tri par défaut : date de création décroissante
- Modifie le layout de la liste pour se laisser un peu de place pour le tri
  - inspiration : https://www.data.gouv.fr/fr/datasets/
  - pour l'instant le bouton "Ajouter un bouquet" est remonté et traité en secondaire, voir nouvelles maquettes pour la suite

<img width="1019" alt="Capture d’écran 2024-03-20 à 11 37 00" src="https://github.com/opendatateam/udata-front-kit/assets/119625/7a3ee6e5-81c4-46ca-b12a-4d085b0110aa">
