### PR TITLE
feat: Allow adding the same dataset multiple times to a bouquet.

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -22,8 +22,8 @@
   font-weight: 600;
   font-family: Spectral;
   font-style: italic;
-  src: url("./fonts/Spectral-Italic.woff2") format("woff2"),
-      url("./fonts/Spectral-Italic.woff") format("woff");
+  src: url('./fonts/Spectral-Italic.woff2') format('woff2'),
+    url('./fonts/Spectral-Italic.woff') format('woff');
 
   font-display: swap;
 }
@@ -110,4 +110,12 @@ textarea {
 
 .datagouv-components h1 {
   margin-bottom: 1.5rem;
+}
+
+/* FIXME */
+
+/* https://github.com/datagouv/udata-front/issues/499 */
+.fr-badge.fr-badge--info.fr-badge--info::before {
+  -webkit-mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
+  mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
 }

--- a/src/components/datasets/DatasetAddToBouquetModal.vue
+++ b/src/components/datasets/DatasetAddToBouquetModal.vue
@@ -43,7 +43,7 @@ const bouquetOptions = computed(() => {
     return {
       value: bouquet.id,
       text: bouquet.name,
-      disabled: isDatasetInBouquet(bouquet)
+      alreadySelected: isDatasetInBouquet(bouquet)
     }
   })
 })
@@ -81,6 +81,17 @@ const isDatasetInBouquet = (bouquet: Topic): boolean => {
     (datasetProps) => datasetProps.id === props.dataset.id
   )
 }
