### PR TITLE
Feat: assign bouquet to any organization

### DIFF
--- a/src/components/forms/bouquet/BouquetOwnerForm.vue
+++ b/src/components/forms/bouquet/BouquetOwnerForm.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Organization } from '@datagouv/components'
 import { debounce } from 'lodash'
-import { computed, defineModel, ref, watch, type Ref } from 'vue'
+import { computed, ref, watch, type Ref } from 'vue'
 import Multiselect from 'vue-multiselect'
 import 'vue-multiselect/dist/vue-multiselect.css'
 
@@ -37,10 +37,9 @@ const radioOptions = [
   }
 ]
 const selectOptions = computed(() => {
-  const options = organizations.value.map((option, index) => {
+  return organizations.value.map((option, index) => {
     return { value: index, text: option.name }
   })
-  return options
 })
 
 const organizations = computed(() => userStore.data?.organizations || [])
@@ -91,8 +90,8 @@ watch(choice, () => {
 <template>
   <div>
     <DsfrRadioButtonSet
-      :required="true"
       v-model="choice"
+      :required="true"
       :options="radioOptions"
       :legend="`Choisissez si vous souhaitez gérer ce ${topicsName}&nbsp;:`"
     />
@@ -102,25 +101,26 @@ watch(choice, () => {
     >
       <div class="fr-fieldset__element">
         <DsfrSelect
-          v-model="selectedOwnOrganization"
-          label="Organisations dont vous faites partie."
-          defaultUnselectedText="Sélectionnez une ogranisation"
           id="ownerOrg"
+          v-model="selectedOwnOrganization"
+          label="Organisations dont vous faites partie&nbsp;:"
+          default-unselected-text="Sélectionnez une ogranisation"
           :options="selectOptions"
-          @update:modelValue="onSelectOwnOrganization()"
+          @update:model-value="onSelectOwnOrganization()"
         />
       </div>
       <div v-if="userStore.isAdmin" class="fr-fieldset__element">
         <label class="fr-mt-2v" for="any-org-select-bouquet"
-          >Cherchez une autre organisation.</label
+          >Cherchez une autre organisation&nbsp;:</label
         >
         <Multiselect
           id="any-org-select-bouquet"
           ref="multiselect"
           v-model="selectedAnyOrganization"
+          role="search"
           :options="options"
           track-by="id"
-          placeholder="Ex: Lyon Métropole"
+          placeholder="Ex: Ministère de la Transition Ecologique"
           select-label="Entrée pour sélectionner"
           :multiple="false"
           :searchable="true"
@@ -132,7 +132,6 @@ watch(choice, () => {
           :hide-selected="true"
           @search-change="search"
           @select="onSelectAnyOrganization()"
-          role="search"
         >
           <template #caret>
             <div

--- a/src/components/forms/bouquet/BouquetOwnerForm.vue
+++ b/src/components/forms/bouquet/BouquetOwnerForm.vue
@@ -69,7 +69,7 @@ const search = debounce(async (query: string) => {
     isLoading.value = false
     return
   }
-  const organizations = (await new SearchAPI().search(query, 10, 1)).data
+  const organizations = await new SearchAPI().search(query, 10)
   options.value = organizations
   isLoading.value = false
 }, 400)
@@ -145,6 +145,8 @@ watch(choice, () => {
           :close-on-select="true"
           :show-no-results="false"
           :hide-selected="true"
+          :limit="3"
+          :options-limit="100"
           @search-change="search"
           @select="onSelectAnyOrganization()"
         >

--- a/src/components/forms/bouquet/BouquetOwnerForm.vue
+++ b/src/components/forms/bouquet/BouquetOwnerForm.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Organization } from '@datagouv/components'
 import { debounce } from 'lodash'
-import { defineModel, computed, ref, watch, type Ref, onMounted } from 'vue'
+import { computed, defineModel, ref, watch, type Ref } from 'vue'
 import Multiselect from 'vue-multiselect'
 import 'vue-multiselect/dist/vue-multiselect.css'
 
@@ -91,7 +91,7 @@ watch(choice, () => {
 <template>
   <div>
     <DsfrRadioButtonSet
-      required="true"
+      :required="true"
       v-model="choice"
       :options="radioOptions"
       :legend="`Choisissez si vous souhaitez gérer ce ${topicsName}&nbsp;:`"
@@ -110,12 +110,11 @@ watch(choice, () => {
           @update:modelValue="onSelectOwnOrganization()"
         />
       </div>
-      <div class="fr-fieldset__element">
+      <div v-if="userStore.isAdmin" class="fr-fieldset__element">
         <label class="fr-mt-2v" for="any-org-select-bouquet"
           >Cherchez une autre organisation.</label
         >
         <Multiselect
-          v-if="userStore.isAdmin"
           id="any-org-select-bouquet"
           ref="multiselect"
           v-model="selectedAnyOrganization"

--- a/src/components/forms/bouquet/BouquetOwnerForm.vue
+++ b/src/components/forms/bouquet/BouquetOwnerForm.vue
@@ -23,8 +23,25 @@ const choice: Ref<'organization' | 'owner'> = ref(
   topic.value.organization != null ? 'organization' : 'owner'
 )
 
-const selectedAnyOrganization: Ref<Organization | undefined> = ref(undefined)
-const selectedOwnOrganization: Ref<string | undefined> = ref(undefined)
+const organizations = computed(() => userStore.data?.organizations || [])
+
+// checks if current owner is a user's org and return its id
+const ownOrganizationIndex = computed(() => {
+  return organizations.value.findIndex(
+    (org) => org.id === topic.value.organization?.id
+  )
+})
+// both models check the above index to determine the default owner to display
+const selectedAnyOrganization: Ref<Organization | undefined> = ref(
+  ownOrganizationIndex.value < 0 && !topic.value.owner
+    ? topic.value.organization
+    : undefined
+)
+const selectedOwnOrganization: Ref<number | string | undefined> = ref(
+  ownOrganizationIndex.value >= 0 && !topic.value.owner
+    ? ownOrganizationIndex.value
+    : undefined
+)
 
 const radioOptions = [
   {
@@ -41,8 +58,6 @@ const selectOptions = computed(() => {
     return { value: index, text: option.name }
   })
 })
-
-const organizations = computed(() => userStore.data?.organizations || [])
 
 const isLoading = ref(false)
 const options: Ref<Organization[]> = ref([])
@@ -61,7 +76,7 @@ const search = debounce(async (query: string) => {
 
 const onSelectOwnOrganization = () => {
   if (selectedOwnOrganization.value) {
-    const idx = parseInt(selectedOwnOrganization.value)
+    const idx = Number(selectedOwnOrganization.value)
     topic.value.organization = organizations.value[idx]
     topic.value.owner = null
     clear()
@@ -104,7 +119,7 @@ watch(choice, () => {
           id="ownerOrg"
           v-model="selectedOwnOrganization"
           label="Organisations dont vous faites partie&nbsp;:"
-          default-unselected-text="Sélectionnez une ogranisation"
+          default-unselected-text="Sélectionnez une organisation"
           :options="selectOptions"
           @update:model-value="onSelectOwnOrganization()"
         />

--- a/src/components/forms/bouquet/BouquetOwnerForm.vue
+++ b/src/components/forms/bouquet/BouquetOwnerForm.vue
@@ -1,13 +1,22 @@
 <script setup lang="ts">
-import { defineModel, computed, ref, watch, type Ref } from 'vue'
+import type { Organization } from '@datagouv/components'
+import { debounce } from 'lodash'
+import { defineModel, computed, ref, watch, type Ref, onMounted } from 'vue'
+import Multiselect from 'vue-multiselect'
+import 'vue-multiselect/dist/vue-multiselect.css'
 
+import '@/assets/multiselect.css'
 import type { Topic } from '@/model/topic'
+import SearchAPI from '@/services/api/SearchOrgAPI'
 import { useUserStore } from '@/store/UserStore'
 import { useTopicsConf } from '@/utils/config'
 
 const topic = defineModel({
   type: Object as () => Topic,
   required: true
+})
+const selectedOrganization = defineModel('selectedOrganization', {
+  type: Object as () => Topic
 })
 
 const userStore = useUserStore()
@@ -18,10 +27,29 @@ const choice: Ref<'organization' | 'owner'> = ref(
 )
 const organizations = computed(() => userStore.data?.organizations || [])
 
+const isLoading = ref(false)
+const options: Ref<Organization[]> = ref([])
+
+const search = debounce(async (query: string) => {
+  isLoading.value = true
+  if (!query) {
+    options.value = []
+    isLoading.value = false
+    return
+  }
+  const organizations = (await new SearchAPI().search(query, 10, 1)).data
+  options.value = organizations
+  isLoading.value = false
+}, 400)
+
 const onSelectOrganization = (value: string) => {
   const idx = parseInt(value)
   topic.value.organization = organizations.value[idx]
   topic.value.owner = null
+}
+
+const clear = () => {
+  selectedOrganization.value = undefined
 }
 
 watch(choice, () => {
@@ -54,6 +82,43 @@ watch(choice, () => {
             label="En tant qu'organisation"
           />
           <div v-if="choice === 'organization'">
+            <Multiselect
+              v-if="userStore.isAdmin"
+              id="bouquet-select-dataset"
+              ref="multiselect"
+              v-model="selectedOrganization"
+              :options="options"
+              label="title"
+              track-by="id"
+              placeholder="Ex: Lyon Métropole"
+              select-label="Entrée pour sélectionner"
+              :multiple="false"
+              :searchable="true"
+              :internal-search="false"
+              :loading="isLoading"
+              :clear-on-select="true"
+              :close-on-select="true"
+              :show-no-results="false"
+              :hide-selected="true"
+              @search-change="search"
+            >
+              <template #caret>
+                <div
+                  v-if="selectedOrganization"
+                  class="multiselect__clear"
+                  @mousedown.prevent.stop="clear"
+                ></div>
+              </template>
+              <template #singleLabel="slotProps">
+                {{ slotProps.option.name }}
+              </template>
+              <template #option="slotProps">
+                {{ slotProps.option.name }}
+              </template>
+              <template #noOptions>
+                Précisez ou élargissez votre recherche
+              </template>
+            </Multiselect>
             <select
               class="fr-select"
               @change="

--- a/src/model/organization.ts
+++ b/src/model/organization.ts
@@ -1,7 +1,0 @@
-import type { Organization } from '@datagouv/components'
-
-import type { GenericResponse } from './api'
-
-export interface OrganizationResponse extends GenericResponse {
-  data: Organization[]
-}

--- a/src/model/organization.ts
+++ b/src/model/organization.ts
@@ -1,0 +1,7 @@
+import type { Organization } from '@datagouv/components'
+
+import type { GenericResponse } from './api'
+
+export interface OrganizationResponse extends GenericResponse {
+  data: Organization[]
+}

--- a/src/services/api/SearchOrgAPI.ts
+++ b/src/services/api/SearchOrgAPI.ts
@@ -1,0 +1,29 @@
+import { size } from 'lodash'
+
+import type { OrganizationResponse } from '@/model/organization'
+
+import DatagouvfrAPI from './DatagouvfrAPI'
+
+/**
+ * A wrapper around search engine API
+ */
+export default class SearchAPI extends DatagouvfrAPI {
+  version = 2
+  endpoint = 'organizations/search'
+
+  async search(
+    query: string,
+    size: number,
+    page: number,
+    args?: object
+  ): Promise<OrganizationResponse> {
+    return await this.list({
+      params: {
+        q: query,
+        size: size ?? 20,
+        page: page ?? 1,
+        ...args
+      }
+    })
+  }
+}

--- a/src/services/api/SearchOrgAPI.ts
+++ b/src/services/api/SearchOrgAPI.ts
@@ -1,6 +1,4 @@
-import { size } from 'lodash'
-
-import type { OrganizationResponse } from '@/model/organization'
+import type { Organization } from '@datagouv/components'
 
 import DatagouvfrAPI from './DatagouvfrAPI'
 
@@ -8,15 +6,15 @@ import DatagouvfrAPI from './DatagouvfrAPI'
  * A wrapper around search engine API
  */
 export default class SearchAPI extends DatagouvfrAPI {
-  version = 2
-  endpoint = 'organizations/search'
+  version = 1
+  endpoint = 'organizations/suggest'
 
   async search(
     query: string,
     size: number,
-    page: number,
+    page?: number,
     args?: object
-  ): Promise<OrganizationResponse> {
+  ): Promise<Organization[]> {
     return await this.list({
       params: {
         q: query,


### PR DESCRIPTION
Possibilité pour un admin de modifier le propriétaire d'un bouquet vers n'importe quelle organisation existante sur data gouv.
J'ai modifié la structure HTML existante pour utiliser le DSFR si possible.

Ajout de la structure nécessaire (model + service) à l'API des organisations. 

FIX https://github.com/ecolabdata/ecospheres/issues/278