### PR TITLE
feat(bouquet): handle 404

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
+/404 /index.html 404
 /* /index.html 200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,1 @@
-/404 /index.html 404
 /* /index.html 200

--- a/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
@@ -125,7 +125,7 @@ watch(
   () => {
     const loader = loading.show()
     store
-      .load(props.bouquetId)
+      .load(props.bouquetId, { toasted: false, redirectNotFound: true })
       .then((res) => {
         topic.value = res
         if (topic.value.slug !== props.bouquetId) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,7 +63,7 @@ routerPromise
       }
     })
 
-    // redirect to 404 if configured
+    // redirect to 404 if configured for this request
     axios.interceptors.response.use(
       async (response) => {
         return response

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,6 +63,19 @@ routerPromise
       }
     })
 
+    // redirect to 404 if configured
+    axios.interceptors.response.use(
+      async (response) => {
+        return response
+      },
+      async (error) => {
+        if (error.config.redirectNotFound === true) {
+          await router.push({ name: 'not_found' })
+        }
+        return await Promise.reject(error)
+      }
+    )
+
     app.mount('#app')
   })
   .catch((error) => {

--- a/src/model/api.ts
+++ b/src/model/api.ts
@@ -33,6 +33,7 @@ export interface DatagouvfrAPIArgs {
 export interface CustomParams {
   toasted?: boolean
   authenticated?: boolean
+  redirectNotFound?: boolean
 }
 
 export interface RequestConfig extends CustomParams {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,6 +7,7 @@ import {
 
 import config from '@/config'
 import type { PageConfig } from '@/model/config'
+import NotFoundView from '@/views/NotFoundView.vue'
 import SimplePageView from '@/views/SimplePageView.vue'
 
 const disableRoutes: string[] = config.website.router.disable ?? []
@@ -72,7 +73,7 @@ const defaultRoutes: RouteRecordRaw[] = [
   {
     path: '/404',
     name: 'not_found',
-    component: async () => await import('@/views/NotFoundView.vue')
+    component: NotFoundView
   }
 ].filter((route) => {
   if (route.name === undefined) return true
@@ -137,6 +138,11 @@ const routerPromise = siteRoutesPromise.then((siteRoutes) => {
   })
   const routes = Array.from(routesMap.values())
   routes.push(...pages)
+  // catch all 404 (keep at the end of the list)
+  routes.push({
+    path: '/:pathMatch(.*)',
+    component: NotFoundView
+  })
   return createRouter({
     history: createWebHistory(import.meta.env.BASE_URL),
     routes,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,9 @@
-import { createRouter, createWebHistory, type RouteLocationNormalizedLoaded, type RouteRecordRaw } from 'vue-router'
+import {
+  createRouter,
+  createWebHistory,
+  type RouteLocationNormalizedLoaded,
+  type RouteRecordRaw
+} from 'vue-router'
 
 import config from '@/config'
 import type { PageConfig } from '@/model/config'
@@ -62,6 +67,12 @@ const defaultRoutes: RouteRecordRaw[] = [
           await import('@/views/organizations/OrganizationDetailView.vue')
       }
     ]
+  },
+  // technical pages
+  {
+    path: '/404',
+    name: 'not_found',
+    component: async () => await import('@/views/NotFoundView.vue')
   }
 ].filter((route) => {
   if (route.name === undefined) return true

--- a/src/services/api/DatagouvfrAPI.ts
+++ b/src/services/api/DatagouvfrAPI.ts
@@ -61,7 +61,8 @@ export default class DatagouvfrAPI {
     params,
     headers,
     toasted = true,
-    authenticated = false
+    authenticated = false,
+    redirectNotFound = false
   }: GetParams): Promise<AxiosResponseData> {
     const url = `${this.url()}/${entityId}/`
     return await this.request({
@@ -70,7 +71,8 @@ export default class DatagouvfrAPI {
       params,
       headers,
       toasted,
-      authenticated
+      authenticated,
+      redirectNotFound
     })
   }
 

--- a/src/store/OrganizationStore.ts
+++ b/src/store/OrganizationStore.ts
@@ -2,6 +2,7 @@ import type { Organization } from '@etalab/data.gouv.fr-components'
 import { defineStore } from 'pinia'
 
 import config from '@/config'
+import type { BaseParams } from '@/model/api'
 
 import OrganizationsAPI from '../services/api/resources/OrganizationsAPI'
 
@@ -121,10 +122,10 @@ export const useOrganizationStore = defineStore('organization', {
     /**
      * Async function to trigger API fetch of an org if not known in store
      */
-    async load(orgId: string, page: number) {
+    async load(orgId: string, page: number, params?: BaseParams) {
       const existing = this.get(orgId)
       if (existing !== undefined) return existing
-      const org = await orgApi.get({ entityId: orgId })
+      const org = await orgApi.get({ entityId: orgId, ...params })
       return this.add(org, page)
     }
   }

--- a/src/views/NotFoundView.vue
+++ b/src/views/NotFoundView.vue
@@ -1,0 +1,3 @@
+<template>
+  <div class="fr-container fr-mt-4w">Page non trouvée.</div>
+</template>

--- a/src/views/NotFoundView.vue
+++ b/src/views/NotFoundView.vue
@@ -1,3 +1,14 @@
+<script setup>
+import { useRoute, useRouter } from 'vue-router'
+
+const route = useRoute()
+const router = useRouter()
+
+if (route.name !== 'not_found') {
+  router.push({ name: 'not_found' })
+}
+</script>
+
 <template>
   <div class="fr-container fr-mt-4w">Page non trouvée.</div>
 </template>

