### PR TITLE
feat: improve indicators in bouquets

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -257,7 +257,7 @@ themes:
 organizations: https://raw.githubusercontent.com/ecolabdata/ecospheres-universe/refs/heads/main/dist/organizations-demo.json
 
 indicators:
-  organization_id: 672b5425a62a44ddee8815bd
+  organization_id: 67c57c2f1a418addfc94d38a
   global_tag_prefix: ecospheres-indicateurs
   filters:
     - name: Thématique

--- a/src/components/bouquets/BouquetDatasetCard.vue
+++ b/src/components/bouquets/BouquetDatasetCard.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import type { DatasetV2 } from '@datagouv/components'
 import { DatasetCard } from '@datagouv/components'
+import type { DatasetV2 } from '@datagouv/components/ts'
 import { toRef } from 'vue'
 
+import IndicatorDatasetCard from '@/custom/ecospheres/components/indicators/IndicatorDatasetCard.vue'
+import { isIndicator } from '@/custom/ecospheres/utils/indicator'
 import { type DatasetProperties } from '@/model/topic'
 
 const props = defineProps({
@@ -18,12 +20,13 @@ const props = defineProps({
 })
 
 const datasetPropertiesRef = toRef(props, 'datasetProperties')
+const datasetIsIndicator = isIndicator(toRef(props, 'datasetContent'))
 </script>
 
 <template>
   <!-- Using :key ensures that the component is recreated when dataset changes otherwise, we have a persistence on the thumbnail -->
   <DatasetCard
-    v-if="datasetContent"
+    v-if="datasetContent && !datasetIsIndicator"
     :key="datasetContent.id"
     :dataset="datasetContent"
     :dataset-url="{
@@ -31,6 +34,12 @@ const datasetPropertiesRef = toRef(props, 'datasetProperties')
       params: { did: datasetContent.id }
     }"
     :show-description="false"
+    class="dataset-card fr-m-0"
+  />
+  <IndicatorDatasetCard
+    v-if="datasetContent && datasetIsIndicator"
+    :key="datasetContent.id"
+    :dataset="datasetContent"
     class="dataset-card fr-m-0"
   />
   <DsfrAlert

--- a/src/components/bouquets/BouquetDatasetCard.vue
+++ b/src/components/bouquets/BouquetDatasetCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import type { DatasetV2 } from '@datagouv/components'
 import { DatasetCard } from '@datagouv/components'
-import type { DatasetV2 } from '@datagouv/components/ts'
 import { toRef } from 'vue'
 
 import IndicatorDatasetCard from '@/custom/ecospheres/components/indicators/IndicatorDatasetCard.vue'

--- a/src/components/bouquets/BouquetDatasetList.vue
+++ b/src/components/bouquets/BouquetDatasetList.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { type DatasetV2 } from '@datagouv/components'
 import { onMounted, ref, type Ref } from 'vue'
+
+import type { DatasetV2 } from '@datagouv/components'
 
 import DatasetEditModal, {
   type DatasetEditModalType
@@ -102,7 +103,7 @@ const loadDatasetsContent = () => {
 }
 
 const showTOC = computed(() => {
-  /* 
+  /*
   hide the table of content if "NoGroup" is the only group and results are not 0
   or
   hide if all factors (datasetProperties) are hidden by the filter

--- a/src/components/datasets/ResourcesList.vue
+++ b/src/components/datasets/ResourcesList.vue
@@ -2,8 +2,8 @@
 import config from '@/config'
 import type { ResourceData } from '@/model/resource'
 import { useResourceStore } from '@/store/ResourceStore'
+import type { DatasetV2 } from '@datagouv/components'
 import { Pagination, ResourceAccordion } from '@datagouv/components'
-import type { DatasetV2 } from '@datagouv/components/ts'
 import { useLoading } from 'vue-loading-overlay'
 
 const pageSize = config.website.pagination_sizes.files_list as number

--- a/src/components/forms/dataset/DatasetCardForSelect.vue
+++ b/src/components/forms/dataset/DatasetCardForSelect.vue
@@ -1,18 +1,15 @@
 <script setup lang="ts">
-// FIXME
-import type { DatasetV2Fix } from '@/model/DatasetV2Fix'
-import {
-  OrganizationNameWithCertificate,
-  useOwnerName
-} from '@datagouv/components'
+import type { DatasetV2 } from '@datagouv/components'
+import { OrganizationNameWithCertificate } from '@datagouv/components'
 import { computed } from 'vue'
 
 import { stripFromMarkdown } from '@/utils'
 import { getOwnerAvatar } from '@/utils/avatar'
+import { useOwnerName } from '@/utils/dataset'
 
 const props = defineProps({
   dataset: {
-    type: Object as () => DatasetV2Fix,
+    type: Object as () => DatasetV2,
     required: true
   },
   alreadySelected: {

--- a/src/custom/ecospheres/components/indicators/IndicatorDatasetCard.vue
+++ b/src/custom/ecospheres/components/indicators/IndicatorDatasetCard.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+/**
+ * This component is a copy of the DatasetCard component from the @datagouv/components package.
+ * It is used to display an indicator.
+ */
+import type { DatasetV2 } from '@datagouv/components'
+import {
+  Avatar,
+  OrganizationNameWithCertificate,
+  Placeholder,
+  QualityComponentInline,
+  formatRelativeIfRecentDate,
+  summarize
+} from '@datagouv/components'
+import TextClamp from 'vue3-text-clamp'
+
+import { useOwnerName } from '@/utils/dataset'
+
+type Props = {
+  dataset: DatasetV2
+}
+
+const props = defineProps<Props>()
+
+const ownerName = useOwnerName(props.dataset)
+</script>
+
+<template>
+  <div class="fr-my-2w fr-p-2w border border-default-grey fr-enlarge-link">
+    <div
+      class="absolute top-0 fr-grid-row fr-grid-row--middle fr-mt-n3v fr-ml-n1v"
+    >
+      <p
+        class="fr-badge fr-badge--sm fr-badge--mention-grey text-grey-380 fr-mr-1w"
+      >
+        <span
+          class="fr-icon-lightbulb-line fr-icon--sm"
+          aria-hidden="true"
+        ></span>
+        Indicateur
+      </p>
+    </div>
+    <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+      <div class="fr-col-auto">
+        <div class="logo">
+          <Placeholder
+            v-if="dataset.organization"
+            type="dataset"
+            :src="dataset.organization.logo_thumbnail"
+            alt=""
+            :size="40"
+          />
+          <Avatar v-else-if="dataset.owner" :user="dataset.owner" :size="40" />
+          <Placeholder v-else type="dataset" :size="40" />
+        </div>
+      </div>
+      <div class="fr-col-12 fr-col-sm">
+        <h4 class="fr-text--md fr-mb-0 fr-grid-row">
+          <RouterLink
+            :to="{ name: 'indicator_detail', params: { iid: dataset.id } }"
+            class="text-grey-500 fr-grid-row"
+          >
+            <TextClamp
+              class="fr-col"
+              :auto-resize="true"
+              :text="dataset.title"
+              :max-lines="1"
+            />
+            <small v-if="dataset.acronym" class="fr-col-auto fr-ml-1w">{{
+              dataset.acronym
+            }}</small>
+          </RouterLink>
+        </h4>
+        <div
+          v-if="dataset.organization || dataset.owner"
+          class="fr-text--sm fr-m-0 inline-flex"
+        >
+          <template v-if="dataset.organization">
+            <span class="not-enlarged fr-mr-1v">
+              <OrganizationNameWithCertificate
+                :organization="dataset.organization"
+              />
+            </span>
+          </template>
+          <TextClamp
+            v-else
+            class="not-enlarged fr-mr-1v"
+            :auto-resize="true"
+            :text="ownerName"
+            :max-lines="1"
+          />
+          <span class="text-mention-grey dash-before-sm whitespace-nowrap"
+            >Mise à jour
+            {{ formatRelativeIfRecentDate(dataset.last_update) }}</span
+          >
+        </div>
+        <div
+          class="fr-mx-0 fr-mb-n1v fr-grid-row fr-grid-row--middle fr-text--sm text-mention-grey"
+        >
+          <div class="fr-hidden flex-sm dash-after-sm text-grey-500">
+            <QualityComponentInline :quality="dataset.quality" />
+          </div>
+          <div class="fr-grid-row fr-grid-row--middle fr-mr-1v">
+            <p
+              class="fr-text--sm fr-my-0"
+              :aria-label="`${dataset.metrics.resources_downloads} téléchargements`"
+            >
+              <span
+                class="fr-icon-download-line fr-icon--sm fr-px-1v"
+                aria-hidden="true"
+              ></span
+              >{{ summarize(dataset.metrics.resources_downloads) }}
+            </p>
+            <p
+              class="fr-text--sm fr-my-0"
+              :aria-label="`${dataset.metrics.followers} abonnés`"
+            >
+              <span
+                class="fr-icon-star-line fr-icon--sm fr-px-1v"
+                aria-hidden="true"
+              ></span
+              >{{ summarize(dataset.metrics.followers) }}
+            </p>
+            <p
+              class="fr-text--sm fr-my-0"
+              :aria-label="`${dataset.metrics.reuses} réutilisations`"
+            >
+              <span
+                class="fr-icon-line-chart-line fr-icon--sm fr-px-1v"
+                aria-hidden="true"
+              ></span
+              >{{ summarize(dataset.metrics.reuses) }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/custom/ecospheres/store/IndicatorStore.ts
+++ b/src/custom/ecospheres/store/IndicatorStore.ts
@@ -2,11 +2,15 @@ import { defineStore } from 'pinia'
 
 import config from '@/config'
 import SearchAPI from '@/services/api/SearchAPI'
+import type { IndicatorsConf } from '../model/config'
 import type { Indicator, IndicatorFilters } from '../model/indicator'
 import { useTagsQuery } from '../utils/indicator'
 
 const searchApi = new SearchAPI()
 const PAGE_SIZE = 20
+
+const indicatorsConf = config.indicators as IndicatorsConf
+const tagPrefix = indicatorsConf.global_tag_prefix
 
 export interface RootState {
   indicators: Indicator[]
@@ -30,7 +34,7 @@ export const useIndicatorStore = defineStore('indicator', {
       const results = await searchApi.search(query, null, 1, {
         organization: config.indicators.organization_id,
         page_size: PAGE_SIZE,
-        tag,
+        tag: [tagPrefix, ...tag],
         ...extraArgs
       })
       this.indicators = results.data as Indicator[]

--- a/src/custom/ecospheres/utils/indicator.ts
+++ b/src/custom/ecospheres/utils/indicator.ts
@@ -1,5 +1,6 @@
 import config from '@/config'
 import { useSpatialStore } from '@/store/SpatialStore'
+import type { DatasetV2 } from '@datagouv/components'
 import type { ComputedRef } from 'vue'
 import type { IndicatorsConf } from '../model/config'
 import type {
@@ -117,4 +118,15 @@ export const useIndicatorExtras = (indicator: Ref<Indicator | undefined>) => {
     api,
     sources
   }
+}
+
+// FIXME: use only tagPrefix when test data are OK
+export const isIndicator = (
+  dataset: Ref<DatasetV2 | undefined>
+): ComputedRef<boolean> => {
+  return computed(() => {
+    return (
+      dataset.value?.tags?.some((tag) => tag.startsWith(tagPrefix)) || false
+    )
+  })
 }

--- a/src/custom/ecospheres/utils/indicator.ts
+++ b/src/custom/ecospheres/utils/indicator.ts
@@ -120,13 +120,10 @@ export const useIndicatorExtras = (indicator: Ref<Indicator | undefined>) => {
   }
 }
 
-// FIXME: use only tagPrefix when test data are OK
 export const isIndicator = (
   dataset: Ref<DatasetV2 | undefined>
 ): ComputedRef<boolean> => {
   return computed(() => {
-    return (
-      dataset.value?.tags?.some((tag) => tag.startsWith(tagPrefix)) || false
-    )
+    return dataset.value?.tags?.includes(tagPrefix) || false
   })
 }

--- a/src/model/DatasetV2Fix.ts
+++ b/src/model/DatasetV2Fix.ts
@@ -1,3 +1,0 @@
-import type { DatasetV2, Owned } from '@datagouv/components/ts'
-
-export type DatasetV2Fix = DatasetV2 & Owned

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,18 +1,21 @@
-import { type Owned } from '@datagouv/components'
+import type { Organization, User } from '@datagouv/components'
 
 import config from '@/config'
 
-/**
- *
- */
+// FIXME: this is an ersatz of the Owned type in @datagouv/components,
+// but correctly working with our type system (especially DatasetV2)
+// see also @utils/dataset:useOwnerName
+// https://github.com/datagouv/udata-front/issues/661
+interface HasOwnership {
+  organization?: Organization | null
+  owner?: User | null
+}
+
 export const getOwnerAvatar = (
-  object: Partial<Owned>,
+  object: HasOwnership,
   size: number = 32
 ): string => {
-  if (
-    object.owner?.avatar_thumbnail !== null &&
-    object.owner?.avatar_thumbnail !== undefined
-  ) {
+  if (object.owner?.avatar_thumbnail != null) {
     return object.owner.avatar_thumbnail
   }
   return `${config.datagouvfr.base_url}/api/1/avatars/${object.owner?.id}/${size}`

--- a/src/utils/dataset.ts
+++ b/src/utils/dataset.ts
@@ -17,3 +17,22 @@ export const useLicense = (
   )
   return license
 }
+
+// FIXME: this is a redefinition of the same function in @datagouv/components
+// It handles types correcly when passing a DatasetV2
+// https://github.com/datagouv/udata-front/issues/661
+export const useOwnerName = (
+  dataset: DatasetV2
+): ComputedRef<string | undefined> => {
+  const owner = computed(() => {
+    const ownedValue = toValue(dataset)
+    if (ownedValue) {
+      if (ownedValue.organization) {
+        return ownedValue.organization.name
+      } else if (ownedValue.owner) {
+        return ownedValue.owner.first_name + ' ' + ownedValue.owner.last_name
+      }
+    }
+  })
+  return owner
+}


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/530
Fix https://github.com/ecolabdata/ecospheres/issues/532
Fix https://github.com/ecolabdata/ecospheres/issues/533

- Utilise le nouvel identifiant d'organisation Ecolab en demo
- Ajoute un filtre global sur le tag `ecospheres-indicateurs` pour la liste des indicateurs, afin de discriminer les indicateurs des autres jeux de données
- Utilise cette nomenclature pour différencier un indicateur d'un autre jeu de données dans la composition d'un bouquet et
  - affiche une pastille "Indicateur" sur la carte d'un indicateur (il a fallu recréer une carte dédiée, on n'a pas la main sur celle des datasets)
  - renvoie vers le page de détail d'un indicateur au clic sur sa carte
 
<img width="978" alt="Capture d’écran 2025-02-19 à 11 03 47" src="https://github.com/user-attachments/assets/eaa8439c-7aad-46d4-bd18-be1658c834fe" />

Nécessite de taguer correctement les indicateurs existants pour tout voir fonctionner (cf https://ecosphres.slack.com/archives/C07NJ7B4XE3/p1739473389862149). En attendant :
- la liste des indicateurs est vide
- la détection d'un indicateur est surchargée pour tests, à corriger avant merge

Change aussi un hack utilisé pour contourner cette issue https://github.com/datagouv/udata-front/issues/661 : plutôt que surcharger le type, surcharge les helpers qui dépendent de ce type. Sinon j'aurais dû retyper quasiment toute la base de code en `DatasetV2Fix`.