### PR TITLE
chore(logistique): themes as tags

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
-VITE_SITE_ID=ecospheres
+# VITE_SITE_ID=ecospheres
 # VITE_SITE_ID=meteo-france
 # VITE_SITE_ID=defis
 # VITE_SITE_ID=simplification
+VITE_SITE_ID=logistique

--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
-# VITE_SITE_ID=ecospheres
+VITE_SITE_ID=ecospheres
 # VITE_SITE_ID=meteo-france
 # VITE_SITE_ID=defis
 # VITE_SITE_ID=simplification
-VITE_SITE_ID=logistique
+# VITE_SITE_ID=hackathon
+# VITE_SITE_ID=logistique

--- a/configs/logistique/config.yaml
+++ b/configs/logistique/config.yaml
@@ -165,6 +165,7 @@ website:
     can_add_topics:
       everyone: yes
 
+# cf configs/ecospheres/config.yaml for filters config format details
 filters:
   bouquets:
     tag_prefix: logistique

--- a/configs/logistique/config.yaml
+++ b/configs/logistique/config.yaml
@@ -67,7 +67,7 @@ website:
         sub_section_buttons:
     meta_description:
   header_button:
-    display: true
+    display: false
     label: 'Donnez votre avis'
     link:
   header_search:

--- a/configs/logistique/config.yaml
+++ b/configs/logistique/config.yaml
@@ -164,49 +164,92 @@ website:
     dataset_editorialization: true
     can_add_topics:
       everyone: yes
-themes:
-  - name: Immobilier logistique
-    color: '#043574'
-    textColor: '#FFFFFF'
-    subthemes:
-      - name: Général
-  - name: Infrastructure
-    color: '#043574'
-    textColor: '#FFFFFF'
-    subthemes:
-      - name: Général
-  - name: Trafic
-    color: '#043574'
-    textColor: '#FFFFFF'
-    subthemes:
-      - name: Général
-      - name: Transport routier
-      - name: Transport aérien
-      - name: Transport ferroviaire
-      - name: Transport fluvial
-      - name: Transport maritime
-  - name: Filières
-    color: '#043574'
-    textColor: '#FFFFFF'
-    subthemes:
-      - name: Général
-      - name: Filière agricole
-      - name: Filière industrielle
-      - name: Filière énergétique
-      - name: Filière pharmaceutique
-      - name: Filière commerce
-      - name: Filière matériaux de construction
-      - name: Filière matière premières
-  - name: Environnement
-    color: '#043574'
-    textColor: '#FFFFFF'
-    subthemes:
-      - name: Général
-  - name: Socio-économique
-    color: '#043574'
-    textColor: '#FFFFFF'
-    subthemes:
-      - name: Général
+
+filters:
+  bouquets:
+    tag_prefix: logistique
+    items:
+      - name: Catégorie
+        id: theme
+        child: subtheme
+        color: green-bourgeon
+        values:
+          - id: immobilier-logistique
+            name: Immobilier logistique
+          - id: infrastructure
+            name: Infrastructure
+          - id: trafic
+            name: Trafic
+          - id: filieres
+            name: Filières
+          - id: environnement
+            name: Environnement
+          - id: socio-economique
+            name: Socio-économique
+      - name: Sous-catégorie
+        id: subtheme
+        color: blue-ecume
+        values:
+          # immobilier-logistique
+          - id: immobilier-logistique-general
+            name: Général
+            parent: immobilier-logistique
+          # infrastructure
+          - id: infrastructure-general
+            name: Général
+            parent: infrastructure
+          # trafic
+          - id: trafic-general
+            name: Général
+            parent: trafic
+          - id: transport-routier
+            name: Transport routier
+            parent: trafic
+          - id: transport-aerien
+            name: Transport aérien
+            parent: trafic
+          - id: transport-ferroviaire
+            name: Transport ferroviaire
+            parent: trafic
+          - id: transport-fluvial
+            name: Transport fluvial
+            parent: trafic
+          - id: transport-maritime
+            name: Transport maritime
+            parent: trafic
+          # filieres
+          - id: filieres-general
+            name: Général
+            parent: filieres
+          - id: filiere-agricole
+            name: Filière agricole
+            parent: filieres
+          - id: filiere-industrielle
+            name: Filière industrielle
+            parent: filieres
+          - id: filiere-energetique
+            name: Filière énergétique
+            parent: filieres
+          - id: filiere-pharmaceutique
+            name: Filière pharmaceutique
+            parent: filieres
+          - id: filiere-commerce
+            name: Filière commerce
+            parent: filieres
+          - id: filiere-materiaux-de-construction
+            name: Filière matériaux de construction
+            parent: filieres
+          - id: filiere-matieres-premiere
+            name: Filière matières premières
+            parent: filieres
+          # environnement
+          - id: environnement-general
+            name: Général
+            parent: environnement
+          # socio-economique
+          - id: socio-economique-general
+            name: Général
+            parent: socio-economique
 
 # list of organisations' ids that should be handled by the portal
 # to find an id go to https://www.data.gouv.fr/fr/organizations/ministere-de-la-transition-ecologique/


### PR DESCRIPTION
Depends on https://github.com/opendatateam/udata-front-kit/pull/661

Conversion des thèmes en tags après passage du script de migration https://github.com/ecolabdata/ecospheres-scripts/pull/17.

Cf la discussion sur les couleurs des tags et l'affichage du thème dans la carte https://github.com/opendatateam/udata-front-kit/pull/661#discussion_r1990897936. Dans le cas de logistique, je trouve que ça marche bien.

<img width="1039" alt="Capture d’écran 2025-03-13 à 14 33 37" src="https://github.com/user-attachments/assets/149306cd-54c4-4d77-add4-25d4ee5d18dc" />
