### PR TITLE
Feat/embed dashboard superset

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -81,6 +81,8 @@ website:
       to: /datasets
     - text: Bouquets
       to: /bouquets
+    - text: Tableau de bord
+      to: /dashboard
     - text: A propos
       to: /about
   router:
@@ -99,6 +101,10 @@ website:
         id: 'terms'
         route: '/terms'
         url: '/ecospheres/pages/terms.md'
+      - title: Tableau de bord
+        id: dashboard
+        url: '/ecospheres/pages/dashboard.md'
+        route: /dashboard
   home_buttons:
   topic_charts:
     display: false

--- a/public/ecospheres/pages/dashboard.md
+++ b/public/ecospheres/pages/dashboard.md
@@ -1,0 +1,7 @@
+<iframe
+    src="https://dashboard.ecologie.data.gouv.fr/public/dashboard/53f071cf-e6e6-4cc1-a3f7-206232851311"
+    frameborder="0"
+    width="100%"
+    height="1200"
+    allowtransparency
+></iframe>

--- a/public/ecospheres/pages/dashboard.md
+++ b/public/ecospheres/pages/dashboard.md
@@ -1,5 +1,5 @@
 <iframe
-    src="http://51.158.105.210:8088/superset/dashboard/12/?standalone=1"
+    src="https://ecospheres-catalog-superset.app.france.sh/superset/dashboard/2/?standalone=1"
     frameborder="0"
     width="100%"
     height="1200"

--- a/public/ecospheres/pages/dashboard.md
+++ b/public/ecospheres/pages/dashboard.md
@@ -1,5 +1,5 @@
 <iframe
-    src="https://dashboard.ecologie.data.gouv.fr/public/dashboard/53f071cf-e6e6-4cc1-a3f7-206232851311"
+    src="http://51.158.105.210:8088/superset/dashboard/12/?standalone=1"
     frameborder="0"
     width="100%"
     height="1200"

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -25,9 +25,10 @@ export const descriptionFromMarkdown = (ref, attr = 'description') => {
  *
  * @param {string} value
  */
-export const fromMarkdown = (value) => {
+export const fromMarkdown = (value, safe = false) => {
   if (!value) return ''
   const parsed = marked.parse(value, markedOptions)
+  if (safe) return parsed
   return DOMPurify.sanitize(parsed)
 }
 

--- a/src/views/SimplePageView.vue
+++ b/src/views/SimplePageView.vue
@@ -35,6 +35,6 @@ watchEffect(async () => {
   </div>
   <GenericContainer>
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <div v-html="fromMarkdown(content)" />
+    <div v-html="fromMarkdown(content, true)" />
   </GenericContainer>
 </template>


### PR DESCRIPTION
POC embed dashboard superset

Il semble que la seule solution pour permettre l'embed en iframe soit de désactiver [Talisman](https://pypi.org/project/talisman/) dans Superset cf https://github.com/apache/superset/issues/24785. Les variables de configuration `HTTP_HEADERS` ou `OVERRIDE_HTTP_HEADERS` n'ont pas d'effet. Ce n'est pas idéal parce que toutes les fonctionnalités de protection de Talisman se retrouvent désactivés. Peut-être à surcharger dans le futur reverse proxy ?

<img width="1037" alt="Capture d’écran 2024-08-01 à 18 24 13" src="https://github.com/user-attachments/assets/71c19a33-68f4-4b15-92d5-ecde12ea3847">
