### PR TITLE
fix: meteo hp sub_section_tiles.class

### DIFF
--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -38,6 +38,7 @@ website:
         sub_section_datasets:
         sub_section_cards:
         sub_section_tiles:
+          class: fr-col-md-6
           title:
           tiles:
             - id: '6571f26dc009674feb726be9'


### PR DESCRIPTION
Reverse engineered from https://meteo.data.gouv.fr/, seems to be a missing class in the config file.