### PR TITLE
feat(bouquet): add harvested dataset quality warning

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -121,6 +121,9 @@ website:
   datasets:
     organization_filter: true
     add_to_bouquet: true
+    # similar to QUALITY_METADATA_BACKEND_IGNORE on data.gouv.fr
+    harvest_backends_quality_warning:
+      - CSW-ISO-19139
 
 themes:
   - name: Se loger

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -127,6 +127,8 @@ website:
   datasets:
     organization_filter: false
     add_to_bouquet: false
+    # similar to QUALITY_METADATA_BACKEND_IGNORE on data.gouv.fr
+    harvest_backends_quality_warning: []
 
 # list of organisations' ids that should be handled by the portal
 # to find an id go to https://www.data.gouv.fr/fr/organizations/ministere-de-la-transition-ecologique/

--- a/src/views/datasets/DatasetDetailView.vue
+++ b/src/views/datasets/DatasetDetailView.vue
@@ -85,6 +85,13 @@ const tabs = computed(() => {
 
 const description = computed(() => descriptionFromMarkdown(dataset))
 
+const showHarvestQualityWarning = computed(() => {
+  const backend = dataset.value?.harvest?.backend
+  const warningBackends =
+    config.website.datasets.harvest_backends_quality_warning || []
+  return backend && warningBackends.includes(backend)
+})
+
 const changePage = (type: string, page = 1, query = '') => {
   resources.value[type].currentPage = page
   resources.value[type].query = query
@@ -218,6 +225,18 @@ onMounted(() => {
           v-if="config.website.show_quality_component"
           :quality="dataset.quality"
         />
+        <div
+          v-if="showHarvestQualityWarning"
+          class="text-mention-grey fr-text--sm fr-my-1v"
+        >
+          <span
+            class="fr-icon-warning-line fr-icon--sm"
+            aria-hidden="true"
+          ></span>
+          La qualité des métadonnées peut être trompeuse car les métadonnées de
+          la source originale peuvent avoir été perdues lors de leur
+          récupération. Nous travaillons actuellement à améliorer la situation.
+        </div>
         <div
           v-if="config.website.datasets.add_to_bouquet && userStore.isLoggedIn"
         >


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/187

Affiche un warning sur le score qualité quand le jeu de données est moissonné via une liste configurable de backends.

Exemple de dataset qui doit déclencher le warning : `1338-marina-di-carrara`.