### PR TITLE
fix(datasets): persist search params in URL query

### DIFF
--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -1,0 +1,4 @@
+export interface TopicConf {
+  id: string
+  name: string
+}

--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -5,6 +5,11 @@ interface RouteLocationParamsAsString
   params: Record<string, string>
 }
 
+interface RouteLocationQueryAsString
+  extends Omit<RouteLocationNormalizedLoaded, 'query'> {
+  query: Record<string, string>
+}
+
 /**
  * Exposes first element from route params that could contain an array
  * Warning: this will discard the other values if any
@@ -18,4 +23,19 @@ export const useRouteParamsAsString = (): RouteLocationParamsAsString => {
     ])
   )
   return { ...route, params }
+}
+
+/**
+ * Exposes first element from route query that could contain an array
+ * Warning: this will discard the other values if any
+ */
+export const useRouteQueryAsString = (): RouteLocationQueryAsString => {
+  const route = useRoute()
+  const query = Object.fromEntries(
+    Object.entries(route.query).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? String(value[0]) : String(value)
+    ])
+  )
+  return { ...route, query }
 }

--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -5,11 +5,6 @@ interface RouteLocationParamsAsString
   params: Record<string, string>
 }
 
-interface RouteLocationQueryAsString
-  extends Omit<RouteLocationNormalizedLoaded, 'query'> {
-  query: Record<string, string>
-}
-
 /**
  * Exposes first element from route params that could contain an array
  * Warning: this will discard the other values if any
@@ -23,19 +18,4 @@ export const useRouteParamsAsString = (): RouteLocationParamsAsString => {
     ])
   )
   return { ...route, params }
-}
-
-/**
- * Exposes first element from route query that could contain an array
- * Warning: this will discard the other values if any
- */
-export const useRouteQueryAsString = (): RouteLocationQueryAsString => {
-  const route = useRoute()
-  const query = Object.fromEntries(
-    Object.entries(route.query).map(([key, value]) => [
-      key,
-      Array.isArray(value) ? String(value[0]) : String(value)
-    ])
-  )
-  return { ...route, query }
 }

--- a/src/services/routerUtils.js
+++ b/src/services/routerUtils.js
@@ -25,7 +25,13 @@ export default class RouterFetch {
             {
               path: '',
               name: item.id,
-              component: DatasetsListView
+              component: DatasetsListView,
+              props: (route) => ({
+                query: route.query.q,
+                page: route.query.page,
+                organization: route.query.organization,
+                topic: route.query.topic
+              })
             },
             {
               path: ':did',

--- a/src/store/TopicStore.ts
+++ b/src/store/TopicStore.ts
@@ -3,6 +3,7 @@ import { computed, type ComputedRef } from 'vue'
 
 import config from '@/config'
 import type { Topic } from '@/model'
+import type { TopicConf } from '@/model/config'
 
 import TopicsAPI from '../services/api/resources/TopicsAPI'
 import { useUserStore } from './UserStore'
@@ -63,7 +64,7 @@ export const useTopicStore = defineStore('topic', {
     /**
      * Load topics to store from a list of ids and API
      */
-    async loadTopicsFromList(topics: Topic[]) {
+    async loadTopicsFromList(topics: TopicConf[]) {
       this.data = []
       for (const topic of topics) {
         const res = await topicsAPIv2.get(topic.id)

--- a/src/views/datasets/DatasetsListView.vue
+++ b/src/views/datasets/DatasetsListView.vue
@@ -1,18 +1,20 @@
-<script setup>
+<script setup lang="ts">
 import { DatasetCard } from '@etalab/data.gouv.fr-components'
 import debounce from 'lodash/debounce'
-import { computed, onMounted, ref, watchEffect, watch } from 'vue'
+import { computed, onMounted, ref, watchEffect, watch, type Ref } from 'vue'
 import { useLoading } from 'vue-loading-overlay'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 
 import config from '@/config'
+import type { TopicConf } from '@/model/config'
+import { useRouteQueryAsString } from '@/router/utils'
 import { useOrganizationStore } from '@/store/OrganizationStore'
 import { useSearchStore } from '@/store/SearchStore'
 import { useTopicStore } from '@/store/TopicStore'
 
 defineEmits(['search'])
 
-const route = useRoute()
+const route = useRouteQueryAsString()
 const router = useRouter()
 const store = useSearchStore()
 const currentPage = ref(1)
@@ -21,14 +23,14 @@ const loader = useLoading()
 
 const topicStore = useTopicStore()
 const topic = computed(() => route.query.topic)
-const selectedTopicId = ref(null)
-const selectedOrganizationId = ref(null)
+const selectedTopicId: Ref<string | null> = ref(null)
+const selectedOrganizationId: Ref<string | null> = ref(null)
 
 const datasets = computed(() => store.datasets)
 const pages = computed(() => store.pagination)
 
 const title = config.website.title
-const topicsConf = config.website.list_highlighted_topics
+const topicsConf = config.website.list_highlighted_topics as TopicConf[]
 const hasOrganizationFilter = config.website.datasets.organization_filter
 
 const topicOptions = computed(() => {
@@ -52,12 +54,12 @@ const organizationOptions = computed(() => [
 
 const links = [{ to: '/', text: 'Accueil' }, { text: 'Données' }]
 
-const onSelectTopic = (topicId) => {
+const onSelectTopic = (topicId: string) => {
   selectedTopicId.value = topicId
   currentPage.value = 1
 }
 
-const onSelectOrganization = (orgId) => {
+const onSelectOrganization = (orgId: string) => {
   selectedOrganizationId.value = orgId
   currentPage.value = 1
 }
@@ -66,19 +68,19 @@ const search = () => {
   router.push({ path: '/datasets', query: { q: query.value, page: 1 } })
 }
 
-const goToPage = (page) => {
+const goToPage = (page: number) => {
   router.push({ path: '/datasets', query: { q: query.value, page: page + 1 } })
 }
 
-const zIndex = (key) => {
+const zIndex = (key: number) => {
   return { zIndex: datasets.value.length - key }
 }
 
-const getDatasetPage = (id) => {
+const getDatasetPage = (id: string) => {
   return { name: 'dataset_detail', params: { did: id } }
 }
 
-const getOrganizationPage = (id) => {
+const getOrganizationPage = (id: string) => {
   if (router.hasRoute('organization_detail')) {
     return { name: 'organization_detail', params: { oid: id } }
   }


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/186

Dans `DatasetsListView`, passe tous les paramètres de recherche en tant que props au composant, liées à la query de l'URL. Ce qui permet :
- de rendre la route/query réactive et donc de la synchroniser dans les deux sens (i.e. je sélectionne une organisation, je mets à jour l'URL ; j'arrive sur une URL avec une organisation, elle est sélectionnée)
- le retour au point de départ depuis une page de détail puisque tous les paramètres sont enregistrés

Les paramètres suivants sont gérés :
- page
- query
- organization (ecosphères)
- topic (météo)

Aussi, refactor `DatasetsListView` et `OrganizationStore` en TS.