### PR TITLE
feat(bouquet): link to organization

### DIFF
--- a/src/components/OrganizationLogo.vue
+++ b/src/components/OrganizationLogo.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import type { DatasetV2 } from '@etalab/data.gouv.fr-components'
+import { computed } from 'vue'
+
+import config from '@/config'
+import type { WithOwned } from '@/model'
+import type { Topic } from '@/model/topic'
+
+const props = defineProps({
+  object: {
+    type: Object as () => WithOwned<DatasetV2 | Topic>,
+    required: true
+  },
+  size: {
+    type: Number,
+    default: 32
+  },
+  padding: {
+    type: Number,
+    default: 6
+  }
+})
+
+const logoSrc = computed(() => {
+  return (
+    props.object.organization?.logo_thumbnail ||
+    `${config.datagouvfr.base_url}/_themes/gouvfr/img/placeholders/organization.png`
+  )
+})
+
+const style = computed(() => {
+  const outerSize = props.size + props.padding * 2 + 1
+  return {
+    width: `${outerSize}px`,
+    height: `${outerSize}px`,
+    padding: `${props.padding}px`
+  }
+})
+</script>
+
+<template>
+  <div class="logo" :style="style">
+    <img :src="logoSrc" :width="size" :height="size" />
+  </div>
+</template>
+
+<style scoped lang="scss">
+.logo {
+  display: inline-block;
+  background: white;
+  border: 1px solid var(--border-default-grey);
+}
+</style>

--- a/src/custom/ecospheres/components/forms/bouquet/BouquetOwnerForm.vue
+++ b/src/custom/ecospheres/components/forms/bouquet/BouquetOwnerForm.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { defineModel, computed, ref, watch, type Ref } from 'vue'
+
+import type { Topic } from '@/model/topic'
+import { useUserStore } from '@/store/UserStore'
+
+const topic = defineModel({
+  type: Object as () => Topic,
+  required: true
+})
+
+const userStore = useUserStore()
+
+const choice: Ref<'organization' | 'owner'> = ref(
+  topic.value.owner != null ? 'owner' : 'organization'
+)
+const organizations = computed(() => userStore.data?.organizations || [])
+
+const onSelectOrganization = (value: string) => {
+  const idx = parseInt(value)
+  topic.value.organization = organizations.value[idx]
+  topic.value.owner = null
+}
+
+watch(choice, () => {
+  if (choice.value === 'owner' && userStore.data?.id) {
+    topic.value.owner = userStore.data
+    topic.value.organization = null
+  }
+})
+</script>
+
+<template>
+  <div>
+    <label class="fr-label" for="owner"
+      >Choisissez si vous souhaitez gérer ce bouquet&nbsp;:</label
+    >
+    <fieldset id="owner" class="fr-fieldset">
+      <div class="fr-fieldset__content" role="radiogroup">
+        <DsfrRadioButton
+          v-model="choice"
+          name="owner"
+          value="owner"
+          label="En votre propre nom"
+        />
+        <div>
+          <DsfrRadioButton
+            v-model="choice"
+            :disabled="organizations.length === 0"
+            name="organization"
+            value="organization"
+            label="En tant qu'organisation"
+          />
+          <div v-if="choice === 'organization'">
+            <select
+              class="fr-select"
+              @change="
+                onSelectOrganization(($event.target as HTMLInputElement)?.value)
+              "
+            >
+              <option selected disabled value="">
+                Choisissez une organisation
+              </option>
+              <option
+                v-for="(org, idx) in organizations"
+                :key="idx"
+                :selected="topic.organization?.id === org.id"
+                :value="idx"
+              >
+                {{ org.name }}
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+</template>

--- a/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
@@ -11,6 +11,7 @@ import { useLoading } from 'vue-loading-overlay'
 import { useRouter } from 'vue-router'
 
 import DiscussionsList from '@/components/DiscussionsList.vue'
+import OrganizationLogo from '@/components/OrganizationLogo.vue'
 import ReusesList from '@/components/ReusesList.vue'
 import config from '@/config'
 import BouquetDatasetList from '@/custom/ecospheres/components/BouquetDatasetList.vue'
