### PR TITLE
fix: destroy review app on PR close

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -2,7 +2,9 @@
 
 name: Deploy review app
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
   handle_review_app:

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -39,7 +39,7 @@ jobs:
           transient-environment: true
 
       - name: Create the review app
-        if: github.event.action == 'opened'
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
         uses: dokku/github-action@master
         with:
           command: review-apps:create
@@ -71,7 +71,7 @@ jobs:
           branch: 'main'
 
       - name: Enable SSL with Let's Encrypt
-        if: github.event.action == 'opened'
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.REVIEW_APP_SSH_HOST }}


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/553

Il semblerait qu'il faille expliciter les événements `pull_request` pour être certain d'attraper le `closed` 🤷 🍿 🤞. 