### PR TITLE
feat(bouquets): add datasets CSV export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@etalab/data.gouv.fr-components": "^1.13.8",
         "@gouvminint/vue-dsfr": "^5.13.0",
+        "@json2csv/plainjs": "^7.0.6",
         "@unhead/vue": "^1.9.4",
         "@vueform/multiselect": "^2.6.2",
         "axios": "^1.6.2",
@@ -1132,6 +1133,20 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@json2csv/formatters": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@json2csv/formatters/-/formatters-7.0.6.tgz",
+      "integrity": "sha512-hjIk1H1TR4ydU5ntIENEPgoMGW+Q7mJ+537sDFDbsk+Y3EPl2i4NfFVjw0NJRgT+ihm8X30M67mA8AS6jPidSA=="
+    },
+    "node_modules/@json2csv/plainjs": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@json2csv/plainjs/-/plainjs-7.0.6.tgz",
+      "integrity": "sha512-4Md7RPDCSYpmW1HWIpWBOqCd4vWfIqm53S3e/uzQ62iGi7L3r34fK/8nhOMEe+/eVfCx8+gdSCt1d74SlacQHw==",
+      "dependencies": {
+        "@json2csv/formatters": "^7.0.6",
+        "@streamparser/json": "^0.0.20"
+      }
+    },
     "node_modules/@kurkle/color": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
@@ -1244,6 +1259,11 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
+    },
+    "node_modules/@streamparser/json": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.20.tgz",
+      "integrity": "sha512-VqAAkydywPpkw63WQhPVKCD3SdwXuihCUVZbbiY3SfSTGQyHmwRoq27y4dmJdZuJwd5JIlQoMPyGvMbUPY0RKQ=="
     },
     "node_modules/@testing-library/dom": {
       "version": "9.3.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@etalab/data.gouv.fr-components": "^1.13.8",
     "@gouvminint/vue-dsfr": "^5.13.0",
     "@unhead/vue": "^1.9.4",
+    "@json2csv/plainjs": "^7.0.6",
     "@vueform/multiselect": "^2.6.2",
     "axios": "^1.6.2",
     "chart.js": "^4.4.0",

--- a/src/custom/ecospheres/components/BouquetDatasetListExport.vue
+++ b/src/custom/ecospheres/components/BouquetDatasetListExport.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import type { DatasetProperties } from '@/model'
+
+import { exportDatasets } from '../services/export'
+
+const props = defineProps({
+  filename: {
+    type: String,
+    required: true
+  },
+  datasets: {
+    type: Array<DatasetProperties>,
+    default: []
+  }
+})
+
+const doExport = async () => {
+  const data = await exportDatasets(props.datasets)
+  const link = document.createElement('a')
+  link.href = URL.createObjectURL(data)
+  link.setAttribute('download', `${props.filename}.csv`)
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+}
+</script>
+
+<template>
+  <div v-if="datasets.length > 0" class="flex align-start fr-mt-2w">
+    <DsfrButton
+      type="button"
+      label="Exporter la liste des jeux de données"
+      class="fr-mt-2w fr-ml-auto"
+      icon="ri-file-download-line"
+      secondary
+      @click.prevent="doExport"
+    />
+  </div>
+</template>

--- a/src/custom/ecospheres/components/forms/bouquet/BouquetFormRecap.vue
+++ b/src/custom/ecospheres/components/forms/bouquet/BouquetFormRecap.vue
@@ -2,6 +2,7 @@
 import type { PropType } from 'vue'
 
 import BouquetDatasetList from '@/custom/ecospheres/components/BouquetDatasetList.vue'
+import BouquetDatasetListExport from '@/custom/ecospheres/components/BouquetDatasetListExport.vue'
 import type { Bouquet } from '@/model'
 import { getDatasetListTitle } from '@/utils/bouquet'
 import { fromMarkdown } from '@/utils/index'
@@ -77,4 +78,8 @@ const goToStep = (step: number) => {
     />
   </h4>
   <BouquetDatasetList :datasets="bouquet.datasetsProperties" />
+  <BouquetDatasetListExport
+    :datasets="bouquet.datasetsProperties"
+    :filename="bouquet.id"
+  />
 </template>

--- a/src/custom/ecospheres/services/export.ts
+++ b/src/custom/ecospheres/services/export.ts
@@ -1,0 +1,56 @@
+import { Parser } from '@json2csv/plainjs'
+
+import type { DatasetProperties } from '@/model'
+import { useDatasetStore } from '@/store/DatasetStore'
+
+interface DatasetRow {
+  label: string
+  label_description: string
+  availability: string
+  uri: string | null
+  title?: string
+  description?: string
+  last_update?: string
+  organization?: string
+}
+
+export const exportDatasets = async (
+  datasets: DatasetProperties[]
+): Promise<Blob> => {
+  const store = useDatasetStore()
+  const headers = [
+    'label',
+    'label_description',
+    'availability',
+    'uri',
+    'title',
+    'description',
+    'last_update',
+    'organization'
+  ]
+  const rows = await Promise.all(
+    datasets.map(async (datasetProperties) => {
+      const row: DatasetRow = {
+        label: datasetProperties.title,
+        label_description: datasetProperties.purpose,
+        availability: datasetProperties.availability,
+        uri: datasetProperties.uri
+      }
+      const remoteDataset =
+        datasetProperties.id != null
+          ? await store.load(datasetProperties.id)
+          : null
+      if (remoteDataset != null) {
+        row.title = remoteDataset.title
+        row.uri = remoteDataset.page
+        row.description = remoteDataset.description
+        row.last_update = remoteDataset.last_update
+        row.organization = remoteDataset.organization?.name
+      }
+      return row
+    })
+  )
+  const parser = new Parser({ fields: headers })
+  const csv = parser.parse(rows)
+  return new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+}

--- a/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
@@ -23,6 +23,8 @@ import { getOwnerAvatar } from '@/utils/avatar'
 import { getDatasetListTitle } from '@/utils/bouquet'
 import { useSpatialCoverage } from '@/utils/spatial'
 
+import BouquetDatasetListExport from '../../components/BouquetDatasetListExport.vue'
+
 const route = useRouteParamsAsString()
 const router = useRouter()
 const store = useTopicStore()
@@ -234,6 +236,10 @@ onMounted(() => {
       >
         <h2>{{ getDatasetListTitle(datasetsProperties) }}</h2>
         <BouquetDatasetList :datasets="datasetsProperties" />
+        <BouquetDatasetListExport
+          :datasets="datasetsProperties"
+          :filename="bouquet.id"
+        />
       </DsfrTabContent>
       <!-- Discussions -->
       <DsfrTabContent


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/152

Ajoute un bouton "Exporter les jeux de données" sous la liste des jeux de données d'un bouquet

- sur la page de détail d'un bouquet
- sur la page récapitulative d'un bouquet pre-publish

<img width="1047" alt="Capture d’écran 2024-04-03 à 12 13 42" src="https://github.com/opendatateam/udata-front-kit/assets/119625/627e9e15-6033-4eaf-8197-def84a82beb4">

[65c9f1f19c4ea574470d7553.csv](https://github.com/opendatateam/udata-front-kit/files/14850305/65c9f1f19c4ea574470d7553.csv)
