### PR TITLE
bouquets: authenticate list API call

### DIFF
--- a/src/store/TopicStore.ts
+++ b/src/store/TopicStore.ts
@@ -94,7 +94,8 @@ export const useTopicStore = defineStore('topic', {
           page_size: config.website.pagination_sizes.topics_list,
           tag: config.universe.name,
           include_private: 'yes'
-        }
+        },
+        authenticated: true
       })
       await useUserStore().waitForStoreInit()
       this.data = this.filter(response.data)


### PR DESCRIPTION
La liste des Topics sur l'API est désormais sensible à l'utilisateur courant pour récupérer ou non les brouillons https://github.com/opendatateam/udata/pull/3265. On utilise donc l'API en mode `authenticated` pour récupérer les brouillons.