### PR TITLE
feat(bouquet): handle redirect

### DIFF
--- a/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
@@ -105,7 +105,7 @@ const metaTitle = (): string => {
 const metaLink = (): string => {
   const resolved = router.resolve({
     name: 'bouquet_detail',
-    params: { bid: topic.value?.id }
+    params: { bid: topic.value?.slug }
   })
   return `${window.location.origin}${resolved.href}`
 }
@@ -128,6 +128,12 @@ watch(
       .load(props.bouquetId)
       .then((res) => {
         topic.value = res
+        if (topic.value.slug !== props.bouquetId) {
+          router.push({
+            name: 'bouquet_detail',
+            params: { bid: topic.value.slug }
+          })
+        }
       })
       .finally(() => loader.hide())
   },


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/217 

(techniquement déjà fixé par https://github.com/opendatateam/udata-front-kit/pull/464)

Redirige un ancien slug ou un id vers le slug courant du bouquet.

Utilise aussi le slug pour l'URL canonique, cf https://github.com/ecolabdata/ecospheres/issues/171#issuecomment-2139646092