### PR TITLE
Affichage d'un lien vers la source externe d'un dataset

### DIFF
--- a/src/views/datasets/DatasetDetailView.vue
+++ b/src/views/datasets/DatasetDetailView.vue
@@ -7,6 +7,7 @@ import {
   ReadMore,
   Well,
   InformationPanel,
+  AppLink,
   type License
 } from '@datagouv/components'
 import { computed, onMounted, ref, watch } from 'vue'
@@ -200,7 +201,7 @@ onMounted(() => {
         >
           <div class="fr-col-auto">
             <div class="border fr-p-1-5v fr-mr-1-5v">
-              <img :src="dataset.organization.logo" height="32" />
+              <img :src="dataset.organization.logo" height="32" alt="" />
             </div>
           </div>
           <p class="fr-col fr-m-0">
@@ -210,6 +211,19 @@ onMounted(() => {
               />
             </a>
           </p>
+        </div>
+        <div v-if="dataset.harvest?.remote_url" class="fr-my-3v fr-text--sm">
+          <div class="bg-alt-blue-cumulus fr-p-3v fr-mb-1w">
+            <p class="fr-grid-row fr-grid-row--middle fr-my-0">
+              Ce jeu de données provient d'un portail externe.
+              <AppLink
+                :to="dataset.harvest.remote_url"
+                target="_blank"
+                rel="noopener nofollow"
+                >Voir la source originale.</AppLink
+              >
+            </p>
+          </div>
         </div>
         <h2 class="subtitle fr-mt-3v fr-mb-1v">Dernière mise à jour</h2>
         <p>{{ formatDate(dataset.last_update) }}</p>


### PR DESCRIPTION
Lorsqu'un dataset est moissoné depuis une source externe, un lien vers l'url est affiché comme dans data.gouv.
Utilisation du composant DSFR [AppLink](https://669123cd8a2c1ef63abe6805-twdpyxdyhx.chromatic.com/?path=/docs/components-applink--docs).

Y aurait-t-il une utilité à en faire un composant à part entière ?

Fix https://github.com/ecolabdata/ecospheres/issues/288