@@ -193,10 +194,8 @@ onMounted(() => {
         </div>
         <h2 id="producer" class="subtitle fr-mb-1v">Auteur</h2>
         <div v-if="topic.organization" class="fr-grid-row fr-grid-row--middle">
-          <div class="fr-col-auto">
-            <div class="border fr-p-1-5v fr-mr-1-5v">
-              <img :src="topic.organization.logo" height="32" />
-            </div>
+          <div class="fr-col-auto fr-mr-1w">
+            <OrganizationLogo :object="topic" />
           </div>
           <p class="fr-col fr-m-0">
             <a class="fr-link" :href="topic.organization.page">

--- a/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
@@ -52,7 +52,7 @@ const showDiscussions = config.website.discussions.topic.display
 const description = computed(() => descriptionFromMarkdown(topic))
 
 const canEdit = computed(() => {
-  return useUserStore().hasEditPermissions(topic.value as Topic)
+  return useUserStore().hasEditPermissions(topic.value)
 })
 
 const goToEdit = () => {

--- a/src/custom/ecospheres/views/bouquets/BouquetFormView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetFormView.vue
@@ -10,6 +10,7 @@ import { useRouteParamsAsString, useRouteQueryAsString } from '@/router/utils'
 import { useTopicStore } from '@/store/TopicStore'
 
 import BouquetForm from '../../components/forms/bouquet/BouquetForm.vue'
+import BouquetOwnerForm from '../../components/forms/bouquet/BouquetOwnerForm.vue'
 
 const props = defineProps({
   isCreate: {
@@ -150,6 +151,10 @@ onMounted(() => {
           v-model="topic"
           @update-validation="(isValid: boolean) => canSave = isValid"
         />
+      </div>
+      <div class="fr-mt-4w">
+        <h2>Propriétaire du bouquet</h2>
+        <BouquetOwnerForm v-if="topic.id || isCreate" v-model="topic" />
       </div>
       <div class="fr-mt-4w fr-grid-row fr-grid-row--right">
         <DsfrButton

--- a/src/model/user.ts
+++ b/src/model/user.ts
@@ -1,0 +1,5 @@
+import type { User, Organization } from '@etalab/data.gouv.fr-components'
+
+export type ExtendedUser = User & {
+  organizations: Organization[]
+}

--- a/src/store/UserStore.ts
+++ b/src/store/UserStore.ts
@@ -1,9 +1,9 @@
-import type { User } from '@etalab/data.gouv.fr-components'
 import type { AxiosError } from 'axios'
 import { defineStore } from 'pinia'
 import { watch } from 'vue'
 
 import type { WithOwned } from '@/model'
+import type { ExtendedUser } from '@/model/user'
 import LocalStorageService from '@/services/LocalStorageService'
 import UserAPI from '@/services/api/resources/UserAPI'
 
@@ -14,7 +14,7 @@ export interface RootState {
   isInited: boolean
   isLoggedIn: boolean
   token: string | undefined
-  data: User | undefined
+  data: ExtendedUser | undefined
 }
 
 export const useUserStore = defineStore('user', {
@@ -34,12 +34,12 @@ export const useUserStore = defineStore('user', {
      * Init store from localStorage
      * If we have a token, fetch user infos from API
      */
-    async init(): Promise<User | undefined> {
+    async init(): Promise<ExtendedUser | undefined> {
       const token = localStorage.getItem(STORAGE_KEY)
       if (token !== null) {
         this.token = token
         this.isLoggedIn = true
-        let userData: User | undefined
+        let userData: ExtendedUser | undefined
         try {
           userData = await userAPI.list()
         } catch (err) {
@@ -103,7 +103,7 @@ export const useUserStore = defineStore('user', {
     /**
      * Store user infos
      */
-    storeInfo(data: User) {
+    storeInfo(data: ExtendedUser) {
       this.data = data
     },
     /**
@@ -117,9 +117,16 @@ export const useUserStore = defineStore('user', {
      */
     hasEditPermissions<T>(object: WithOwned<T> | null): boolean {
       if (object === null) return false
-      if (!this.isLoggedIn) return false
+      if (!this.isLoggedIn || this.data === undefined) return false
       if (this.isAdmin() === true) return true
-      return object.owner?.id === this.data?.id
+      if (object.owner != null) {
+        return object.owner.id === this.data.id
+      } else if (object.organization != null) {
+        return this.data.organizations
+          .map((o) => o.id)
+          .includes(object.organization.id)
+      }
+      return false
     }
   }
 })


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/89

- Ajoute la possibilité d'associer un bouquet à une organisation de l'utilisateur connecté
- Permet aux membres de l'organisation d'éditer un bouquet

Une section "Propriétaire du bouquet" apparait en bas dans le formulaire d'édition/création. Wording à valider / revoir. Placé en bas car probablement pas la première chose à laquelle on a envie de réfléchir en créant un bouquet, ni la première chose à modifier. On peut sélectionner "en son propre nom" ou une organisation à laquelle on appartient (similaire à la création d'un jeu de données sur data.gouv.fr).

Le fait que le formulaire "propriétaire" soit disponible en édition permet à chaque membre de l'organisation de s'attribuer le bouquet en son nom ou dans le déplacer dans une autre organisation a posteriori. C'est quelque chose qui n'est pas possible sur data.gouv.fr pour un jeu de données, il faut passer par une demande de transfert. Je ne pense pas que ça pose de problème à court terme, au pire il suffira de demander à la personne de changer l'affectation s'il y a un problème (ou le faire via l'API).

<img width="954" alt="Capture d’écran 2024-05-27 à 14 12 51" src="https://github.com/opendatateam/udata-front-kit/assets/119625/e1b99063-82de-4573-a656-b286e84eecea">

<img width="901" alt="Capture d’écran 2024-05-27 à 14 53 01" src="https://github.com/opendatateam/udata-front-kit/assets/119625/1e1640fb-0ee8-4d05-9a67-b8f3e16e6651">

