### PR TITLE
feat(ecospheres/datasets): add inspire themes filter

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -227,7 +227,7 @@ filters:
     universe_tag:
     tag_prefix:
     items:
-      - name: Thème Inspire
+      - name: Thème INSPIRE
         default_option: Tous les thèmes
         id: inspire
         color: noop

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -222,11 +222,87 @@ organizations: https://raw.githubusercontent.com/ecolabdata/ecospheres-universe/
 #             name: {string}     # name of the value
 #             parent: {string?}  # id of the parent filter value (optional)
 filters:
-  # DATASETS (dummy)
+  # DATASETS
   datasets:
     universe_tag:
     tag_prefix:
-    items: []
+    items:
+      - name: Thème Inspire
+        default_option: Tous les thèmes
+        id: inspire
+        color: noop
+        use_tag_prefix: false
+        values:
+          - id: adresses
+            name: Adresses
+          - id: altitude
+            name: Altitude
+          - id: conditions-atmospheriques
+            name: Conditions atmosphériques
+          - id: batiments
+            name: Bâtiments
+          - id: caracteristiques-geographiques-meteorologiques
+            name: Caractéristiques géographiques météorologiques
+          - id: caracteristiques-geographiques-oceanographiques
+            name: Caractéristiques géographiques océanographiques
+          - id: conditions-atmospheriques
+            name: Conditions atmosphériques
+          - id: denominations-geographiques
+            name: Dénominations géographiques
+          - id: geologie
+            name: Géologie
+          - id: habitats-et-biotopes
+            name: Habitats et biotopes
+          - id: hydrographie
+            name: Hydrographie
+          - id: installations-agricoles-et-aquacoles
+            name: Installations agricoles et aquacoles
+          - id: installations-de-suivi-environnemental
+            name: Installations de suivi environnemental
+          - id: lieux-de-production-et-sites-industriels
+            name: Lieux de production et sites industriels
+          - id: occupation-des-terres
+            name: Occupation des terres
+          - id: ortho-imagerie
+            name: Ortho-imagerie
+          - id: parcelles-cadastrales
+            name: Parcelles cadastrales
+          - id: ressources-minerales
+            name: Ressources minérales
+          - id: referentiels-de-coordonnees
+            name: Référentiels de coordonnées
+          - id: regions-biogeographiques
+            name: Régions biogéographiques
+          - id: regions-maritimes
+            name: Régions maritimes
+          - id: repartition-de-la-population-demographie
+            name: Répartition de la population — démographie
+          - id: repartition-des-especes
+            name: Répartition des espèces
+          - id: reseaux-de-transport
+            name: Réseaux de transport
+          - id: sante-et-securite-des-personnes
+            name: Santé et sécurité des personnes
+          - id: services-dutilite-publique-et-services-publics
+            name: Services d'utilité publique et services publics
+          - id: sites-proteges
+            name: Sites protégés
+          - id: sols
+            name: Sols
+          - id: sources-denergie
+            name: Sources d'énergie
+          - id: systemes-de-maillage-geographique
+            name: Systèmes de maillage géographique
+          - id: unites-administratives
+            name: Unités administratives
+          - id: unites-statistiques
+            name: Unités statistiques
+          - id: usage-des-sols
+            name: Usage des sols
+          - id: zones-de-gestion-de-restriction-ou-de-reglementation-et-unites-de-declaration
+            name: Zones de gestion, de restriction ou de réglementation et unités de déclaration
+          - id: zones-a-risque-naturel
+            name: Zones à risque naturel
   # BOUQUETS
   bouquets:
     universe_tag:

--- a/src/components/datasets/DatasetList.vue
+++ b/src/components/datasets/DatasetList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import NoResults from '@/components/NoResults.vue'
-import { useSearchStore } from '@/store/SearchStore'
+import { useSearchStore } from '@/store/DatasetSearchStore'
 import { useFiltersConf } from '@/utils/config'
 import { DatasetCard } from '@datagouv/components'
 import { storeToRefs } from 'pinia'

--- a/src/store/DatasetSearchStore.ts
+++ b/src/store/DatasetSearchStore.ts
@@ -13,7 +13,6 @@ const searchAPI = new SearchAPI()
 const filtersConf = useFiltersConf('datasets')
 
 interface QueryArgs {
-  // [key: string]: string | number
   query: string
   page: string
 }


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/550

Ajoute un filtre sur les thèmes Inspire pour les jeux de données de ecologie.data.gouv.fr.

Les thèmes proviennent de https://inspire.ec.europa.eu/theme/theme.fr.json, le tag est construit en passant le `slugify` de data.gouv.fr sur le `label.text` (équivalent à ce qui est fait au moissonnage).

<img width="1263" alt="Capture d’écran 2025-03-28 à 11 40 42" src="https://github.com/user-attachments/assets/d8085da8-3045-40b6-aecb-b61c9dab8390" />
