### PR TITLE
fix(build): use VITE_SITE_ID instead of CONFIG_NAME for robots

### DIFF
--- a/.github/workflows/robots.yml
+++ b/.github/workflows/robots.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: 'npm'

--- a/scripts/generate-robots-txt.mjs
+++ b/scripts/generate-robots-txt.mjs
@@ -4,7 +4,7 @@ import dotenv from 'dotenv'
 
 dotenv.config()
 
-const configDir = `./configs/${process.env.CONFIG_NAME}`
+const configDir = `./configs/${process.env.VITE_SITE_ID}`
 const configFile = `${configDir}/config.yaml`
 
 // Read the config file


### PR DESCRIPTION
Tested here on this branch: https://github.com/opendatateam/udata-front-kit/actions/runs/8845558317