### PR TITLE
chore: Add orgs to ecospheres demo universe

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -348,6 +348,7 @@ organizations:
   - grdf
   - institut-francais-de-recherche-pour-lexploitation-de-la-mer
   - institut-national-de-l-information-geographique-et-forestiere
+  - institut-national-de-lenvironnement-industriel-et-des-risques
   - irstea
   - jvmalin
   - ligair
@@ -370,6 +371,7 @@ organizations:
   - parc-naturel-regional-du-vercors
   - regie-autonome-des-transports-parisiens-ratp
   - reseau-de-transport-delectricite
+  - rnb
   - section-cadastre-topographie-de-la-polynesie-francaise
   - shom
   - sncf


### PR DESCRIPTION
Fix ecolabdata/ecospheres#489
Fix ecolabdata/ecospheres#504

- (atmo-occitanie missing on demo)
- institut-national-de-lenvironnement-industriel-et-des-risques
- rnb

In case we don't switch to Grist on the next MEP.