### PR TITLE
feat(bouquets): add global datasets CSV export

### DIFF
--- a/src/views/datasets/DatasetsListView.vue
+++ b/src/views/datasets/DatasetsListView.vue
@@ -10,6 +10,7 @@ import type { TopicConf } from '@/model/config'
 import { useOrganizationStore } from '@/store/OrganizationStore'
 import { useSearchStore } from '@/store/SearchStore'
 import { useTopicStore } from '@/store/TopicStore'
+import { useUserStore } from '@/store/UserStore'
 
 defineEmits(['search'])
 const props = defineProps({
@@ -38,6 +39,7 @@ const localQuery = ref()
 const loader = useLoading()
 
 const topicStore = useTopicStore()
+const userStore = useUserStore()
 
 const selectedTopicId: Ref<string | null> = ref(null)
 const selectedOrganizationId: Ref<string | null> = ref(null)
@@ -183,7 +185,21 @@ onMounted(() => {
     <DsfrBreadcrumb class="fr-mb-1v" :links="links" />
   </div>
   <div class="fr-container fr-mb-4w">
-    <h1 class="fr-mb-2v">Jeux de données</h1>
+    <div
+      class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle justify-between fr-pb-1w"
+    >
+      <h1 class="fr-col-auto fr-mb-2v">Jeux de données</h1>
+      <div class="fr-col-auto fr-grid-row fr-grid-row--middle">
+        <a
+          v-if="userStore.isAdmin()"
+          :href="`${config.datagouvfr.base_url}/fr/datasets.csv?topic=${config.universe.topic_id}`"
+          class="fr-btn fr-btn--secondary fr-btn--md inline-flex fr-mb-1w fr-ml-2w"
+        >
+          <VIcon name="ri-file-download-line" class="fr-mr-1w" />
+          Exporter la liste des jeux de données
+        </a>
+      </div>
+    </div>
     <p v-if="query">Résultats de recherche pour "{{ query }}".</p>
     <p v-else>Parcourir tous les jeux de données présents sur {{ title }}.</p>
     <div class="fr-col-md-12 fr-mb-2w">


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/153

- Exporte la liste de tous les jeux de données de tous les bouquets
- Utilise le Endpoint existant de data.gouv.fr, filtré sur l'univers
- Visible seulement aux admins
- Un poil long à générer mais ça passe encore (5Mo)
  - il semble y avoir un cache côté data.gouv.fr, je récupère (rapidement) le même fichier horodaté d'il y a quelques minutes
- Le titre est trop long ;-) mais cf https://github.com/opendatateam/udata-front-kit/pull/417/files#r1549444623

<img width="1177" alt="Capture d’écran 2024-04-18 à 14 28 02" src="https://github.com/opendatateam/udata-front-kit/assets/119625/9e489f62-297b-48a5-b740-8746c2c80bc5">