--- a/src/views/datasets/DatasetDetailView.vue
+++ b/src/views/datasets/DatasetDetailView.vue
@@ -174,7 +174,7 @@ watch(
 )
 
 onMounted(() => {
-  datasetStore.load(datasetId)
+  datasetStore.load(datasetId, { toasted: false, redirectNotFound: true })
 })
 </script>
 

--- a/src/views/organizations/OrganizationDetailView.vue
+++ b/src/views/organizations/OrganizationDetailView.vue
@@ -1,34 +1,36 @@
-<script setup>
-import { computed, onMounted, ref, watchEffect } from 'vue'
+<script setup lang="ts">
+import type { DatasetV2 } from '@etalab/data.gouv.fr-components'
+import { computed, onMounted, ref, watchEffect, type Ref } from 'vue'
 import { useLoading } from 'vue-loading-overlay'
-import { useRoute } from 'vue-router'
+
+import { useRouteParamsAsString } from '@/router/utils'
 
 import Tile from '../../components/Tile.vue'
 import { useDatasetStore } from '../../store/DatasetStore'
 import { useOrganizationStore } from '../../store/OrganizationStore'
 import { descriptionFromMarkdown } from '../../utils'
 
-const route = useRoute()
+const route = useRouteParamsAsString()
 const organizationId = route.params.oid
 
 const orgStore = useOrganizationStore()
 const datasetStore = useDatasetStore()
 
-const org = computed(() => orgStore.get(organizationId) || {})
+const org = computed(() => orgStore.get(organizationId))
 
 const links = computed(() => [
   { to: '/', text: 'Accueil' },
   { to: '/organizations', text: 'Organisations' },
-  { text: org.value.name }
+  { text: org.value?.name }
 ])
 
 const currentPage = ref(1)
-const pages = ref([])
-const datasets = ref({})
+const pages: Ref<object[]> = ref([])
+const datasets: Ref<DatasetV2[] | undefined> = ref(undefined)
 const selectedSort = ref('-created')
 
 onMounted(() => {
-  orgStore.load(organizationId)
+  orgStore.load(organizationId, -1, { toasted: false, redirectNotFound: true })
 })
 
 const sorts = [
@@ -36,7 +38,7 @@ const sorts = [
   { value: 'title', text: 'Titre' }
 ]
 
-function doSort(sort) {
+function doSort(sort: string) {
   currentPage.value = 1
   selectedSort.value = sort
 }
@@ -45,14 +47,14 @@ const description = computed(() => descriptionFromMarkdown(org))
 
 // we need the technical id to fetch the datasets and thus pagination
 watchEffect(() => {
-  if (!org.value.id) return
+  if (org.value?.id === undefined) return
   const loader = useLoading().show()
   datasetStore
     .loadDatasetsForOrg(org.value.id, currentPage.value, selectedSort.value)
-    .then((_datasets) => {
-      datasets.value = _datasets
-      if (!pages.value.length) {
-        pages.value = datasetStore.getDatasetsPaginationForOrg(org.value.id)
+    .then((res) => {
+      datasets.value = res?.data
+      if (!pages.value.length && org.value?.id) {
+        pages.value = datasetStore.getDatasetsPaginationForOrg(org.value?.id)
       }
     })
     .finally(() => loader.hide())
@@ -64,7 +66,7 @@ watchEffect(() => {
     <DsfrBreadcrumb class="fr-mb-1v" :links="links" />
   </div>
   <div class="fr-container fr-mb-4w">
-    <h1 class="fr-mb-2v">{{ org.name }}</h1>
+    <h1 class="fr-mb-2v">{{ org?.name }}</h1>
     <!-- eslint-disable-next-line vue/no-v-html -->
     <div v-html="description"></div>
 
@@ -88,16 +90,16 @@ watchEffect(() => {
     </div>
 
     <h2 class="fr-mt-2w">Jeux de données</h2>
-    <div v-if="!datasets?.data?.length">
+    <div v-if="!datasets?.length">
       Pas de jeu de données pour cette organisation.
     </div>
     <ul v-else class="fr-grid-row fr-grid-row--gutters es__tiles__list">
-      <li v-for="d in datasets.data" :key="d.id" class="fr-col-12 fr-col-lg-4">
+      <li v-for="d in datasets" :key="d.id" class="fr-col-12 fr-col-lg-4">
         <Tile
           :link="`/datasets/${d.slug}`"
           :title="d.title"
           :description="d.description"
-          :img="d.organization.logo"
+          :img="d.organization?.logo"
         />
       </li>
     </ul>
@@ -106,6 +108,6 @@ watchEffect(() => {
     v-if="pages.length"
     :current-page="currentPage - 1"
     :pages="pages"
-    @update:current-page="(p) => (currentPage = p + 1)"
+    @update:current-page="(p: number) => (currentPage = p + 1)"
   />
 </template>


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/215

Ajoute une page "Page non trouvée" vers laquelle on est redirigé quand on accède à :
- un bouquet qui n'existe pas
- une organisation qui n'existe pas
- un bouquet qui n'existe pas
- une route qui n'existe pas

Il ne s'agit pas d'une "vraie" page 404 car le code de retour sera 200, à cause de l'architecture SPA. Il faudrait faire quelque chose d'un peu compliqué pour faire mieux : rediriger vers une page serveur qui retourne une 404. Vu la complexité et le peu d'intérêt (la redirection serait faite en JS, donc un curl ou autre n'y verrait que du feu), j'ai choisi de rester (relativement) simple.