### PR TITLE
feat(ecologie): home page and banner color 🟦 

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -341,7 +341,6 @@ pages:
         default_option: Toutes les thématiques
         id: theme
         type: select
-        child: subtheme
         color: green-emeraude
         use_tag_prefix: true
         # TODO: use a dedicated config for the form?

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -341,6 +341,7 @@ pages:
         default_option: Toutes les thématiques
         id: theme
         type: select
+        child: subtheme
         color: green-emeraude
         use_tag_prefix: true
         # TODO: use a dedicated config for the form?

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -173,6 +173,25 @@ body {
 }
 
 /* overload datagouv-components */
+
+// datagouv-components applies `color: inherit` to titles, we want the title color
+.datagouv-components {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  .h1,
+  .h2,
+  .h3,
+  .h4,
+  .h5,
+  .h6 {
+    color: var(--text-title-grey);
+  }
+}
+
 .datagouv-components h3.fr-accordion__title {
   margin-bottom: 0;
 }

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -228,7 +228,7 @@ body {
 }
 
 .hero-banner {
-  background: #f3f3f3;
+  background-color: var(--background-alt-blue-cumulus);
   p:last-child {
     margin-bottom: 0;
   }

--- a/src/custom/ecospheres/views/HomeView.vue
+++ b/src/custom/ecospheres/views/HomeView.vue
@@ -125,7 +125,7 @@ const dropdown = config.website.header_search.dropdown
         </li>
       </ul>
     </section>
-    <section class="fr-container--fluid bg-grey fr-py-16v">
+    <section class="fr-container--fluid bg-green fr-py-16v">
       <div class="fr-container">
         <h2>Les bouquets à découvrir</h2>
         <ul class="fr-grid-row discover fr-mb-2w" role="list">
@@ -157,8 +157,8 @@ const dropdown = config.website.header_search.dropdown
 </template>
 
 <style scoped>
-.bg-grey {
-  background-color: var(--background-alt-grey);
+.bg-green {
+  background-color: var(--background-alt-green-emeraude);
 }
 
 .faq {

--- a/src/custom/ecospheres/views/HomeView.vue
+++ b/src/custom/ecospheres/views/HomeView.vue
@@ -125,7 +125,7 @@ const dropdown = config.website.header_search.dropdown
         </li>
       </ul>
     </section>
-    <section class="fr-container--fluid bg-green fr-py-16v">
+    <section class="fr-container--fluid bg-blue fr-py-16v">
       <div class="fr-container">
         <h2>Les bouquets à découvrir</h2>
         <ul class="fr-grid-row discover fr-mb-2w" role="list">
@@ -157,8 +157,8 @@ const dropdown = config.website.header_search.dropdown
 </template>
 
 <style scoped>
-.bg-green {
-  background-color: var(--background-alt-green-emeraude);
+.bg-blue {
+  background-color: var(--background-alt-blue-cumulus);
 }
 
 .faq {


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/558
Pending https://github.com/ecolabdata/ecospheres/issues/551

Ajoute un fond ~~vert~~ bleu sur la section bouquets de la HP, ainsi que sur les différents bandeaux. Corrige aussi le noir des titres (à passer quoiqu'il arrive).