### PR TITLE
Fix: overlaping elements on multiselect list

### DIFF
--- a/src/components/forms/dataset/SelectDataset.vue
+++ b/src/components/forms/dataset/SelectDataset.vue
@@ -90,3 +90,15 @@ const clear = () => {
     <template #noOptions> Précisez ou élargissez votre recherche </template>
   </Multiselect>
 </template>
+
+<style scoped>
+:deep(.multiselect__option::after) {
+  padding: 0;
+  padding-top: 0.25rem;
+  position: relative;
+  display: block;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  background: none;
+}
+</style>

--- a/src/components/forms/dataset/SelectDataset.vue
+++ b/src/components/forms/dataset/SelectDataset.vue
@@ -93,12 +93,12 @@ const clear = () => {
 
 <style scoped>
 :deep(.multiselect__option::after) {
-  padding: 0;
-  padding-top: 0.25rem;
-  position: relative;
-  display: block;
-  font-size: 0.75rem;
-  line-height: 1.4;
-  background: none;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  block-size: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  inline-size: 1px;
 }
 </style>


### PR DESCRIPTION
En attendant de savoir s'il faut redesigner ou masquer cet élément, je l'ai positionné sous les autres éléments de la carte.
Inconvénient: lors de son apparition, il pousse un peu les cartes suivantes vers le bas.

Fix https://github.com/ecolabdata/ecospheres/issues/294