### PR TITLE
feat(dataset): add extended information panel

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -124,6 +124,7 @@ website:
     # similar to QUALITY_METADATA_BACKEND_IGNORE on data.gouv.fr
     harvest_backends_quality_warning:
       - CSW-ISO-19139
+    show_extended_information_panel: true
 
 themes:
   - name: Se loger

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -129,6 +129,7 @@ website:
     add_to_bouquet: false
     # similar to QUALITY_METADATA_BACKEND_IGNORE on data.gouv.fr
     harvest_backends_quality_warning: []
+    show_extended_information_panel: false
 
 # list of organisations' ids that should be handled by the portal
 # to find an id go to https://www.data.gouv.fr/fr/organizations/ministere-de-la-transition-ecologique/

--- a/src/components/datasets/ExtendedInformationPanel.vue
+++ b/src/components/datasets/ExtendedInformationPanel.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import type { ExtendedDatasetV2 } from '@/model/dataset'
+
+const props = defineProps({
+  dataset: {
+    type: Object as () => ExtendedDatasetV2,
+    required: true
+  }
+})
+
+const contactPoint = props.dataset.contact_point
+const accessRights = props.dataset.extras?.harvest?.['dct:accessRights']
+
+const hasExtendedInfo = !!accessRights || !!contactPoint
+</script>
+
+<template>
+  <div
+    v-if="hasExtendedInfo"
+    class="fr-py-3w fr-mb-3w border-bottom border-default-grey"
+  >
+    <h2 class="subtitle subtitle--uppercase">Informations étendues</h2>
+    <div class="fr-text--sm fr-m-0">
+      <div class="fr-grid-row fr-grid-row--gutters">
+        <div v-if="accessRights" class="fr-col-12 fr-col-sm-6 fr-col-md-4">
+          <h3 class="subtitle fr-mb-1v">Conditions d'accès et d'utilisation</h3>
+          <p class="fr-text--sm fr-m-0 text-mention-grey">
+            {{ accessRights }}
+          </p>
+        </div>
+        <div v-if="contactPoint" class="fr-col-12 fr-col-sm-6 fr-col-md-4">
+          <h3 class="subtitle fr-mb-1v">Point de contact</h3>
+          <p class="fr-text--sm fr-m-0 text-mention-grey">
+            <a :href="`mailto:${contactPoint.email}`">{{
+              contactPoint.name
+            }}</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/datasets/ExtendedInformationPanel.vue
+++ b/src/components/datasets/ExtendedInformationPanel.vue
@@ -10,8 +10,12 @@ const props = defineProps({
 
 const contactPoint = props.dataset.contact_point
 const accessRights = props.dataset.extras?.harvest?.['dct:accessRights']
+const provenance = (
+  props.dataset.extras?.harvest?.['dct:provenance'] || []
+).filter((p: string) => !!p)
 
-const hasExtendedInfo = !!accessRights || !!contactPoint
+const hasExtendedInfo =
+  !!accessRights || !!contactPoint || provenance.length > 0
 </script>
 
 <template>
@@ -35,6 +39,12 @@ const hasExtendedInfo = !!accessRights || !!contactPoint
               contactPoint.name
             }}</a>
           </p>
+        </div>
+        <div v-if="provenance.length" class="fr-col-12 fr-col-sm-6 fr-col-md-4">
+          <h3 class="subtitle fr-mb-1v">Généalogie</h3>
+          <ul class="fr-text--sm fr-m-0 text-mention-grey">
+            <li v-for="p in provenance" :key="p">{{ p }}</li>
+          </ul>
         </div>
       </div>
     </div>

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -13,3 +13,13 @@ export interface DatasetModalData {
   isValid: boolean
   mode: 'edit' | 'create'
 }
+
+export interface ContactPoint {
+  id: string
+  name: string
+  email: string
+}
+
+export type ExtendedDatasetV2 = DatasetV2 & {
+  contact_point?: ContactPoint
+}

--- a/src/views/datasets/DatasetDetailView.vue
+++ b/src/views/datasets/DatasetDetailView.vue
@@ -18,6 +18,7 @@ import DatasetAddToBouquetModal from '@/custom/ecospheres/components/datasets/Da
 import ChartData from '../../components/ChartData.vue'
 import DiscussionsList from '../../components/DiscussionsList.vue'
 import ReusesList from '../../components/ReusesList.vue'
+import ExtendedInformationPanel from '../../components/datasets/ExtendedInformationPanel.vue'
 import type { ResourceDataWithQuery } from '../../model/resource'
 import { useRouteParamsAsString } from '../../router/utils'
 import { useDatasetStore } from '../../store/DatasetStore'
@@ -369,6 +370,12 @@ onMounted(() => {
         tab-id="tab-3"
         :selected="selectedTabIndex === 3"
       >
+        <ExtendedInformationPanel
+          v-if="
+            config.website.datasets.show_extended_information_panel && dataset
+          "
+          :dataset="dataset"
+        />
         <InformationPanel
           v-if="dataset && license"
           :dataset="dataset"


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/219
Fix https://github.com/ecolabdata/ecospheres/issues/234
Fix https://github.com/ecolabdata/ecospheres/issues/235

Ajoute l'affichage de métadonnées supplémentaires pour un jeu de données (configurable) :
- Point de contact (`dataset.contact_point`)
- Conditions d'accès et d'utilisation (`dataset.extras.harvest['dct:accessRights']`)
- Généalogie (`dataset.extras.harvest['dct:provenance']`)

Une section "Informations étendues" s'ajoute au dessus du panneau d'information "standard" de data.gouv.fr. Peut-être revoir le wording du titre de la section. Afin de mieux mettre en valeur ces métadonnées, elles s'affichent au-dessus des autres informations existantes.

<img width="770" alt="Capture d’écran 2024-05-21 à 17 05 45" src="https://github.com/opendatateam/udata-front-kit/assets/119625/8dc0fe5a-4142-4362-a431-da0577d67e24">

<img width="702" alt="Capture d’écran 2024-05-21 à 18 24 55" src="https://github.com/opendatateam/udata-front-kit/assets/119625/3a9347c7-81b3-4dd9-b27e-ebdf35f4449b">

- Exemple point de contact et conditions (mauvaise qualité) : `service-de-force-de-securite-2`
- Exemple point de contact : `point-numerique-cc-grand-chambord`
- Exemple point de contact et généalogie : `lot-des-plans-de-prevention-des-risques-inondation-dans-le-departement-des-bouches-du-rhone-1`



