### PR TITLE
fix: handle multiple contact points

### DIFF
--- a/src/components/datasets/ExtendedInformationPanel.vue
+++ b/src/components/datasets/ExtendedInformationPanel.vue
@@ -9,8 +9,7 @@ const props = defineProps({
   }
 })
 
-const dcatExtras: Record<string, string[] | undefined> | undefined =
-  props.dataset.extras?.dcat
+const dcatExtras = props.dataset.extras?.dcat
 const uri: string | undefined = props.dataset.harvest?.uri
 
 const contactPoints = props.dataset.contact_points

--- a/src/components/datasets/ExtendedInformationPanel.vue
+++ b/src/components/datasets/ExtendedInformationPanel.vue
@@ -9,16 +9,17 @@ const props = defineProps({
   }
 })
 
-const contactPoints = props.dataset.contact_points
 const dcatExtras: Record<string, string[] | undefined> | undefined =
   props.dataset.extras?.dcat
 const uri: string | undefined = props.dataset.harvest?.uri
 
-const formattedContactPoints = contactPoints.map((contactPoint) => {
-  return contactPoint.email
-    ? `<a href="mailto:${contactPoint.email}">${contactPoint.name}</a>`
-    : contactPoint.name
-})
+const contactPoints = props.dataset.contact_points
+  .filter((contactPoint) => contactPoint.role === 'contact')
+  .map((contactPoint) => {
+    return contactPoint.email
+      ? `<a href="mailto:${contactPoint.email}">${contactPoint.name}</a>`
+      : contactPoint.name
+  })
 
 const hasExtendedInfo = contactPoints.length > 0 || !!dcatExtras || !!uri
 </script>
@@ -44,7 +45,7 @@ const hasExtendedInfo = contactPoints.length > 0 || !!dcatExtras || !!uri
         title="Généalogie"
       />
       <ExtendedInformationPanelItem
-        :items="formattedContactPoints"
+        :items="contactPoints"
         title="Points de contact"
       />
     </div>

--- a/src/components/datasets/ExtendedInformationPanel.vue
+++ b/src/components/datasets/ExtendedInformationPanel.vue
@@ -9,11 +9,18 @@ const props = defineProps({
   }
 })
 
-const contactPoint = props.dataset.contact_point
-const dcatExtras = props.dataset.extras?.dcat
-const uri = props.dataset.harvest?.uri
+const contactPoints = props.dataset.contact_points
+const dcatExtras: Record<string, string[] | undefined> | undefined =
+  props.dataset.extras?.dcat
+const uri: string | undefined = props.dataset.harvest?.uri
 
-const hasExtendedInfo = !!contactPoint || !!dcatExtras || !!uri
+const formattedContactPoints = contactPoints.map((contactPoint) => {
+  return contactPoint.email
+    ? `<a href="mailto:${contactPoint.email}">${contactPoint.name}</a>`
+    : contactPoint.name
+})
+
+const hasExtendedInfo = contactPoints.length > 0 || !!dcatExtras || !!uri
 </script>
 
 <template>
@@ -29,19 +36,17 @@ const hasExtendedInfo = !!contactPoint || !!dcatExtras || !!uri
         title="Identifiant de ressource unique"
       />
       <ExtendedInformationPanelItem
-        :items="dcatExtras.accessRights"
+        :items="dcatExtras?.accessRights"
         title="Conditions d'accès et d'utilisation"
       />
       <ExtendedInformationPanelItem
-        :items="dcatExtras.provenance"
+        :items="dcatExtras?.provenance"
         title="Généalogie"
       />
-      <div v-if="contactPoint">
-        <h3 class="subtitle fr-mb-2v">Point de contact</h3>
-        <p class="fr-text--sm fr-m-0">
-          <a :href="`mailto:${contactPoint.email}`">{{ contactPoint.name }}</a>
-        </p>
-      </div>
+      <ExtendedInformationPanelItem
+        :items="formattedContactPoints"
+        title="Points de contact"
+      />
     </div>
   </div>
 </template>

--- a/src/components/datasets/ExtendedInformationPanelItem.vue
+++ b/src/components/datasets/ExtendedInformationPanelItem.vue
@@ -10,7 +10,7 @@ defineProps<Props>()
 </script>
 
 <template>
-  <div v-if="items" class="fr-mb-3w">
+  <div v-if="items && items.length > 0" class="fr-mb-3w">
     <h3 class="subtitle fr-mb-2v">{{ title }}</h3>
     <ul v-if="items.length > 1" class="fr-mb-0">
       <!-- eslint-disable-next-line vue/no-v-html -->

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -23,4 +23,8 @@ interface ContactPoint {
 
 export type ExtendedDatasetV2 = DatasetV2 & {
   contact_points: ContactPoint[]
+  extras: {
+    [key: string]: unknown
+    dcat?: Record<string, string[] | undefined>
+  }
 }

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -14,12 +14,13 @@ export interface DatasetModalData {
   mode: 'edit' | 'create'
 }
 
-export interface ContactPoint {
-  id: string
+interface ContactPoint {
   name: string
-  email: string
+  email?: string
+  contact_form?: string
+  role: string
 }
 
 export type ExtendedDatasetV2 = DatasetV2 & {
-  contact_point?: ContactPoint
+  contact_points: ContactPoint[]
 }


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/534

data.gouv.fr expose maintenant (fait en démo, en prod d'ici fin de semaine) les points de contact sous forme de liste https://github.com/opendatateam/udata/pull/3149.

Cette PR permet de gérer une liste vs un item unique.

data.gouv.fr introduit aussi une notion de `role`. Pour l'instant (iso-fonctionnel), on n'affiche que `role == contact`. Vu avec data.gouv.fr, se synchroniser pour voir le traitement sur les autres rôles.

Au passage :
- meilleur typage de `dcatExtras` (crash sur `service-de-force-de-securite-2` fixé)
- meilleur typage du `contactPoint` en fonction du modèle udata

Exemples :
- `point-numerique-cc-grand-chambord`
- `5808de39c751df1e0679df72`
- `67b42e2a11a9813d380bbd5b` (multiple)