+const isAlreadySelected = computed(() => {
+  if (selectedBouquetId.value === null) {
+    return false
+  }
+  const selectedBouquet = topicStore.get(selectedBouquetId.value)
+  const datasetsProperties =
+    selectedBouquet?.extras[topicsExtrasKey].datasets_properties
+  return datasetsProperties?.some(
+    (datasetProps) => datasetProps.id === props.dataset.id
+  )
+})
 
 const submit = async () => {
   if (selectedBouquetId.value === null) {
@@ -140,10 +151,29 @@ onMounted(() => {
         />
       </template>
     </DsfrSelect>
-
+    <DsfrBadge
+      v-if="isAlreadySelected"
+      type="info"
+      label="Déjà utilisé dans ce bouquet"
+      small
+      ellipsis
+      class="dsfr-badge-info fr-mb-2w"
+    />
     <DatasetPropertiesTextFields
       v-if="topicsDatasetEditorialization"
       v-model:dataset-properties="datasetProperties"
     />
   </DsfrModal>
 </template>
+
+<style scoped>
+.fr-select-group:has(+ .dsfr-badge-info) {
+  margin-bottom: 0.5rem;
+}
+
+/* FIXME https://github.com/datagouv/udata-front/issues/499 */
+.dsfr-badge-info.dsfr-badge-info::before {
+  -webkit-mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
+  mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
+}
+</style>

--- a/src/components/datasets/DatasetAddToBouquetModal.vue
+++ b/src/components/datasets/DatasetAddToBouquetModal.vue
@@ -6,7 +6,7 @@ import { useLoading } from 'vue-loading-overlay'
 
 import Tooltip from '@/components/TooltipWrapper.vue'
 import DatasetPropertiesTextFields from '@/components/forms/dataset/DatasetPropertiesTextFields.vue'
-import { Availability, type DatasetProperties, type Topic } from '@/model/topic'
+import { Availability, type DatasetProperties } from '@/model/topic'
 import { useTopicStore } from '@/store/TopicStore'
 import { useTopicsConf } from '@/utils/config'
 
@@ -140,7 +140,7 @@ onMounted(() => {
         {{ capitalize(topicsName) }} à associer
         <span class="required">&nbsp;*</span>
         <Tooltip
-          :text="`Choisissez parmi les ${topicsName}s dont vous êtes l'auteur. Si un ${topicsName} apparait désactivé, c'est que le jeu de données y est déjà associé.`"
+          :text="`Choisissez parmi les ${topicsName}s dont vous êtes l'auteur.`"
         />
       </template>
     </DsfrSelect>

--- a/src/components/datasets/DatasetAddToBouquetModal.vue
+++ b/src/components/datasets/DatasetAddToBouquetModal.vue
@@ -42,8 +42,7 @@ const bouquetOptions = computed(() => {
   return bouquets.value.map((bouquet) => {
     return {
       value: bouquet.id,
-      text: bouquet.name,
-      alreadySelected: isDatasetInBouquet(bouquet)
+      text: bouquet.name
     }
   })
 })
@@ -75,13 +74,7 @@ const modalActions = computed(() => {
   ]
 })
 
-const isDatasetInBouquet = (bouquet: Topic): boolean => {
-  const datasetsProperties = bouquet.extras[topicsExtrasKey].datasets_properties
-  return datasetsProperties.some(
-    (datasetProps) => datasetProps.id === props.dataset.id
-  )
-}
-const isAlreadySelected = computed(() => {
+const isDatasetInBouquet = computed(() => {
   if (selectedBouquetId.value === null) {
     return false
   }
@@ -152,12 +145,12 @@ onMounted(() => {
       </template>
     </DsfrSelect>
     <DsfrBadge
-      v-if="isAlreadySelected"
+      v-if="isDatasetInBouquet"
       type="info"
       label="Déjà utilisé dans ce bouquet"
       small
       ellipsis
-      class="dsfr-badge-info fr-mb-2w"
+      class="fr-mb-2w"
     />
     <DatasetPropertiesTextFields
       v-if="topicsDatasetEditorialization"
@@ -167,13 +160,7 @@ onMounted(() => {
 </template>
 
 <style scoped>
-.fr-select-group:has(+ .dsfr-badge-info) {
+.fr-select-group:has(+ .fr-badge) {
   margin-bottom: 0.5rem;
-}
-
-/* FIXME https://github.com/datagouv/udata-front/issues/499 */
-.dsfr-badge-info.dsfr-badge-info::before {
-  -webkit-mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
-  mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
 }
 </style>

--- a/src/components/forms/dataset/DatasetCardForSelect.vue
+++ b/src/components/forms/dataset/DatasetCardForSelect.vue
@@ -59,7 +59,7 @@ const badgeClasse = computed(() => {
       label="Déjà utilisé dans ce bouquet"
       small
       ellipsis
-      :class="[badgeClasse, 'dsfr-badge-info']"
+      :class="badgeClasse"
     />
     <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
       <div class="fr-col-auto">
@@ -101,11 +101,6 @@ const badgeClasse = computed(() => {
 <style scoped>
 .card:has(.fr-badge.absolute) {
   padding-top: 1rem;
-}
-/* FIXME https://github.com/datagouv/udata-front/issues/499 */
-.dsfr-badge-info.dsfr-badge-info::before {
-  -webkit-mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
-  mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
 }
 h4 {
   font-size: 1rem;

--- a/src/components/forms/dataset/DatasetCardForSelect.vue
+++ b/src/components/forms/dataset/DatasetCardForSelect.vue
@@ -102,6 +102,7 @@ const badgeClasse = computed(() => {
 .card:has(.fr-badge.absolute) {
   padding-top: 1rem;
 }
+/* FIXME https://github.com/datagouv/udata-front/issues/499 */
 .dsfr-badge-info.dsfr-badge-info::before {
   -webkit-mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
   mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);

--- a/src/components/forms/dataset/DatasetCardForSelect.vue
+++ b/src/components/forms/dataset/DatasetCardForSelect.vue
@@ -13,6 +13,16 @@ const props = defineProps({
   dataset: {
     type: Object as () => DatasetV2,
     required: true
+  },
+  alreadySelected: {
+    type: Boolean,
+    required: false,
+    default: false
+  },
+  badgePosition: {
+    type: String as () => 'relative' | 'absolute' | 'sr-only',
+    required: false,
+    default: 'relative'
   }
 })
 
@@ -23,14 +33,38 @@ const thumbnail = computed(() => {
     return props.dataset.organization.logo_thumbnail
   return getOwnerAvatar(props.dataset)
 })
+
+const badgeClasse = computed(() => {
+  let classes: string = ''
+  switch (props.badgePosition) {
+    case 'relative':
+      classes = 'relative fr-mb-2v'
+      break
+    case 'absolute':
+      classes = 'absolute top-0 fr-mt-n4v'
+      break
+    case 'sr-only':
+      classes = 'fr-sr-only'
+      break
+  }
+  return classes
+})
 </script>
 
 <template>
-  <div>
+  <div class="card">
+    <DsfrBadge
+      v-if="alreadySelected"
+      type="info"
+      label="Déjà utilisé dans ce bouquet"
+      small
+      ellipsis
+      :class="[badgeClasse, 'dsfr-badge-info']"
+    />
     <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
       <div class="fr-col-auto">
         <div class="logo">
-          <img :src="thumbnail" width="60" height="60" />
+          <img :src="thumbnail" width="60" height="60" alt="" />
         </div>
       </div>
       <div class="fr-col">
@@ -64,7 +98,14 @@ const thumbnail = computed(() => {
   </div>
 </template>
 
-<style lang="scss" scoped>
+<style scoped>
+.card:has(.fr-badge.absolute) {
+  padding-top: 1rem;
+}
+.dsfr-badge-info.dsfr-badge-info::before {
+  -webkit-mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
+  mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
+}
 h4 {
   font-size: 1rem;
 }

--- a/src/components/forms/dataset/SelectDataset.vue
+++ b/src/components/forms/dataset/SelectDataset.vue
@@ -81,23 +81,28 @@ const clear = () => {
       ></div>
     </template>
     <template #singleLabel="slotProps">
-      <DsfrBadge
-        v-if="alreadySelected(slotProps.option.id)"
-        type="warning"
-        label="Déjà sélectionné"
-        small
-        class="dsfr-badge-warning"
-      />
-      <DatasetCardForSelect :dataset="slotProps.option" />
+      <div class="fr-pt-2w">
+        <DsfrBadge
+          v-if="alreadySelected(slotProps.option.id)"
+          type="info"
+          label="Déjà utilisé dans ce bouquet"
+          small
+          ellipsis
+          class="absolute top-0 fr-mt-n4v dsfr-badge-info"
+        />
+        <DatasetCardForSelect :dataset="slotProps.option" />
+      </div>
     </template>
     <template #option="slotProps">
       <DsfrBadge
         v-if="alreadySelected(slotProps.option.id)"
-        type="warning"
-        label="Déjà sélectionné"
+        type="info"
+        label="Déjà utilisé dans ce bouquet"
         small
-        class="dsfr-badge-warning"
+        ellipsis
+        class="relative top-0 fr-mt-n4v fr-mb-2v dsfr-badge-info"
       />
+      {{ slotProps.option.archived }}
       <DatasetCardForSelect :dataset="slotProps.option" />
     </template>
     <template #noOptions> Précisez ou élargissez votre recherche </template>

--- a/src/components/forms/dataset/SelectDataset.vue
+++ b/src/components/forms/dataset/SelectDataset.vue
@@ -81,29 +81,18 @@ const clear = () => {
       ></div>
     </template>
     <template #singleLabel="slotProps">
-      <div class="fr-pt-2w">
-        <DsfrBadge
-          v-if="alreadySelected(slotProps.option.id)"
-          type="info"
-          label="Déjà utilisé dans ce bouquet"
-          small
-          ellipsis
-          class="absolute top-0 fr-mt-n4v dsfr-badge-info"
-        />
-        <DatasetCardForSelect :dataset="slotProps.option" />
-      </div>
+      <DatasetCardForSelect
+        :dataset="slotProps.option"
+        :already-selected="alreadySelected(slotProps.option.id)"
+        badge-position="absolute"
+      />
     </template>
     <template #option="slotProps">
-      <DsfrBadge
-        v-if="alreadySelected(slotProps.option.id)"
-        type="info"
-        label="Déjà utilisé dans ce bouquet"
-        small
-        ellipsis
-        class="relative top-0 fr-mt-n4v fr-mb-2v dsfr-badge-info"
+      <DatasetCardForSelect
+        :dataset="slotProps.option"
+        :already-selected="alreadySelected(slotProps.option.id)"
+        badge-position="relative"
       />
-      {{ slotProps.option.archived }}
-      <DatasetCardForSelect :dataset="slotProps.option" />
     </template>
     <template #noOptions> Précisez ou élargissez votre recherche </template>
   </Multiselect>
@@ -112,10 +101,6 @@ const clear = () => {
 <style scoped>
 .multiselect {
   margin-top: 1rem;
-}
-.dsfr-badge-info.dsfr-badge-info::before {
-  -webkit-mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
-  mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
 }
 :deep(.multiselect__option::after) {
   clip: rect(0 0 0 0);

--- a/src/components/forms/dataset/SelectDataset.vue
+++ b/src/components/forms/dataset/SelectDataset.vue
@@ -105,9 +105,13 @@ const clear = () => {
 </template>
 
 <style scoped>
-/* specificity override fix for badge icon */
-.dsfr-badge-warning.dsfr-badge-warning::before {
-  -webkit-mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--warning-fill.svg);
-  mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--warning-fill.svg);
+:deep(.multiselect__option::after) {
+  padding: 0;
+  padding-top: 0.25rem;
+  position: relative;
+  display: block;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  background: none;
 }
 </style>

--- a/src/components/forms/dataset/SelectDataset.vue
+++ b/src/components/forms/dataset/SelectDataset.vue
@@ -43,7 +43,7 @@ const search = debounce(async (query: string) => {
     await new SearchAPI().search(query, null, 1, {
       page_size: 10
     })
-  ).data.filter((dataset) => !alreadySelected(dataset.id))
+  ).data
   options.value = datasets
   isLoading.value = false
 }, 400)
@@ -69,7 +69,6 @@ const clear = () => {
     :loading="isLoading"
     :clear-on-select="true"
     :close-on-select="true"
-    :max-height="600"
     :show-no-results="false"
     :hide-selected="true"
     @search-change="search"
@@ -82,11 +81,33 @@ const clear = () => {
       ></div>
     </template>
     <template #singleLabel="slotProps">
+      <DsfrBadge
+        v-if="alreadySelected(slotProps.option.id)"
+        type="warning"
+        label="Déjà sélectionné"
+        small
+        class="dsfr-badge-warning"
+      />
       <DatasetCardForSelect :dataset="slotProps.option" />
     </template>
     <template #option="slotProps">
+      <DsfrBadge
+        v-if="alreadySelected(slotProps.option.id)"
+        type="warning"
+        label="Déjà sélectionné"
+        small
+        class="dsfr-badge-warning"
+      />
       <DatasetCardForSelect :dataset="slotProps.option" />
     </template>
     <template #noOptions> Précisez ou élargissez votre recherche </template>
   </Multiselect>
 </template>
+
+<style scoped>
+/* specificity override fix for badge icon */
+.dsfr-badge-warning.dsfr-badge-warning::before {
+  -webkit-mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--warning-fill.svg);
+  mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--warning-fill.svg);
+}
+</style>

--- a/src/components/forms/dataset/SelectDataset.vue
+++ b/src/components/forms/dataset/SelectDataset.vue
@@ -110,6 +110,13 @@ const clear = () => {
 </template>
 
 <style scoped>
+.multiselect {
+  margin-top: 1rem;
+}
+.dsfr-badge-info.dsfr-badge-info::before {
+  -webkit-mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
+  mask-image: url(/node_modules/@gouvfr/dsfr/dist/icons/system/fr--info-fill.svg);
+}
 :deep(.multiselect__option::after) {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);

--- a/src/components/forms/dataset/SelectDataset.vue
+++ b/src/components/forms/dataset/SelectDataset.vue
@@ -106,12 +106,12 @@ const clear = () => {
 
 <style scoped>
 :deep(.multiselect__option::after) {
-  padding: 0;
-  padding-top: 0.25rem;
-  position: relative;
-  display: block;
-  font-size: 0.75rem;
-  line-height: 1.4;
-  background: none;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  block-size: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  inline-size: 1px;
 }
 </style>

--- a/src/views/bouquets/BouquetDetailView.vue
+++ b/src/views/bouquets/BouquetDetailView.vue
@@ -103,13 +103,22 @@ const onUpdateDatasets = () => {
     throw Error('Trying to update null topic')
   }
   const loader = useLoading().show()
+
+  // Deduplicate datasets ids in case of same DS used multiple times
+  // API rejects PUT if the same id is used more than once
+  const dedupedDatasets = [
+    ...new Set(
+      datasetsProperties.value
+        .filter((d) => d.id !== null && d.remoteDeleted !== true)
+        .map((d) => d.id)
+    )
+  ]
+
   store
     .update(topic.value.id, {
       // send the tags or payload will be rejected
       tags: topic.value.tags,
-      datasets: datasetsProperties.value
-        .filter((d) => d.id !== null && d.remoteDeleted !== true)
-        .map((d) => d.id),
+      datasets: dedupedDatasets,
       extras: updateTopicExtras(topic.value, {
         datasets_properties: datasetsProperties.value.map(
           ({ remoteDeleted, ...data }) => data


### PR DESCRIPTION
- J'ai autorisé la sélection du même jeu de données dans un seul bouquet.
- J'ai cependant ajouté un avertissement lors de la sélection afin que l'utilisateur identifie facilement les datasets déjà utilisés. Initiative personnelle, à voir si ça vous plaît !

![image](https://github.com/user-attachments/assets/2327dd82-bd20-4781-9fe9-eb4cd667cd1d)

- J'ai également supprimé la prop `max-height` du `Multiselect` car ça causait un overflow lors de la sélection:

![Screenshot from 2024-08-23 16-55-57](https://github.com/user-attachments/assets/7903ea34-7c3f-4325-9daf-d50f9d60663e)

- J'ai dû forcer l'icône du [badge](https://vue-ds.fr/composants/DsfrBadge) car il allait la chercher ici `../../icons/system/fr--warning-fill.svg` et ne la trouvait pas.

Fix https://github.com/ecolabdata/ecospheres/issues/206
fix https://github.com/ecolabdata/ecospheres/issues/233