### PR TITLE
feat(bouquet): auto handle data.gouv.fr URL in dataset

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -1,7 +1,7 @@
 # config file for ecospheres-front
 
 datagouvfr:
-  # data.gouv.fr base URL
+  # data.gouv.fr base URL (use www subdomain on prod)
   base_url: https://demo.data.gouv.fr
   # oauth settings
   oauth_client_id: 651479c317ad47b21e41a9d4

--- a/src/custom/ecospheres/components/forms/dataset/DatasetEditModal.vue
+++ b/src/custom/ecospheres/components/forms/dataset/DatasetEditModal.vue
@@ -82,7 +82,7 @@ const submitModal = async (modalData: DatasetModalData) => {
     // check if data.gouv.fr URL and update metadata if needed
     if (
       modalData.dataset.uri &&
-      modalData.dataset.availability !== Availability.LOCAL_AVAILABLE
+      modalData.dataset.availability === Availability.URL_AVAILABLE
     ) {
       const pattern = new RegExp(
         `^${config.datagouvfr.base_url}(?:/.*)?/datasets/(?<datasetName>[a-zA-Z0-9_-]+)(?:/|#|$)`

--- a/src/custom/ecospheres/components/forms/dataset/DatasetEditModal.vue
+++ b/src/custom/ecospheres/components/forms/dataset/DatasetEditModal.vue
@@ -102,7 +102,10 @@ const submitModal = async (modalData: DatasetModalData) => {
             modalData.dataset.id = dataset.id
           }
         } catch (error) {
-          console.error('Error fetching dataset from data.gouv.fr', error)
+          console.error(
+            `Error fetching dataset from ${config.datagouvfr.base_url}`,
+            error
+          )
         }
       }
     }

--- a/src/custom/ecospheres/components/forms/dataset/DatasetEditModal.vue
+++ b/src/custom/ecospheres/components/forms/dataset/DatasetEditModal.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { ref, computed, defineModel, type Ref } from 'vue'
+
+import type { DatasetModalData } from '@/model/dataset'
+import { Availability, type DatasetProperties } from '@/model/topic'
+
+import DatasetPropertiesFields from './DatasetPropertiesFields.vue'
+
+export interface DatasetEditModalType {
+  addDataset: () => void
+  editDataset: (dataset: DatasetProperties, index: number) => void
+}
+
+const emits = defineEmits(['submitModal'])
+
+const datasets = defineModel({
+  type: Object as () => DatasetProperties[],
+  required: true
+})
+
+const isModalOpen = ref(false)
+const modalData: Ref<DatasetModalData> = ref({
+  isValid: false,
+  mode: 'edit'
+})
+
+const modalActions = computed(() => {
+  return [
+    {
+      label: 'Enregistrer',
+      disabled: !modalData.value.isValid,
+      onClick: ($event: PointerEvent) => {
+        $event.preventDefault()
+        submitModal(modalData.value)
+        closeModal()
+      }
+    },
+    {
+      label: 'Annuler',
+      secondary: true,
+      onClick: () => {
+        closeModal()
+      }
+    }
+  ]
+})
+
+const editDataset = (dataset: DatasetProperties, index: number) => {
+  // clone the object to enable cancellation
+  modalData.value = {
+    index,
+    dataset: { ...dataset },
+    isValid: false,
+    mode: 'edit'
+  }
+  isModalOpen.value = true
+}
+
+const addDataset = () => {
+  modalData.value = {
+    index: undefined,
+    dataset: {
+      title: '',
+      purpose: '',
+      availability: Availability.LOCAL_AVAILABLE,
+      uri: null,
+      id: null
+    },
+    isValid: false,
+    mode: 'create'
+  }
+  isModalOpen.value = true
+}
+
+// move to parent
+const submitModal = (modalData: DatasetModalData) => {
+  if (modalData.dataset !== undefined) {
+    if (modalData.mode === 'create') {
+      datasets.value.push(modalData.dataset)
+    } else if (modalData.mode === 'edit' && modalData.index !== undefined) {
+      datasets.value[modalData.index] = modalData.dataset
+    }
+  }
+  emits('submitModal')
+}
+
+// call from parent
+const closeModal = () => {
+  isModalOpen.value = false
+}
+
+defineExpose({ addDataset, editDataset })
+</script>
+
+<template>
+  <DsfrModal
+    v-if="isModalOpen && modalData.dataset"
+    size="lg"
+    class="bouquet-dataset-modal"
+    :title="
+      modalData.mode === 'edit'
+        ? 'Éditer le jeu de données'
+        : 'Ajouter un jeu de données'
+    "
+    :opened="isModalOpen"
+    :actions="modalActions"
+    @close="closeModal"
+  >
+    <DatasetPropertiesFields
+      v-model:dataset-properties="modalData.dataset"
+      :already-selected-datasets="datasets"
+      @update-validation="(isValid: boolean) => modalData.isValid = isValid"
+    />
+  </DsfrModal>
+</template>
+
+<style lang="scss">
+.bouquet-dataset-modal {
+  h1 {
+    margin-bottom: 1rem;
+  }
+}
+</style>


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/218

- Détecte une URL manuelle data.gouv.fr à la soumission de la modale de création / édition d'un jeu de données et remplit le cas échéant les métadonnées pour un jeu de données `LOCAL_AVAILABLE`.
- Refactor la modale dans son propre composant afin de ne pas avoir un composant `BouquetDatasetList` trop gros

Fait de manière silencieuse car ça me parait acceptable et c'est définitivement plus simple.

Pour l'instant on ne peut pas attraper l'erreur 404 correctement, pending https://github.com/datagouv/data.gouv.fr/issues/1359, donc c'est un peu moche dans ce cas. Ca ne devrait pas arriver souvent donc je pense qu'on peut merger ça et traiter le FIXME plus tard.