### PR TITLE
remove: oauth variables from config and put it to .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-VITE_SITE_ID=ecospheres
-# VITE_SITE_ID=meteo-france
-# VITE_SITE_ID=defis
-# VITE_SITE_ID=simplification

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,6 +12,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      VITE_OAUTH_CLIENT_KEY: ${{ secrets.VITE_OAUTH_CLIENT_KEY }}
+      VITE_OAUTH_CLIENT_ID: ${{ secrets.VITE_OAUTH_CLIENT_ID }}
+      VITE_SITE_ID: ${{ vars.VITE_SITE_ID }}
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 .env.local
 .eslintcache
 .idea

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ Verticales thématiques adossées à [data.gouv.fr](https://www.data.gouv.fr/).
 Chaque verticale est configurée dans un fichier `config.yaml` stocké sous [`configs/$verticale`](configs).
 
 La variable d'environnement `VITE_SITE_ID` permet de définir la configuration utilisée au lancement de l'application.
-Cette variable peut être définie dans le fichier [`.env`](.env) ou ses dérivés.
+La variable d'environnement `VITE_OAUTH_CLIENT_ID` indique l'ID oauth (pas obligatoire si pas de besoin de login sur l'application)
+La variable d'environnement `VITE_OAUTH_CLIENT_KEY` indique la clé PKCE de l'oauth (pas obligatoire si pas de besoin de login sur l'application)
+
+Ces variables peuvent être définies dans le fichier [`.env`](.env) ou ses dérivés.
 
 
 ## Développement

--- a/configs/defis/config.yaml
+++ b/configs/defis/config.yaml
@@ -223,6 +223,7 @@ website:
       authorized_users:
         - 6230733357772160a4f77fbadd
 themes:
+# list of organisations' ids that should be handled by the portal
 # to find an id go to https://www.data.gouv.fr/fr/organizations/ministere-de-la-transition-ecologique/
 # then Informations > ID at the bottom of the page
 organizations:

--- a/configs/defis/config.yaml
+++ b/configs/defis/config.yaml
@@ -3,10 +3,6 @@
 datagouvfr:
   # data.gouv.fr base URL
   base_url: https://www.data.gouv.fr
-  # oauth settings
-  oauth_client_id:
-  # pkce client secret, explicitely public
-  oauth_client_secret:
 
 universe:
   # "universe" topic id
@@ -223,10 +219,10 @@ website:
     activate_read_more: false
     dataset_editorialization: false
     can_add_topics:
-      everyone: false
+      everyone: true
       authorized_users:
         - 6230733357772160a4f77fbadd
-# list of organisations' ids that should be handled by the portal
+themes:
 # to find an id go to https://www.data.gouv.fr/fr/organizations/ministere-de-la-transition-ecologique/
 # then Informations > ID at the bottom of the page
 organizations:

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -3,10 +3,6 @@
 datagouvfr:
   # data.gouv.fr base URL (use www subdomain on prod)
   base_url: https://demo.data.gouv.fr
-  # oauth settings
-  oauth_client_id: 651479c317ad47b21e41a9d4
-  # pkce client secret, explicitely public
-  oauth_client_secret: v4ohcEhC4vEq8SpOl7tOiEXZfW1JSej1QpsH4oec4Gn11hCxUF
 
 universe:
   # "universe" topic id

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -3,10 +3,6 @@
 datagouvfr:
   # data.gouv.fr base URL
   base_url: https://www.data.gouv.fr
-  # oauth settings
-  oauth_client_id:
-  # pkce client secret, explicitely public
-  oauth_client_secret:
 
 universe:
   # "universe" topic id

--- a/configs/simplification/config.yaml
+++ b/configs/simplification/config.yaml
@@ -3,10 +3,6 @@
 datagouvfr:
   # data.gouv.fr base URL
   base_url: https://demo.data.gouv.fr
-  # oauth settings
-  oauth_client_id:
-  # pkce client secret, explicitely public
-  oauth_client_secret:
 
 universe:
   # "universe" topic id

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -6,8 +6,8 @@ const api = new OauthAPI()
 
 export default class AuthService {
   constructor() {
-    this.clientSecret = config.datagouvfr.oauth_client_secret
-    this.clientId = config.datagouvfr.oauth_client_id
+    this.clientSecret = import.meta.env.VITE_OAUTH_CLIENT_KEY
+    this.clientId = import.meta.env.VITE_OAUTH_CLIENT_ID
     this.baseURL = config.datagouvfr.base_url
     this.redirectURI = `${window.location.origin}/login/callback`
   }


### PR DESCRIPTION
côté data.gouv.fr, on préfère ne pas exposer, même sans risque sérieux, les client_key et client_id. 
On propose donc de les mettre dans le .env et on va mettre ces variables dans ansible. 
J'imagine que cela a un impact sur netlify pour le déploiement sur branche donc il faudrait faire une modif @abulte mais je n'ai pas la main sur le netlify j'ai l'impression.