### PR TITLE
feat(bouquet): enable discussion notification

### DIFF
--- a/src/components/DiscussionsList.vue
+++ b/src/components/DiscussionsList.vue
@@ -38,6 +38,14 @@ const props = defineProps({
   subjectClass: {
     type: String as () => SubjectClass,
     default: 'Dataset'
+  },
+  externalUrl: {
+    type: String,
+    default: undefined
+  },
+  modelName: {
+    type: String,
+    default: undefined
   }
 })
 
@@ -86,6 +94,15 @@ const triggerLogin = () => {
 }
 
 const createDiscussion = () => {
+  if (props.externalUrl !== undefined && props.modelName !== undefined) {
+    discussionForm.value.extras = {
+      ...discussionForm.value.extras,
+      notification: {
+        external_url: props.externalUrl,
+        model_name: props.modelName
+      }
+    }
+  }
   discussionStore.createDiscussion(discussionForm.value).then((d) => {
     if (d !== undefined) {
       discussionForm.value.title = ''

--- a/src/components/discussions/DiscussionDetails.vue
+++ b/src/components/discussions/DiscussionDetails.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { ref, type Ref } from 'vue'
+
+import config from '@/config'
+import type {
+  Discussion,
+  Post,
+  PostForm,
+  DiscussionId
+} from '@/model/discussion'
+import { useDiscussionStore } from '@/store/DiscussionStore'
+import { useUserStore } from '@/store/UserStore'
+import { formatDate } from '@/utils'
+
+const props = defineProps({
+  discussion: {
+    type: Object as () => Discussion,
+    required: true
+  },
+  subjectId: {
+    type: String,
+    required: true
+  },
+  allowDiscussionComment: {
+    type: Boolean
+  }
+})
+
+const emits = defineEmits(['triggerLogin'])
+
+const discussionStore = useDiscussionStore()
+const userStore = useUserStore()
+const { loggedIn } = storeToRefs(userStore)
+
+const postFormId: Ref<DiscussionId | null> = ref(null)
+const postForm: Ref<PostForm> = ref({ comment: '' })
+
+const getUserAvatar = (post: Post) => {
+  if (post.posted_by.avatar_thumbnail) {
+    return post.posted_by.avatar_thumbnail
+  }
+  return `${config.datagouvfr.base_url}/api/1/avatars/${post.posted_by.id}/20`
+}
+
+const createPost = (discussionId: DiscussionId) => {
+  discussionStore
+    .createPost(props.subjectId, discussionId, postForm.value)
+    .then((d) => {
+      if (d !== undefined) {
+        postForm.value.comment = ''
+        postFormId.value = null
+      }
+    })
+}
+</script>
+
+<template>
+  <div class="discussion-title">{{ discussion.title }}</div>
+  <div class="discussion-subtitle">
+    <div class="avatar fr-mr-1v">
+      <img
+        style="border-radius: 50%"
+        :src="getUserAvatar(discussion.discussion[0])"
+        width="20"
+      />
+    </div>
+    <div class="user-name fr-mb-md-1v">
+      {{ discussion.discussion[0].posted_by.first_name }}
+      {{ discussion.discussion[0].posted_by.last_name }}
+    </div>
+    <div class="date-comment">
+      - le {{ formatDate(discussion.discussion[0].posted_on) }}
+    </div>
+  </div>
+  <div class="comment comment-text">
+    {{ discussion.discussion[0].content }}
+  </div>
+  <template v-if="discussion.discussion.length > 1">
+    <div
+      v-for="comment in discussion.discussion.slice(1)"
+      :key="comment.content"
+      class="fr-mt-md-3v fr-pl-3v"
+    >
+      <div class="secondary-comment-content comment-text">
+        {{ comment.content }}
+      </div>
+      <div class="discussion-subtitle fr-mb-2w">
+        <div class="avatar fr-mr-1v">
+          <img
+            style="border-radius: 50%"
+            :src="getUserAvatar(comment)"
+            width="20"
+          />
+        </div>
+        <div class="user-name fr-mb-md-1v">
+          {{ comment.posted_by.first_name }}
+          {{ comment.posted_by.last_name }}
+        </div>
+        <div class="comment">- le {{ formatDate(comment.posted_on) }}</div>
+      </div>
+    </div>
+  </template>
+  <div v-if="allowDiscussionComment">
+    <button
+      v-if="postFormId !== discussion.id && loggedIn"
+      type="button"
+      class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-grey-500 fr-icon-chat-3-line fr-btn--icon-left"
+      @click.stop.prevent="
+        () => {
+          postForm.comment = ''
+          postFormId = discussion.id
+        }
+      "
+    >
+      Répondre
+    </button>
+    <button
+      v-if="!loggedIn"
+      type="button"
+      class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-grey-500 fr-icon-account-line fr-btn--icon-left"
+      @click.stop.prevent="emits('triggerLogin')"
+    >
+      Connectez-vous pour répondre
+    </button>
+    <form
+      v-if="postFormId === discussion.id"
+      @submit.stop.prevent="createPost(discussion.id)"
+    >
+      <div class="fr-input-group">
+        <label class="fr-label" for="discussion-message"> Commentaire * </label>
+        <textarea
+          id="discussion-message"
+          v-model="postForm.comment"
+          required
+          class="fr-input"
+          name="message"
+        ></textarea>
+      </div>
+      <div class="text-align-right">
+        <button
+          type="button"
+          class="fr-btn fr-btn--secondary fr-mr-1w"
+          @click.stop.prevent="postFormId = null"
+        >
+          Annuler
+        </button>
+        <button type="submit" class="fr-btn">Soumettre</button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.discussion-title {
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 5px;
+}
+
+.discussion-subtitle {
+  display: flex;
+}
+
+.user-name {
+  color: #3557a2;
+  font-size: 14px;
+}
+
+.avatar {
+  display: flex;
+  align-items: center;
+}
+
+.comment-date {
+  color: #777777;
+  font-style: italic;
+  font-size: 14px;
+}
+
+.comment {
+  font-size: 14px;
+}
+
+.secondary-comment-content {
+  font-size: 14px;
+  border-left: 2px solid #dddddd;
+  padding-left: 10px;
+  margin-bottom: 10px;
+}
+
+.comment-text {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+</style>

--- a/src/components/discussions/DiscussionFocus.vue
+++ b/src/components/discussions/DiscussionFocus.vue
@@ -4,6 +4,7 @@ import { useRouter, useRoute } from 'vue-router'
 
 import config from '@/config'
 import type { Discussion, SubjectClass } from '@/model/discussion'
+import { SubjectClassLabels } from '@/model/discussion'
 import { useDiscussionStore } from '@/store/DiscussionStore'
 
 import DiscussionDetails from './DiscussionDetails.vue'
@@ -63,7 +64,8 @@ onMounted(() => {
     @click.stop.prevent="seeAll"
   >
     <span class="text-decoration-underline"
-      >Voir toutes les discussions sur ce jeu de données</span
+      >Voir toutes les discussions sur ce
+      {{ SubjectClassLabels[props.subjectClass] }}</span
     >
   </button>
 </template>

--- a/src/components/discussions/DiscussionFocus.vue
+++ b/src/components/discussions/DiscussionFocus.vue
@@ -33,7 +33,7 @@ const allowDiscussionCreation = computed(() => {
   return config.website.discussions[props.subjectClass.toLowerCase()].create
 })
 
-const onNoticeClose = () => {
+const seeAll = () => {
   router.push({ path: route.path, hash: '' })
 }
 
@@ -46,11 +46,11 @@ onMounted(() => {
 
 <template>
   <DsfrNotice
-    class="fr-mb-2w"
+    class="fr-mb-9v"
     type="info"
     title="Vous consultez une discussion spécifique sur ce jeu de données."
     :closeable="true"
-    @close="onNoticeClose"
+    @close="seeAll"
   />
   <DiscussionDetails
     v-if="discussion"
@@ -58,4 +58,12 @@ onMounted(() => {
     :subject-id="subject.id"
     :allow-discussion-comment="allowDiscussionCreation"
   />
+  <button
+    class="nav-link nav-link--no-icon text-decoration-none fr-link fr-mt-9v fr-link--icon-left fr-icon-arrow-right-s-line"
+    @click.stop.prevent="seeAll"
+  >
+    <span class="text-decoration-underline"
+      >Voir toutes les discussions sur ce jeu de données</span
+    >
+  </button>
 </template>

--- a/src/components/discussions/DiscussionFocus.vue
+++ b/src/components/discussions/DiscussionFocus.vue
@@ -5,6 +5,7 @@ import { useRouter, useRoute } from 'vue-router'
 import config from '@/config'
 import type { Discussion, SubjectClass } from '@/model/discussion'
 import { SubjectClassLabels } from '@/model/discussion'
+import LocalStorageService from '@/services/LocalStorageService'
 import { useDiscussionStore } from '@/store/DiscussionStore'
 
 import DiscussionDetails from './DiscussionDetails.vue'
@@ -38,6 +39,11 @@ const seeAll = () => {
   router.push({ path: route.path, hash: '' })
 }
 
+const triggerLogin = () => {
+  LocalStorageService.setItem('lastRoute', route)
+  router.push({ name: 'login' })
+}
+
 onMounted(() => {
   store.getDiscussion(props.discussionId).then((data) => {
     discussion.value = data
@@ -58,6 +64,7 @@ onMounted(() => {
     :discussion="discussion"
     :subject-id="subject.id"
     :allow-discussion-comment="allowDiscussionCreation"
+    @trigger-login="triggerLogin"
   />
   <button
     class="nav-link nav-link--no-icon text-decoration-none fr-link fr-mt-9v fr-link--icon-left fr-icon-arrow-right-s-line"

--- a/src/components/discussions/DiscussionFocus.vue
+++ b/src/components/discussions/DiscussionFocus.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { onMounted, ref, computed, type Ref } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+
+import config from '@/config'
+import type { Discussion, SubjectClass } from '@/model/discussion'
+import { useDiscussionStore } from '@/store/DiscussionStore'
+
+import DiscussionDetails from './DiscussionDetails.vue'
+
+const props = defineProps({
+  subject: {
+    type: Object,
+    required: true
+  },
+  discussionId: {
+    type: String,
+    required: true
+  },
+  subjectClass: {
+    type: String as () => SubjectClass,
+    default: 'Dataset'
+  }
+})
+
+const store = useDiscussionStore()
+const router = useRouter()
+const route = useRoute()
+
+const discussion: Ref<Discussion | undefined> = ref()
+
+const allowDiscussionCreation = computed(() => {
+  return config.website.discussions[props.subjectClass.toLowerCase()].create
+})
+
+const onNoticeClose = () => {
+  router.push({ path: route.path, hash: '' })
+}
+
+onMounted(() => {
+  store.getDiscussion(props.discussionId).then((data) => {
+    discussion.value = data
+  })
+})
+</script>
+
+<template>
+  <DsfrNotice
+    class="fr-mb-2w"
+    type="info"
+    title="Vous consultez une discussion spécifique sur ce jeu de données."
+    :closeable="true"
+    @close="onNoticeClose"
+  />
+  <DiscussionDetails
+    v-if="discussion"
+    :discussion="discussion"
+    :subject-id="subject.id"
+    :allow-discussion-comment="allowDiscussionCreation"
+  />
+</template>

--- a/src/components/discussions/DiscussionsList.vue
+++ b/src/components/discussions/DiscussionsList.vue
@@ -4,20 +4,17 @@ import type { ComputedRef, Ref } from 'vue'
 import { ref, watchEffect, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
-import LocalStorageService from '@/services/LocalStorageService'
-
-import config from '../config'
+import config from '@/config'
 import type {
   DiscussionResponse,
   DiscussionForm,
-  SubjectClass,
-  PostForm,
-  DiscussionId,
-  Post
-} from '../model/discussion'
-import { useDiscussionStore } from '../store/DiscussionStore'
-import { useUserStore } from '../store/UserStore'
-import { formatDate } from '../utils'
+  SubjectClass
+} from '@/model/discussion'
+import LocalStorageService from '@/services/LocalStorageService'
+import { useDiscussionStore } from '@/store/DiscussionStore'
+import { useUserStore } from '@/store/UserStore'
+
+import DiscussionDetails from './DiscussionDetails.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -28,7 +25,6 @@ const userStore = useUserStore()
 const { loggedIn } = storeToRefs(userStore)
 const currentPage: Ref<number> = ref(1)
 const showDiscussionForm: Ref<boolean> = ref(false)
-const postFormId: Ref<DiscussionId | null> = ref(null)
 
 const props = defineProps({
   subject: {
@@ -63,8 +59,6 @@ const discussionForm: Ref<DiscussionForm> = ref({
   }
 })
 
-const postForm: Ref<PostForm> = ref({ comment: '' })
-
 const discussions: ComputedRef<DiscussionResponse | undefined> = computed(
   () => {
     return discussionStore.getDiscussionsForSubject(
@@ -80,13 +74,6 @@ const pages: ComputedRef<object[]> = computed(() => {
 const allowDiscussionCreation = computed(() => {
   return config.website.discussions[props.subjectClass.toLowerCase()].create
 })
-
-const getUserAvatar = (post: Post) => {
-  if (post.posted_by.avatar_thumbnail) {
-    return post.posted_by.avatar_thumbnail
-  }
-  return `${config.datagouvfr.base_url}/api/1/avatars/${post.posted_by.id}/20`
-}
 
 const triggerLogin = () => {
   LocalStorageService.setItem('lastRoute', route)
@@ -111,17 +98,6 @@ const createDiscussion = () => {
       currentPage.value = 1
     }
   })
-}
-
-const createPost = (discussionId: DiscussionId) => {
-  discussionStore
-    .createPost(props.subject.id, discussionId, postForm.value)
-    .then((d) => {
-      if (d !== undefined) {
-        postForm.value.comment = ''
-        postFormId.value = null
-      }
-    })
 }
 
 watchEffect(() => {
@@ -214,101 +190,12 @@ watchEffect(() => {
       :key="discussion.id"
       class="fr-mb-6w"
     >
-      <div class="discussion-title">{{ discussion.title }}</div>
-      <div class="discussion-subtitle">
-        <div class="avatar fr-mr-1v">
-          <img
-            style="border-radius: 50%"
-            :src="getUserAvatar(discussion.discussion[0])"
-            width="20"
-          />
-        </div>
-        <div class="user-name fr-mb-md-1v">
-          {{ discussion.discussion[0].posted_by.first_name }}
-          {{ discussion.discussion[0].posted_by.last_name }}
-        </div>
-        <div class="date-comment">
-          - le {{ formatDate(discussion.discussion[0].posted_on) }}
-        </div>
-      </div>
-      <div class="comment comment-text">
-        {{ discussion.discussion[0].content }}
-      </div>
-      <template v-if="discussion.discussion.length > 1">
-        <div
-          v-for="comment in discussion.discussion.slice(1)"
-          :key="comment.content"
-          class="fr-mt-md-3v fr-pl-3v"
-        >
-          <div class="secondary-comment-content comment-text">
-            {{ comment.content }}
-          </div>
-          <div class="discussion-subtitle fr-mb-2w">
-            <div class="avatar fr-mr-1v">
-              <img
-                style="border-radius: 50%"
-                :src="getUserAvatar(comment)"
-                width="20"
-              />
-            </div>
-            <div class="user-name fr-mb-md-1v">
-              {{ comment.posted_by.first_name }}
-              {{ comment.posted_by.last_name }}
-            </div>
-            <div class="comment">- le {{ formatDate(comment.posted_on) }}</div>
-          </div>
-        </div>
-      </template>
-      <div v-if="allowDiscussionCreation">
-        <button
-          v-if="postFormId !== discussion.id && loggedIn"
-          type="button"
-          class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-grey-500 fr-icon-chat-3-line fr-btn--icon-left"
-          @click.stop.prevent="
-            () => {
-              postForm.comment = ''
-              postFormId = discussion.id
-            }
-          "
-        >
-          Répondre
-        </button>
-        <button
-          v-if="!loggedIn"
-          type="button"
-          class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-grey-500 fr-icon-account-line fr-btn--icon-left"
-          @click.stop.prevent="triggerLogin()"
-        >
-          Connectez-vous pour répondre
-        </button>
-        <form
-          v-if="postFormId === discussion.id"
-          @submit.stop.prevent="createPost(discussion.id)"
-        >
-          <div class="fr-input-group">
-            <label class="fr-label" for="discussion-message">
-              Commentaire *
-            </label>
-            <textarea
-              id="discussion-message"
-              v-model="postForm.comment"
-              required
-              class="fr-input"
-              name="message"
-            ></textarea>
-          </div>
-          <div class="text-align-right">
-            <button
-              type="button"
-              class="fr-btn fr-btn--secondary fr-mr-1w"
-              @click.stop.prevent="postFormId = null"
-            >
-              Annuler
-            </button>
-            <button type="submit" class="fr-btn">Soumettre</button>
-          </div>
-        </form>
-      </div>
+      <DiscussionDetails
+        :discussion="discussion"
+        :subject-id="subject.id"
+        :allow-discussion-comment="allowDiscussionCreation"
+        @trigger-login="triggerLogin"
+      />
     </div>
     <div v-if="pages?.length > 1" class="fr-container">
       <DsfrPagination
@@ -319,47 +206,3 @@ watchEffect(() => {
     </div>
   </div>
 </template>
-
-<style scoped lang="scss">
-.discussion-title {
-  font-size: 18px;
-  font-weight: bold;
-  margin-bottom: 5px;
-}
-
-.discussion-subtitle {
-  display: flex;
-}
-
-.user-name {
-  color: #3557a2;
-  font-size: 14px;
-}
-
-.avatar {
-  display: flex;
-  align-items: center;
-}
-
-.comment-date {
-  color: #777777;
-  font-style: italic;
-  font-size: 14px;
-}
-
-.comment {
-  font-size: 14px;
-}
-
-.secondary-comment-content {
-  font-size: 14px;
-  border-left: 2px solid #dddddd;
-  padding-left: 10px;
-  margin-bottom: 10px;
-}
-
-.comment-text {
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-}
-</style>

--- a/src/components/discussions/DiscussionsList.vue
+++ b/src/components/discussions/DiscussionsList.vue
@@ -10,6 +10,7 @@ import type {
   DiscussionForm,
   SubjectClass
 } from '@/model/discussion'
+import { SubjectClassLabels } from '@/model/discussion'
 import LocalStorageService from '@/services/LocalStorageService'
 import { useDiscussionStore } from '@/store/DiscussionStore'
 import { useUserStore } from '@/store/UserStore'
@@ -44,11 +45,6 @@ const props = defineProps({
     default: undefined
   }
 })
-
-const subjectClassLabels = {
-  Dataset: 'jeu de données',
-  Topic: 'bouquet'
-}
 
 const discussionForm: Ref<DiscussionForm> = ref({
   title: '',
@@ -181,7 +177,7 @@ watchEffect(() => {
       src="/blank_state/discussion.svg"
     />
     <p class="fr-h6 fr-mt-2w fr-mb-5v text-center">
-      Pas de discussion pour ce {{ subjectClassLabels[props.subjectClass] }}.
+      Pas de discussion pour ce {{ SubjectClassLabels[props.subjectClass] }}.
     </p>
   </div>
   <div v-else>

--- a/src/custom/ecospheres/components/forms/dataset/DatasetPropertiesFields.vue
+++ b/src/custom/ecospheres/components/forms/dataset/DatasetPropertiesFields.vue
@@ -96,7 +96,6 @@ watch(
 watch(
   () => datasetProperties.value.availability,
   (availability) => {
-    console.log('watch', availability)
     if (availability !== Availability.LOCAL_AVAILABLE) {
       selectedDataset.value = undefined
       datasetProperties.value.uri = null

--- a/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
+++ b/src/custom/ecospheres/views/bouquets/BouquetDetailView.vue
@@ -52,6 +52,7 @@ const canEdit = computed(() => {
   return useUserStore().hasEditPermissions(topic.value)
 })
 const canClone = computed(() => useUserStore().isLoggedIn)
+const bouquetUrl = computed(() => window.location.href)
 const { theme, subtheme, datasetsProperties, clonedFrom } = useExtras(topic)
 const breadcrumbLinks = useBreadcrumbLinksForTopic(theme, subtheme, topic)
 
@@ -288,6 +289,8 @@ watch(
         <DiscussionsList
           v-if="showDiscussions && topic"
           :subject="topic"
+          :external-url="bouquetUrl"
+          model-name="bouquet"
           subject-class="Topic"
         />
       </DsfrTabContent>

--- a/src/model/discussion.ts
+++ b/src/model/discussion.ts
@@ -15,6 +15,13 @@ interface DiscussionForm {
   title: string
   comment: string
   subject: Subject
+  extras?: {
+    notification: {
+      external_url: string
+      model_name: string
+    }
+    [key: string]: any
+  }
 }
 
 interface Post {

--- a/src/model/discussion.ts
+++ b/src/model/discussion.ts
@@ -41,6 +41,11 @@ interface Subject {
 
 type SubjectClass = 'Dataset' | 'Topic'
 
+enum SubjectClassLabels {
+  Dataset = 'jeu de données',
+  Topic = 'bouquet'
+}
+
 type SubjectId = string
 
 interface DiscussionResponse extends GenericResponse {
@@ -58,3 +63,5 @@ export type {
   PostForm,
   DiscussionId
 }
+
+export { SubjectClassLabels }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -147,7 +147,15 @@ const routerPromise = siteRoutesPromise.then((siteRoutes) => {
     history: createWebHistory(import.meta.env.BASE_URL),
     routes,
     scrollBehavior(to, from, savedPosition) {
-      if (to.hash !== '') {
+      // if only hash changes without target hash, do nothing
+      if (
+        to.path === from.path &&
+        JSON.stringify(to.query) === JSON.stringify(from.query) &&
+        to.hash === ''
+      )
+        return
+      // discussion scroll is handled in discussion components
+      if (to.hash !== '' && !to.hash.startsWith('#discussion-')) {
         return {
           el: to.hash
         }

--- a/src/services/api/resources/DiscussionsAPI.ts
+++ b/src/services/api/resources/DiscussionsAPI.ts
@@ -39,7 +39,8 @@ export default class DiscussionsAPI extends DatagouvfrAPI {
     return await this.request({
       url,
       method: 'post',
-      data: postForm
+      data: postForm,
+      authenticated: true
     })
   }
 }

--- a/src/store/DiscussionStore.ts
+++ b/src/store/DiscussionStore.ts
@@ -105,6 +105,12 @@ export const useDiscussionStore = defineStore('discussion', {
           title: `Page ${page}`
         }
       })
+    },
+    /**
+     * Get a single discussion from API
+     */
+    async getDiscussion(discussionId: string): Promise<Discussion> {
+      return await discussionsAPI.get({ entityId: discussionId })
     }
   }
 })

--- a/src/views/datasets/DatasetDetailView.vue
+++ b/src/views/datasets/DatasetDetailView.vue
@@ -12,20 +12,19 @@ import {
 import { computed, onMounted, ref, watch } from 'vue'
 import { useLoading } from 'vue-loading-overlay'
 
+import ChartData from '@/components/ChartData.vue'
 import GenericContainer from '@/components/GenericContainer.vue'
+import ReusesList from '@/components/ReusesList.vue'
+import ExtendedInformationPanel from '@/components/datasets/ExtendedInformationPanel.vue'
+import DiscussionsList from '@/components/discussions/DiscussionsList.vue'
 import config from '@/config'
 import DatasetAddToBouquetModal from '@/custom/ecospheres/components/datasets/DatasetAddToBouquetModal.vue'
-
-import ChartData from '../../components/ChartData.vue'
-import DiscussionsList from '../../components/DiscussionsList.vue'
-import ReusesList from '../../components/ReusesList.vue'
-import ExtendedInformationPanel from '../../components/datasets/ExtendedInformationPanel.vue'
-import type { ResourceDataWithQuery } from '../../model/resource'
-import { useRouteParamsAsString } from '../../router/utils'
-import { useDatasetStore } from '../../store/DatasetStore'
-import { useResourceStore } from '../../store/ResourceStore'
-import { useUserStore } from '../../store/UserStore'
-import { descriptionFromMarkdown, formatDate } from '../../utils'
+import type { ResourceDataWithQuery } from '@/model/resource'
+import { useRouteParamsAsString } from '@/router/utils'
+import { useDatasetStore } from '@/store/DatasetStore'
+import { useResourceStore } from '@/store/ResourceStore'
+import { useUserStore } from '@/store/UserStore'
+import { descriptionFromMarkdown, formatDate } from '@/utils'
 
 const route = useRouteParamsAsString()
 const datasetId = route.params.did


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/263
Related https://github.com/opendatateam/udata/pull/3072

Introduit la notification d'une discussion sur un bouquet via data.gouv.fr.

Pour l'envoi de notification, le payload de la discussion est augmenté de `external_url` qui pointe vers l'URL courante du bouquet et de `model_name` qui vaut "bouquet". data.gouv.fr utilise ces informations dans https://github.com/opendatateam/udata/pull/3072 pour construire l'email de notification.

Afin d'afficher une discussion au clic sur le lien dans la notification, on utilise une technique similaire à celle de data.gouv.fr (voir screenshots plus bas) : un composant `DiscussionFocus` est monté à la place de `DiscussionsList`. Il affiche un "zoom" sur cette discussion, ce qui permet de s'affranchir de la pagination. Il est possible de revenir depuis ce composant à la liste des discussions. On scroll aussi automatiquement sur la discussion "zoomée", ce qui entraine malheureusement pas mal de tweaks divers (NB: on ne peut pas scroller directement sur `DiscussionFocus`, les tabs sont perturbés).

## Vue sur une discussion (focus)

<img width="1013" alt="Capture d’écran 2024-07-02 à 09 10 12" src="https://github.com/opendatateam/udata-front-kit/assets/119625/8edf66f4-866b-4759-8903-65397b20fa6d">
<img width="1232" alt="Capture d’écran 2024-07-02 à 09 16 44" src="https://github.com/opendatateam/udata-front-kit/assets/119625/cf8bc9c8-66a3-4a86-98f7-9fe5bf53f171">

## Mails de notification (local en)

<img width="791" alt="Capture d’écran 2024-07-01 à 10 23 32" src="https://github.com/opendatateam/udata-front-kit/assets/119625/8b5acec1-3333-4a5e-b668-073169a93a5f">
<img width="859" alt="Capture d’écran 2024-07-01 à 09 20 25" src="https://github.com/opendatateam/udata-front-kit/assets/119625/36545397-3727-491d-a9df-b3697f93cc2c">
<img width="913" alt="Capture d’écran 2024-07-01 à 08 59 05" src="https://github.com/opendatateam/udata-front-kit/assets/119625/602bd018-eea0-45f5-aa4a-795842a4f5c3">
