### PR TITLE
fix: allow pr previews only from same repo

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -18,7 +18,8 @@ jobs:
           - logistique
     permissions:
       deployments: write
-    if: github.event_name == 'pull_request'
+    # only run if the PR is from the same repo
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request'
     steps:
       - name: Cloning repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Sans cela, trop facile d'injecter un payload malicieux depuis n'importe quel repo.