### PR TITLE
feat(seo): add meta to bouquet detail and home

### DIFF
--- a/configs/defis/config.yaml
+++ b/configs/defis/config.yaml
@@ -29,11 +29,11 @@ website:
     title: 'Apprendre avec l’open data'
     subtitle: 'Se former et utiliser des données ouvertes pour répondre à des enjeux sociaux et environnementaux.'
     below_hero: >-
-      Les données ouvertes (open data) sont des données brutes téléchargeables en accès libre et gratuit qui peuvent être utilisées par toutes et tous. Elles permettent de créer des analyses, des services ou des produits sur une diversité de sujets (santé, emploi, urbanisme, éducation, mobilités, etc.).  
+      Les données ouvertes (open data) sont des données brutes téléchargeables en accès libre et gratuit qui peuvent être utilisées par toutes et tous. Elles permettent de créer des analyses, des services ou des produits sur une diversité de sujets (santé, emploi, urbanisme, éducation, mobilités, etc.).
 
       ### Des défis open data
 
-      La communauté open data et l’équipe de data.gouv.fr vous proposent de mettre à contribution et de développer vos compétences en réalisant des projets utiles à partir de données ouvertes.  
+      La communauté open data et l’équipe de data.gouv.fr vous proposent de mettre à contribution et de développer vos compétences en réalisant des projets utiles à partir de données ouvertes.
 
 
       Les défis proposés s’adressent notamment à toutes celles et ceux qui souhaitent s’exercer ou apprendre à exploiter des données en travaillant sur des projets concrets.
@@ -47,6 +47,7 @@ website:
 
 
       [En savoir plus sur l’Open Data University.](/opendatauniversity)
+    meta_description:
   header_button:
     display: false
     label: 'Donnez votre avis'

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -30,6 +30,7 @@ website:
     subtitle:
     below_hero:
     below_topics:
+    meta_description: ecologie.data.gouv.fr référence et centralise les données de la transition écologique.
   header_search: true
   header_button:
     display: true

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -30,6 +30,7 @@ website:
     subtitle: 'meteo.data.gouv.fr vise à référencer, héberger et diffuser les données publiques météorologiques produites par Météo-France. Vous y trouverez des données téléchargeables et utilisables de manière libre et gratuite.'
     below_hero:
     below_topics:
+    meta_description:
   header_button:
     display: true
     label: 'Donnez votre avis'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@etalab/data.gouv.fr-components": "^1.13.8",
         "@gouvminint/vue-dsfr": "^5.7.0",
+        "@unhead/vue": "^1.9.4",
         "@vueform/multiselect": "^2.6.2",
         "axios": "^1.6.2",
         "chart.js": "^4.4.0",
