### PR TITLE
fix(bouquet): use correct route for dataset.uri

### DIFF
--- a/src/custom/ecospheres/components/forms/dataset/DatasetPropertiesFields.vue
+++ b/src/custom/ecospheres/components/forms/dataset/DatasetPropertiesFields.vue
@@ -73,8 +73,8 @@ const onSelectDataset = (value: DatasetV2 | undefined) => {
     datasetProperties.value.availability = Availability.LOCAL_AVAILABLE
     datasetProperties.value.id = value.id
     const resolved = router.resolve({
-      name: 'bouquet_detail',
-      params: { bid: value.id }
+      name: 'dataset_detail',
+      params: { did: value.id }
     })
     datasetProperties.value.uri = resolved.href
   }


### PR DESCRIPTION
A déployer en prod ASAP.

Voir ce qu'on fait avec le stock. Cette propriété n'est malheureusement ou heureusement pas utilisée dans le cas `LOCAL_AVAILABLE`.