### PR TITLE
Remove un-used "levier" from config.yaml

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -320,96 +320,34 @@ indicators:
       id: levier
       color: green-archipel
       values:
-        - id: 2-roues-elec-efficacite
-          name: 2 roues (élec&efficacité)
-        - id: bio-carburants
-          name: Bio-carburants
         - id: biogaz
           name: Biogaz
-        - id: bus-et-cars-decarbones
-          name: Bus et cars décarbonés
-        - id: batiments-machines-agricoles
-          name: Bâtiments & Machines agricoles
-        - id: captage-de-methane-dans-les-isdnd
-          name: Captage de méthane dans les ISDND
-        - id: changement-chaudieres-fioul-renovation-residentiel
-          name: Changement chaudières fioul + rénovation (résidentiel)
-        - id: changement-chaudieres-fioul-renovation-tertiaire
-          name: Changement chaudières fioul + rénovation (tertiaire)
-        - id: changement-chaudieres-gaz-renovation-residentiel
-          name: Changement chaudières gaz + rénovation (résidentiel)
-        - id: changement-chaudieres-gaz-renovation-tertiaire
-          name: Changement chaudières gaz + rénovation (tertiaire)
         - id: changements-de-pratiques-de-fertilisation-azotee
           name: Changements de pratiques de fertilisation azotée
         - id: covoiturage
           name: Covoiturage
-        - id: desimpermeabilisation-des-sols
-          name: Désimperméabilisation des sols
         - id: developpement-de-lagriculture-biologique-et-de-hve
           name: Développement de l'agriculture biologique et de HVE
-        - id: efficacite-des-aeronefs
-          name: Efficacité des aéronefs
         - id: efficacite-et-sobriete-logistique
           name: Efficacité et sobriété logistique
-        - id: efficacite-energetique-des-vehicules-prives
-          name: Efficacité énergétique des véhicules privés
-        - id: electricite-renouvelable
-          name: Electricité renouvelable
-        - id: elevage-durable
-          name: Elevage durable
-        - id: fret-decarbone-et-multimodalite
-          name: Fret décarboné et multimodalité
-        - id: gaz-fluores-residentiel
-          name: Gaz fluorés résidentiel
-        - id: gaz-fluores-tertiaire
-          name: Gaz fluorés tertiaire
-        - id: gestion-des-forets-et-produits-bois
-          name: Gestion des forêts et produits bois
-        - id: gestion-des-haies
-          name: Gestion des haies
         - id: gestion-des-prairies
           name: Gestion des prairies
-        - id: industrie-diffuse
-          name: Industrie diffuse
-        - id: moindre-stockage-en-decharge
-          name: Moindre stockage en décharge
-        - id: nucleaire
-          name: Nucléaire
         - id: pratiques-stockantes
           name: Pratiques stockantes
-        - id: protection-des-zones-de-captage-deau
-          name: Protection des zones de captage d'eau
         - id: prevention-des-dechets
           name: Prévention des déchets
-        - id: respect-degalim-pour-la-restauration-collective
-          name: Respect d'Egalim pour la restauration collective
-        - id: restauration-des-habitats-naturels
-          name: Restauration des habitats naturels
-        - id: reduction-de-lusage-des-produits-phytosanitaires
-          name: Réduction de l'usage des produits phytosanitaires
         - id: reduction-des-deplacements
           name: Réduction des déplacements
         - id: renovation-hors-changement-chaudieres
           name: Rénovation (hors changement chaudières)
-        - id: reseaux-de-chaleur-decarbones
-          name: Réseaux de chaleur décarbonés
-        - id: resorption-des-points-noirs-prioritaires-de-continuite-ecologique
-          name: Résorption des points noirs prioritaires de continuité écologique
-        - id: saf
-          name: SAF
         - id: sobriete-dans-lutilisation-de-la-ressource-en-eau
           name: Sobriété dans l'utilisation de la ressource en eau
         - id: sobriete-des-batiments-residentiel
           name: Sobriété des bâtiments (résidentiel)
-        - id: sobriete-des-batiments-tertiaire
-          name: Sobriété des bâtiments (tertiaire)
         - id: sobriete-fonciere
           name: Sobriété foncière
         - id: surface-en-aire-protegee
           name: Surface en aire protégée
-        - id: top-50-sites-industriels
-          name: Top 50 sites industriels
         - id: transports-en-commun
           name: Transports en commun
         - id: valorisation-matiere-des-dechets


### PR DESCRIPTION
We decided not to display in the list of "levier" the ones that were not yet associated to an indicator in order to improve the user search experience on the website.

I left only 18 leviers that were already attached to an indicator