### PR TITLE
feat(organization): quick redesign of datasets list

### DIFF
--- a/src/services/api/resources/DatasetsAPI.ts
+++ b/src/services/api/resources/DatasetsAPI.ts
@@ -12,7 +12,6 @@ export default class DatasetsAPI extends DatagouvfrAPI {
     page?: number,
     sort?: string
   ): Promise<DatasetV2Response> {
-    // WARNING: specify `-created` or another sort explicitely because default sort has a pagination issue
     const url = `${this.url()}/search/`
     return await this.request({
       url,

--- a/src/services/api/resources/DatasetsAPI.ts
+++ b/src/services/api/resources/DatasetsAPI.ts
@@ -9,8 +9,8 @@ export default class DatasetsAPI extends DatagouvfrAPI {
    */
   async getDatasetsForOrganization(
     orgId: string,
-    page: number = 1,
-    sort: string = '-created'
+    page?: number,
+    sort?: string
   ): Promise<DatasetV2Response> {
     // WARNING: specify `-created` or another sort explicitely because default sort has a pagination issue
     const url = `${this.url()}/search/`

--- a/src/store/DatasetStore.ts
+++ b/src/store/DatasetStore.ts
@@ -8,10 +8,10 @@ import DatasetsAPI from '@/services/api/resources/DatasetsAPI'
 const datasetsApi = new DatasetsAPI()
 const datasetsApiv2 = new DatasetsAPI({ version: 2 })
 
-export interface RootState {
+interface RootState {
   data: Record<string, DatasetV2Response[]>
   resourceTypes: unknown[]
-  sort: string | null
+  sort: string | undefined
 }
 
 /**
@@ -31,7 +31,7 @@ export const useDatasetStore = defineStore('dataset', {
   state: (): RootState => ({
     data: {},
     resourceTypes: [],
-    sort: null
+    sort: undefined
   }),
   actions: {
     /**
@@ -53,11 +53,7 @@ export const useDatasetStore = defineStore('dataset', {
     /**
      * Get datasets from store for an org and a page
      */
-    getDatasetsForOrg(
-      orgId: string,
-      page: number = 1,
-      sort: string = '-created'
-    ) {
+    getDatasetsForOrg(orgId: string, page: number = 1, sort?: string) {
       if (this.sort !== sort) return undefined
       if (this.data[orgId] === undefined) return undefined
       return this.data[orgId].find((d) => d.page === page)
@@ -65,11 +61,7 @@ export const useDatasetStore = defineStore('dataset', {
     /**
      * Async function to trigger API fetch of an org's datasets if not known in store
      */
-    async loadDatasetsForOrg(
-      orgId: string,
-      page: number = 1,
-      sort: string = '-created'
-    ) {
+    async loadDatasetsForOrg(orgId: string, page: number = 1, sort?: string) {
       const existing = this.getDatasetsForOrg(orgId, page, sort)
       if (existing !== undefined) return existing
       const datasets = await datasetsApiv2.getDatasetsForOrganization(
@@ -83,7 +75,7 @@ export const useDatasetStore = defineStore('dataset', {
     /**
      * Store the result of a datasets fetch operation for an org in store
      */
-    addDatasets(orgId: string, res: DatasetV2Response, sort: string | null) {
+    addDatasets(orgId: string, res: DatasetV2Response, sort?: string) {
       // reset org data if another sort has been requested
       if (this.data[orgId] === undefined) this.data[orgId] = []
       if (this.sort !== sort) this.data[orgId] = []
@@ -118,7 +110,7 @@ export const useDatasetStore = defineStore('dataset', {
           previous_page: null,
           total: 1
         },
-        null
+        undefined
       )
       return dataset
     },

--- a/src/store/DatasetStore.ts
+++ b/src/store/DatasetStore.ts
@@ -44,7 +44,7 @@ export const useDatasetStore = defineStore('dataset', {
       return [...Array(nbPages).keys()].map((page) => {
         page += 1
         return {
-          label: page,
+          label: page.toString(),
           href: '#',
           title: `Page ${page}`
         }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 import DOMPurify from 'dompurify'
 import { marked } from 'marked'
 import { stripHtml } from 'string-strip-html'
+import type { Ref } from 'vue'
 
 const markedOptions = {
   gfm: true,
@@ -14,7 +15,7 @@ const markedOptions = {
  *
  * @param {ref} ref
  */
-export const descriptionFromMarkdown = (ref, attr = 'description') => {
+export const descriptionFromMarkdown = (ref: Ref, attr = 'description') => {
   if (ref.value?.description) {
     return fromMarkdown(ref.value[attr])
   }
@@ -22,23 +23,18 @@ export const descriptionFromMarkdown = (ref, attr = 'description') => {
 
 /**
  * Parse markdown to HTML
- *
- * @param {string} value
  */
-export const fromMarkdown = (value) => {
+export const fromMarkdown = async (value: string) => {
   if (!value) return ''
-  const parsed = marked.parse(value, markedOptions)
+  const parsed = await marked.parse(value, markedOptions)
   return DOMPurify.sanitize(parsed)
 }
 
 /**
  * Strip HTML tags from markdown
- *
- * @param {string} value
- * @returns {string}
  */
-export const stripFromMarkdown = (value) => {
-  const html = marked.parse(value, markedOptions)
+export const stripFromMarkdown = async (value: string) => {
+  const html = await marked.parse(value, markedOptions)
   return stripHtml(html).result
 }
 
@@ -46,9 +42,9 @@ export const stripFromMarkdown = (value) => {
  * Format date
  *
  */
-export const formatDate = (dateString, short = false) => {
+export const formatDate = (dateString: string, short = false) => {
   const date = new Date(dateString)
-  const params = short
+  const params: Intl.DateTimeFormatOptions = short
     ? {
         day: 'numeric',
         month: 'short',

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,8 +12,6 @@ const markedOptions = {
 
 /**
  * Parse description from markdown to HTML
- *
- * @param {ref} ref
  */
 export const descriptionFromMarkdown = (ref: Ref, attr = 'description') => {
   if (ref.value?.description) {
@@ -24,18 +22,20 @@ export const descriptionFromMarkdown = (ref: Ref, attr = 'description') => {
 /**
  * Parse markdown to HTML
  */
-export const fromMarkdown = async (value: string) => {
+export const fromMarkdown = (value: string) => {
   if (!value) return ''
-  const parsed = await marked.parse(value, markedOptions)
-  return DOMPurify.sanitize(parsed)
+  const parsed = marked.parse(value, markedOptions)
+  // type cast to string because we don't use async mode of marked
+  return DOMPurify.sanitize(parsed as string)
 }
 
 /**
  * Strip HTML tags from markdown
  */
-export const stripFromMarkdown = async (value: string) => {
-  const html = await marked.parse(value, markedOptions)
-  return stripHtml(html).result
+export const stripFromMarkdown = (value: string) => {
+  const html = marked.parse(value, markedOptions)
+  // type cast to string because we don't use async mode of marked
+  return stripHtml(html as string).result
 }
 
 /**

--- a/src/views/organizations/OrganizationDetailView.vue
+++ b/src/views/organizations/OrganizationDetailView.vue
@@ -122,7 +122,7 @@ watchEffect(() => {
     <div v-if="!datasets?.length">
       Pas de jeu de données pour cette organisation.
     </div>
-    <ul v-else class="fr-grid-row fr-grid-row--gutters" role="list">
+    <ul v-else class="fr-px-0" role="list">
       <li v-for="d in datasets" :key="d.id" class="fr-col-md-12 fr-py-0">
         <DatasetCard
           :dataset="d"

--- a/src/views/organizations/OrganizationDetailView.vue
+++ b/src/views/organizations/OrganizationDetailView.vue
@@ -122,11 +122,8 @@ watchEffect(() => {
     <div v-if="!datasets?.length">
       Pas de jeu de données pour cette organisation.
     </div>
-    <div
-      v-else
-      class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle justify-between fr-pb-1w"
-    >
-      <div class="fr-col-md-12">
+    <ul v-else class="fr-grid-row fr-grid-row--gutters">
+      <li class="fr-col-md-12">
         <DatasetCard
           v-for="d in datasets"
           :key="d.id"
@@ -137,8 +134,8 @@ watchEffect(() => {
             params: { oid: d.organization?.id }
           }"
         />
-      </div>
-    </div>
+      </li>
+    </ul>
   </GenericContainer>
   <DsfrPagination
     v-if="pages.length"

--- a/src/views/organizations/OrganizationDetailView.vue
+++ b/src/views/organizations/OrganizationDetailView.vue
@@ -108,6 +108,7 @@ watchEffect(() => {
         <!-- TODO: add "pertinence" when custom SelectComponent has landed -->
         <div class="fr-col">
           <DsfrSelect
+            select-id="sort-search"
             :model-value="selectedSort"
             :options="sorts"
             label=""

--- a/src/views/organizations/OrganizationDetailView.vue
+++ b/src/views/organizations/OrganizationDetailView.vue
@@ -58,24 +58,28 @@ function doSort(sort: string | number) {
 const description = computed(() => descriptionFromMarkdown(org))
 
 // we need the technical id to fetch the datasets and thus pagination
-watch(org, () => {
-  if (org.value?.id === undefined) return
-  breadcrumbLinks.value.push({ text: org.value.name })
-  const loader = useLoading().show({
-    enforceFocus: false
-  })
-  datasetStore
-    .loadDatasetsForOrg(org.value.id, currentPage.value, selectedSort.value)
-    .then((res) => {
-      datasets.value = res?.data
-      if (!pages.value.length && org.value?.id) {
-        pages.value = datasetStore.getDatasetsPaginationForOrg(org.value?.id)
-      }
+watch(
+  () => org.value?.id,
+  () => {
+    if (org.value?.id === undefined) return
+    breadcrumbLinks.value.push({ text: org.value.name })
+    const loader = useLoading().show({
+      enforceFocus: false
     })
-    .finally(() => {
-      loader.hide()
-    })
-})
+    datasetStore
+      .loadDatasetsForOrg(org.value.id, currentPage.value, selectedSort.value)
+      .then((res) => {
+        datasets.value = res?.data
+        if (!pages.value.length && org.value?.id) {
+          pages.value = datasetStore.getDatasetsPaginationForOrg(org.value?.id)
+        }
+      })
+      .finally(() => {
+        loader.hide()
+      })
+  },
+  { immediate: true }
+)
 </script>
 
 <template>

--- a/src/views/organizations/OrganizationDetailView.vue
+++ b/src/views/organizations/OrganizationDetailView.vue
@@ -122,11 +122,9 @@ watchEffect(() => {
     <div v-if="!datasets?.length">
       Pas de jeu de données pour cette organisation.
     </div>
-    <ul v-else class="fr-grid-row fr-grid-row--gutters">
-      <li class="fr-col-md-12">
+    <ul v-else class="fr-grid-row fr-grid-row--gutters" role="list">
+      <li v-for="d in datasets" :key="d.id" class="fr-col-md-12 fr-py-0">
         <DatasetCard
-          v-for="d in datasets"
-          :key="d.id"
           :dataset="d"
           :dataset-url="{ name: 'dataset_detail', params: { did: d.id } }"
           :organization-url="{


### PR DESCRIPTION
- Corrige les erreurs de linting / typage sur `OrganizationDetailView`
- Corrige le tri (avec un TODO sur le tri par défaut dépendant de #605)
- Utilise les `DatasetCard` de data.gouv.fr pour la liste des jeux de données
- Migre les misc utils en Typescript