### PR TITLE
Prod robots config

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -16,7 +16,9 @@ universe:
 
 robots:
   disallow:
-    - /
+    - /admin
+    - /datasets
+    - /organizations
   sitemap:
 
 # UI customizations


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/171

:warning: Cible `ecospheres-demo` au lieu de `ecospheres-prod` pour le diff, en attendant le merge de https://github.com/opendatateam/udata-front-kit/pull/440.
La PR sera rebased sur `ecospheres-prod` pour le merge.