@@ -1642,6 +1643,58 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@unhead/dom": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-1.9.4.tgz",
+      "integrity": "sha512-nEaHOcCL0u56g4XOV5XGwRMFZ05eEINfp8nxVrPiIGLrS9BoFrZS7/6IYSkalkNRTmw8M5xqxt6BalBr594SaA==",
+      "dependencies": {
+        "@unhead/schema": "1.9.4",
+        "@unhead/shared": "1.9.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/@unhead/schema": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@unhead/schema/-/schema-1.9.4.tgz",
+      "integrity": "sha512-/J6KYQ+aqKO5uLDTU9BXfiRAfJ3mQNmF5gh3Iyd4qZaWfqjsDGYIaAe4xAGPnJxwBn6FHlnvQvZBSGqru1MByw==",
+      "dependencies": {
+        "hookable": "^5.5.3",
+        "zhead": "^2.2.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/@unhead/shared": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@unhead/shared/-/shared-1.9.4.tgz",
+      "integrity": "sha512-ErP6SUzPPRX9Df4fqGlwlLInoG+iBiH0nDudRuIpoFGyTnv1uO9BQ+lfFld8s1gI1WCdoBwVkISBp9/f/E/GLA==",
+      "dependencies": {
+        "@unhead/schema": "1.9.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/@unhead/vue": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-1.9.4.tgz",
+      "integrity": "sha512-F37bDhhieWQJyXvFV8NmrOXoIVJMhxVI/0ZUDrI9uTkMCofjfKWDJ+Gz0iYdhYF9mjQ5BN+pM31Zpxi+fN5Cfg==",
+      "dependencies": {
+        "@unhead/schema": "1.9.4",
+        "@unhead/shared": "1.9.4",
+        "hookable": "^5.5.3",
+        "unhead": "1.9.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vue": ">=2.7 || >=3"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "4.6.1",
@@ -4743,6 +4796,11 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="
+    },
     "node_modules/html-entities": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.4.0.tgz",
@@ -7713,6 +7771,20 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "devOptional": true
     },
+    "node_modules/unhead": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-1.9.4.tgz",
+      "integrity": "sha512-QVU0y3KowRu2cLjXxfemTKNohK4vdEwyahoszlEnRz0E5BTNRZQSs8AnommorGmVM7DvB2t4dwWadB51wDlPzw==",
+      "dependencies": {
+        "@unhead/dom": "1.9.4",
+        "@unhead/schema": "1.9.4",
+        "@unhead/shared": "1.9.4",
+        "hookable": "^5.5.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -8515,6 +8587,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zhead": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/zhead/-/zhead-2.2.4.tgz",
+      "integrity": "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==",
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@etalab/data.gouv.fr-components": "^1.13.8",
     "@gouvminint/vue-dsfr": "^5.7.0",
+    "@unhead/vue": "^1.9.4",
     "@vueform/multiselect": "^2.6.2",
     "axios": "^1.6.2",
     "chart.js": "^4.4.0",

--- a/src/custom/ecospheres/views/HomeView.vue
+++ b/src/custom/ecospheres/views/HomeView.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useHead } from '@unhead/vue'
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 
@@ -12,8 +13,21 @@ const doSearch = () => {
   router.push({ name: 'datasets', query: { q: query.value } })
 }
 
-const homepageTitle = config.website.homepage_title
+const homepageTitle = config.website.homepage.title
 const searchConfig = config.website.search_bar
+
+useHead({
+  title: config.website.title,
+  meta: [
+    { property: 'og:title', content: config.website.title },
+    { name: 'description', content: config.website.homepage.meta_description },
+    {
+      property: 'og:description',
+      content: config.website.homepage.meta_description
+    }
+  ],
+  link: [{ rel: 'canonical', href: window.location.origin }]
+})
 </script>
 
 <template>

--- a/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import {
   ReadMore,
-  OrganizationNameWithCertificate
+  OrganizationNameWithCertificate,
+  excerpt
 } from '@etalab/data.gouv.fr-components'
+import { useHead } from '@unhead/vue'
 import { onMounted, ref, computed } from 'vue'
 import type { Ref } from 'vue'
 import { useLoading } from 'vue-loading-overlay'
@@ -81,6 +83,32 @@ const getSelectedThemeColor = (themed: string) => {
   selectedTheme.value = themed
   return getThemeColor(selectedTheme.value)
 }
+
+const metaDescription = (): string | undefined => {
+  return excerpt(bouquet.value?.description ?? '')
+}
+
+const metaTitle = (): string => {
+  return `${bouquet.value?.name ?? ''} - ${config.website.title}`
+}
+
+const metaLink = (): string => {
+  const resolved = router.resolve({
+    name: 'bouquet_detail',
+    params: { bid: bouquet.value?.id }
+  })
+  return `${window.location.origin}${resolved.href}`
+}
+
+useHead({
+  title: metaTitle,
+  meta: [
+    { property: 'og:title', content: metaTitle },
+    { name: 'description', content: metaDescription },
+    { property: 'og:description', content: metaDescription }
+  ],
+  link: [{ rel: 'canonical', href: metaLink }]
+})
 
 onMounted(() => {
   const loader = loading.show()

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import '@gouvfr/dsfr/dist/dsfr.min.css'
 import '@gouvfr/dsfr/dist/utility/utility.min.css'
 import VueDsfr from '@gouvminint/vue-dsfr'
 import '@gouvminint/vue-dsfr/styles'
+import { createHead } from '@unhead/vue'
 import '@vueform/multiselect/themes/default.css'
 import axios from 'axios'
 import { createPinia } from 'pinia'
@@ -26,11 +27,13 @@ import { useUserStore } from './store/UserStore'
 const app = createApp(App)
 const pinia = createPinia()
 const i18n = setupI18n()
+const head = createHead()
 
 app.use(router)
 app.use(VueDsfr, { icons: Object.values(icons) })
 app.use(pinia)
 app.use(i18n)
+app.use(head)
 if (config.website.matomo.siteId) {
   app.use(VueMatomo, {
     host: config.website.matomo.host,


### PR DESCRIPTION
Related https://github.com/ecolabdata/ecospheres/issues/171

Ajoute des balises meta sur la page de détails d'un bouquet et la home ecosphères :

- title
- description
- og:title
- og:description
- canonical URL

Fun fact : le titre avait "disparu" sur la home, il est de retour.