### PR TITLE
refactor: toasted and authenticated config params for API methods

### DIFF
--- a/src/custom/ecospheres/components/forms/dataset/DatasetEditModal.vue
+++ b/src/custom/ecospheres/components/forms/dataset/DatasetEditModal.vue
@@ -89,9 +89,13 @@ const submitModal = async (modalData: DatasetModalData) => {
       )
       const match = pattern.exec(modalData.dataset.uri)
       if (match?.groups?.datasetName) {
-        // FIXME: check 404 on data.gouv.fr when CORS allows it and remove toast
         try {
-          const dataset = await useDatasetStore().load(match.groups.datasetName)
+          const dataset = await useDatasetStore().load(
+            match.groups.datasetName,
+            {
+              toasted: false
+            }
+          )
           if (dataset !== undefined) {
             modalData.dataset.availability = Availability.LOCAL_AVAILABLE
             const resolved = router.resolve({

--- a/src/custom/ecospheres/utils/bouquet.ts
+++ b/src/custom/ecospheres/utils/bouquet.ts
@@ -105,14 +105,14 @@ export function useExtras(topic: Ref<Topic | null>): {
     subtheme.value = topic.value?.extras['ecospheres:informations'][0].subtheme
     datasetsProperties.value =
       topic.value?.extras['ecospheres:datasets_properties'] ?? []
-    // FIXME: catch 404 when possible from data.gouv.fr
     if (topic.value?.extras?.ecospheres?.cloned_from != null) {
       useTopicStore()
-        .load(topic.value?.extras.ecospheres.cloned_from)
+        .load(topic.value?.extras.ecospheres.cloned_from, { toasted: false })
         .then((res) => {
           clonedFrom.value = res
         })
-        .catch(() => {
+        .catch((err) => {
+          console.error('Failed fetching cloned_from', err.response?.data)
           clonedFrom.value = null
         })
     } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import VueDsfr from '@gouvminint/vue-dsfr'
 import '@gouvminint/vue-dsfr/styles'
 import { createHead } from '@unhead/vue'
 import axios from 'axios'
+import type { InternalAxiosRequestConfig } from 'axios'
 import { createPinia } from 'pinia'
 import { createApp, markRaw } from 'vue'
 import TextClamp from 'vue3-text-clamp'
@@ -19,6 +20,7 @@ import config from '@/config'
 import App from './App.vue'
 import './assets/main.css'
 import * as icons from './icons.js'
+import type { CustomParams } from './model/api'
 import routerPromise from './router'
 import LocalStorageService from './services/LocalStorageService'
 import { useUserStore } from './store/UserStore'
@@ -72,9 +74,9 @@ routerPromise
 
 // inject token in requests if user is loggedIn
 axios.interceptors.request.use(
-  async (config) => {
+  async (config: InternalAxiosRequestConfig & CustomParams) => {
     const store = useUserStore()
-    if (store.$state.isLoggedIn) {
+    if (store.$state.isLoggedIn && config.authenticated === true) {
       config.headers.Authorization = `Bearer ${store.$state.token}`
     }
     return config

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,12 +74,12 @@ routerPromise
 
 // inject token in requests if user is loggedIn
 axios.interceptors.request.use(
-  async (config: InternalAxiosRequestConfig & CustomParams) => {
+  async (requestConfig: InternalAxiosRequestConfig & CustomParams) => {
     const store = useUserStore()
-    if (store.$state.isLoggedIn && config.authenticated === true) {
-      config.headers.Authorization = `Bearer ${store.$state.token}`
+    if (store.$state.isLoggedIn && requestConfig.authenticated === true) {
+      requestConfig.headers.Authorization = `Bearer ${store.$state.token}`
     }
-    return config
+    return requestConfig
   },
   async (error) => await Promise.reject(error)
 )

--- a/src/model/api.ts
+++ b/src/model/api.ts
@@ -11,16 +11,6 @@ export type HttpMethod =
   | 'head'
   | 'options'
 
-export interface RequestConfig {
-  url: string
-  method: HttpMethod
-  params?: object
-  data?: object
-  headers?: object
-}
-
-export type URLParams = Record<string, string | number | null>
-
 export type AxiosResponseData = AxiosResponse['data']
 
 export type GenericData = object[]
@@ -39,3 +29,40 @@ export interface DatagouvfrAPIArgs {
   version?: number
   endpoint?: string
 }
+
+export interface CustomParams {
+  toasted?: boolean
+  authenticated?: boolean
+}
+
+export interface RequestConfig extends CustomParams {
+  url: string
+  method: HttpMethod
+  params?: object
+  data?: object
+  headers?: object
+}
+
+export type URLParams = Record<string, string | number | null>
+
+interface BaseParams extends CustomParams {
+  headers?: Record<string, unknown>
+}
+
+interface EntityParam {
+  entityId: string
+}
+
+interface QueryParam {
+  params?: URLParams
+}
+
+interface DataParam {
+  data: object
+}
+
+export type GetParams = BaseParams & QueryParam & EntityParam
+export type ListParams = BaseParams & QueryParam
+export type CreateParams = BaseParams & DataParam
+export type UpdateParams = BaseParams & DataParam & EntityParam
+export type DeleteParams = BaseParams & EntityParam

--- a/src/model/api.ts
+++ b/src/model/api.ts
@@ -45,7 +45,7 @@ export interface RequestConfig extends CustomParams {
 
 export type URLParams = Record<string, string | number | null>
 
-interface BaseParams extends CustomParams {
+export interface BaseParams extends CustomParams {
   headers?: Record<string, unknown>
 }
 

--- a/src/services/api/DatagouvfrAPI.ts
+++ b/src/services/api/DatagouvfrAPI.ts
@@ -8,7 +8,11 @@ import type {
   AxiosResponseData,
   RequestConfig,
   AxiosError,
-  URLParams
+  GetParams,
+  UpdateParams,
+  ListParams,
+  CreateParams,
+  DeleteParams
 } from '../../model/api'
 
 /**
@@ -41,7 +45,7 @@ export default class DatagouvfrAPI {
    */
   async request(config: RequestConfig): Promise<AxiosResponseData> {
     const response = await axios(config).catch((error: AxiosError) => {
-      if (this.toasted) {
+      if (this.toasted && config.toasted === true) {
         toast(error.message, { type: 'error', autoClose: false })
       }
       throw error
@@ -52,57 +56,99 @@ export default class DatagouvfrAPI {
   /**
    * Get an entity's detail from its id
    */
-  async get(
-    entityId: string,
-    params?: URLParams,
-    headers?: object
-  ): Promise<AxiosResponseData> {
+  async get({
+    entityId,
+    params,
+    headers,
+    toasted = true,
+    authenticated = false
+  }: GetParams): Promise<AxiosResponseData> {
     const url = `${this.url()}/${entityId}/`
-    return await this.request({ url, method: 'get', params, headers })
+    return await this.request({
+      url,
+      method: 'get',
+      params,
+      headers,
+      toasted,
+      authenticated
+    })
   }
 
   /**
    * List entities
    */
-  async list(params?: URLParams): Promise<AxiosResponseData> {
+  async list({
+    params,
+    headers,
+    toasted = true,
+    authenticated = false
+  }: ListParams): Promise<AxiosResponseData> {
     return await this.request({
       url: this.url(true),
       method: 'get',
-      params
+      params,
+      headers,
+      toasted,
+      authenticated
     })
   }
 
   /**
    * Create an entity (POST)
    */
-  async create(data: object): Promise<AxiosResponseData> {
+  async create({
+    data,
+    headers,
+    toasted = true,
+    authenticated = true
+  }: CreateParams): Promise<AxiosResponseData> {
     return await this.request({
       url: this.url(true),
       method: 'post',
-      data
+      data,
+      headers,
+      toasted,
+      authenticated
     })
   }
 
   /**
    * Update an entity (PUT)
    */
-  async update(entityId: string, data: object): Promise<AxiosResponseData> {
+  async update({
+    entityId,
+    data,
+    headers,
+    toasted = true,
+    authenticated = true
+  }: UpdateParams): Promise<AxiosResponseData> {
     const url = `${this.url()}/${entityId}/`
     return await this.request({
       url,
       method: 'put',
-      data
+      data,
+      headers,
+      toasted,
+      authenticated
     })
   }
 
   /**
    * Delete an entity (DELETE)
    */
-  async delete(entityId: string): Promise<AxiosResponseData> {
+  async delete({
+    entityId,
+    headers,
+    toasted = true,
+    authenticated = true
+  }: DeleteParams): Promise<AxiosResponseData> {
     const url = `${this.url()}/${entityId}/`
     return await this.request({
       url,
-      method: 'delete'
+      method: 'delete',
+      headers,
+      toasted,
+      authenticated
     })
   }
 }

--- a/src/services/api/DatagouvfrAPI.ts
+++ b/src/services/api/DatagouvfrAPI.ts
@@ -43,8 +43,8 @@ export default class DatagouvfrAPI {
   /**
    * Make a `method` request to URL and optionnaly attach a toaster to the error
    */
-  async request(config: RequestConfig): Promise<AxiosResponseData> {
-    const response = await axios(config).catch((error: AxiosError) => {
+  async request(requestConfig: RequestConfig): Promise<AxiosResponseData> {
+    const response = await axios(requestConfig).catch((error: AxiosError) => {
       if (this.toasted && config.toasted === true) {
         toast(error.message, { type: 'error', autoClose: false })
       }

--- a/src/services/api/SearchAPI.ts
+++ b/src/services/api/SearchAPI.ts
@@ -16,10 +16,12 @@ export default class SearchAPI extends DatagouvfrAPI {
     args?: object
   ): Promise<DatasetV2Response> {
     return await this.list({
-      topic,
-      q: query,
-      page: page ?? 1,
-      ...args
+      params: {
+        topic,
+        q: query,
+        page: page ?? 1,
+        ...args
+      }
     })
   }
 }

--- a/src/services/api/SpatialAPI.ts
+++ b/src/services/api/SpatialAPI.ts
@@ -11,17 +11,20 @@ export default class SpatialAPI extends DatagouvfrAPI {
   endpoint = 'spatial'
 
   async suggestZones(query: string, args?: object): Promise<SpatialCoverage[]> {
-    return await this.get('zones/suggest', { q: query, ...args })
+    return await this.get({
+      entityId: 'zones/suggest',
+      params: { q: query, ...args }
+    })
   }
 
   async getLevels(): Promise<SpatialCoverageLevel[]> {
-    return await this.get('levels')
+    return await this.get({ entityId: 'levels' })
   }
 
   async getZone(zoneId: string): Promise<SpatialCoverage> {
-    const response = (await this.get(
-      `zone/${zoneId}`
-    )) as SpatialCoverageResponse
+    const response = (await this.get({
+      entityId: `zone/${zoneId}`
+    })) as SpatialCoverageResponse
     return {
       id: response.id,
       ...response.properties

--- a/src/services/api/__tests__/DatagouvfrAPI.test.ts
+++ b/src/services/api/__tests__/DatagouvfrAPI.test.ts
@@ -37,7 +37,7 @@ describe('DatagouvfrAPI', () => {
     const entityData = { id: entityId, name: 'Test Entity' }
     mock.onGet(`${endpointUrl()}/${entityId}/`).reply(200, entityData)
 
-    const data = await api.get(entityId)
+    const data = await api.get({ entityId })
     expect(data).toEqual(entityData)
   })
 
@@ -48,7 +48,7 @@ describe('DatagouvfrAPI', () => {
     ]
     mock.onGet(endpointUrl(true)).reply(200, entitiesData)
 
-    const data = await api.list()
+    const data = await api.list({})
     expect(data).toEqual(entitiesData)
   })
 
@@ -56,7 +56,7 @@ describe('DatagouvfrAPI', () => {
     const newEntityData = { name: 'New Entity' }
     mock.onPost(endpointUrl(true)).reply(201, newEntityData)
 
-    const data = await api.create(newEntityData)
+    const data = await api.create({ data: newEntityData })
     expect(data).toEqual(newEntityData)
   })
 
@@ -65,7 +65,7 @@ describe('DatagouvfrAPI', () => {
     const updatedEntityData = { id: entityId, name: 'Updated Entity' }
     mock.onPut(`${endpointUrl()}/${entityId}/`).reply(200, updatedEntityData)
 
-    const data = await api.update(entityId, updatedEntityData)
+    const data = await api.update({ entityId, data: updatedEntityData })
     expect(data).toEqual(updatedEntityData)
   })
 
@@ -73,7 +73,7 @@ describe('DatagouvfrAPI', () => {
     const entityId = '123'
     mock.onDelete(`${endpointUrl()}/${entityId}/`).reply(204)
 
-    const data = await api.delete(entityId)
+    const data = await api.delete({ entityId })
     expect(data).toEqual(undefined)
   })
 })

--- a/src/store/DatasetStore.ts
+++ b/src/store/DatasetStore.ts
@@ -1,6 +1,7 @@
 import type { DatasetV2, License } from '@etalab/data.gouv.fr-components'
 import { defineStore } from 'pinia'
 
+import type { BaseParams } from '@/model/api'
 import type { DatasetV2Response } from '@/model/dataset'
 
 import DatasetsAPI from '../services/api/resources/DatasetsAPI'
@@ -125,10 +126,13 @@ export const useDatasetStore = defineStore('dataset', {
     /**
      * Async function to trigger API fetch of a dataset if not known in store
      */
-    async load(datasetId: string) {
+    async load(datasetId: string, params?: BaseParams) {
       const existing = this.get(datasetId)
       if (existing !== undefined) return existing
-      const dataset = await datasetsApiv2.get({ entityId: datasetId })
+      const dataset = await datasetsApiv2.get({
+        entityId: datasetId,
+        ...params
+      })
       if (dataset === undefined) return
       return this.addOrphan(dataset)
     },

--- a/src/store/DatasetStore.ts
+++ b/src/store/DatasetStore.ts
@@ -128,7 +128,7 @@ export const useDatasetStore = defineStore('dataset', {
     async load(datasetId: string) {
       const existing = this.get(datasetId)
       if (existing !== undefined) return existing
-      const dataset = await datasetsApiv2.get(datasetId)
+      const dataset = await datasetsApiv2.get({ entityId: datasetId })
       if (dataset === undefined) return
       return this.addOrphan(dataset)
     },
@@ -154,7 +154,9 @@ export const useDatasetStore = defineStore('dataset', {
     },
 
     async getLicense(license: string) {
-      const response: License[] = await datasetsApi.get('licenses')
+      const response: License[] = await datasetsApi.get({
+        entityId: 'licenses'
+      })
       const foundLicense = response.find((l) => l.id === license)
       return foundLicense
     }

--- a/src/store/DiscussionStore.ts
+++ b/src/store/DiscussionStore.ts
@@ -54,7 +54,9 @@ export const useDiscussionStore = defineStore('discussion', {
     async createDiscussion(
       discussionForm: DiscussionForm
     ): Promise<Discussion> {
-      const discussion: Discussion = await discussionsAPI.create(discussionForm)
+      const discussion: Discussion = await discussionsAPI.create({
+        data: discussionForm
+      })
       await this.reloadForSubject(discussionForm.subject.id)
       return discussion
     },

--- a/src/store/OrganizationStore.ts
+++ b/src/store/OrganizationStore.ts
@@ -70,7 +70,10 @@ export const useOrganizationStore = defineStore('organization', {
     async loadFromConfigFlat() {
       if (this.flatData.length > 0) return this.flatData
       const promises = config.organizations.map(async (orgId: string) => {
-        return await orgApi.get(orgId, undefined, { 'x-fields': 'id,name' })
+        return await orgApi.get({
+          entityId: orgId,
+          headers: { 'x-fields': 'id,name' }
+        })
       })
       this.flatData = await Promise.all(promises)
       return this.flatData
@@ -83,7 +86,7 @@ export const useOrganizationStore = defineStore('organization', {
         const existing = this.get(orgId)
         if (existing !== undefined) continue
         try {
-          const org = await orgApi.get(orgId)
+          const org = await orgApi.get({ entityId: orgId })
           this.add(org, page)
         } catch (e) {
           console.log(
@@ -121,7 +124,7 @@ export const useOrganizationStore = defineStore('organization', {
     async load(orgId: string, page: number) {
       const existing = this.get(orgId)
       if (existing !== undefined) return existing
-      const org = await orgApi.get(orgId)
+      const org = await orgApi.get({ entityId: orgId })
       return this.add(org, page)
     }
   }

--- a/src/store/ResourceStore.ts
+++ b/src/store/ResourceStore.ts
@@ -30,7 +30,9 @@ export const useResourceStore = defineStore('resource', {
         return this.data[datasetId]
       }
       if (this.resourceTypes.length === 0) {
-        this.resourceTypes = await datasetsApi.get('resource_types', {})
+        this.resourceTypes = await datasetsApi.get({
+          entityId: 'resource_types'
+        })
       }
       this.data[datasetId] = []
       for (const type of this.resourceTypes) {
@@ -58,11 +60,14 @@ export const useResourceStore = defineStore('resource', {
       page: number,
       q = ''
     ): Promise<{ data: Resource[]; total: number }> {
-      const response = await datasetsApiv2.get(`${datasetId}/resources`, {
-        page,
-        page_size: pageSize,
-        type: typeId,
-        q
+      const response = await datasetsApiv2.get({
+        entityId: `${datasetId}/resources`,
+        params: {
+          page,
+          page_size: pageSize,
+          type: typeId,
+          q
+        }
       })
       return { data: response.data, total: response.total }
     }

--- a/src/store/ReuseStore.ts
+++ b/src/store/ReuseStore.ts
@@ -41,7 +41,7 @@ export const useReuseStore = defineStore('reuse', {
      * Get reuses types from the API
      */
     async getTypes(): Promise<ReuseType[]> {
-      return await reusesAPI.get('types')
+      return await reusesAPI.get({ entityId: 'types' })
     }
   }
 })

--- a/src/store/TopicStore.ts
+++ b/src/store/TopicStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { computed, type ComputedRef } from 'vue'
 
 import config from '@/config'
+import type { BaseParams } from '@/model/api'
 import type { TopicConf } from '@/model/config'
 import type { Topic } from '@/model/topic'
 
@@ -116,10 +117,10 @@ export const useTopicStore = defineStore('topic', {
     /**
      * Get a single topic from store or API
      */
-    async load(slugOrId: string): Promise<Topic> {
+    async load(slugOrId: string, params?: BaseParams): Promise<Topic> {
       const existing = this.get(slugOrId)
       if (existing !== undefined) return existing
-      const topic = await topicsAPIv2.get({ entityId: slugOrId })
+      const topic = await topicsAPIv2.get({ entityId: slugOrId, ...params })
       this.data.push(topic)
       return topic
     },

--- a/src/store/UserStore.ts
+++ b/src/store/UserStore.ts
@@ -41,7 +41,7 @@ export const useUserStore = defineStore('user', {
         this.isLoggedIn = true
         let userData: ExtendedUser | undefined
         try {
-          userData = await userAPI.list()
+          userData = await userAPI.list({ authenticated: true })
         } catch (err) {
           // profile info fetching has failed, we're probably using a bad token
           // keep the current route and redirect to the login flow

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -23,7 +23,7 @@ onMounted(() => {
     auth.retrieveToken(route.query.code, route.query.state).then((token) => {
       auth.cleanup()
       store.login(token)
-      api.list().then((data) => {
+      api.list({ authenticated: true }).then((data) => {
         store.storeInfo(data)
       })
       const lastRoute = LocalStorageService.getItem('lastRoute')


### PR DESCRIPTION
Introduit les paramètres suivants pour chaque appel d'API :
- `toasted` : est-ce qu'un toast doit être affiché en cas d'erreur ?
- `authentificated` : est-ce que la clé d'API doit être envoyée si elle existe ?

Ces changements permettent :
- d'ignorer silencieusement une erreur réseau
- de contourner https://github.com/datagouv/data.gouv.fr/issues/1359 en n'envoyant la clé d'API seulement quand c'est nécessaire, et donc de ne pas avoir (la plupart du temps) d'erreur CORS sur les 3xx, 4xx et 5xx au GET

On peut ainsi traiter les deux `FIXME` :
- dataset non trouvé sur data.gouv.fr quand on tente d'auto-remplacer un jeu de données référence via URL dans un bouquet
- bouquet `cloned_from` non trouvé (parce que supprimé probablement)

Cela ouvre aussi la possibilité de traiter https://github.com/ecolabdata/ecospheres/issues/217 et https://github.com/ecolabdata/ecospheres/issues/221.