### PR TITLE
chore(ecologie): themes list labels coherence

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -347,18 +347,18 @@ pages:
         form:
           required: true
         values:
-          - id: se-loger
-            name: Mieux se loger
-          - id: produire
-            name: Mieux produire
-          - id: se-nourrir
-            name: Mieux se nourrir
           - id: consommer
             name: Mieux consommer
+          - id: produire
+            name: Mieux produire
           - id: preserver
             name: Mieux préserver et valoriser nos ecosystèmes
           - id: se-deplacer
             name: Mieux se déplacer
+          - id: se-loger
+            name: Mieux se loger
+          - id: se-nourrir
+            name: Mieux se nourrir
           - id: chantiers-transverses
             name: Autre
       - name: Couverture territoriale
@@ -397,8 +397,6 @@ pages:
         color: green-menthe
         use_tag_prefix: true
         values:
-          - id: autre
-            name: Autre
           - id: mieux-consommer
             name: Mieux consommer
           - id: mieux-produire
@@ -411,6 +409,8 @@ pages:
             name: Mieux se loger
           - id: mieux-se-nourrir
             name: Mieux se nourrir
+          - id: autre
+            name: Autre
       - name: Enjeu
         default_option: Tous les enjeux
         id: enjeu

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -170,6 +170,24 @@ website:
 
 organizations: https://raw.githubusercontent.com/ecolabdata/ecospheres-universe/refs/heads/main/dist/organizations-demo.json
 
+# shared themes list for indicators and bouquets
+definitions: &definitions
+  fnv_themes: &fnv_themes
+    - id: mieux-consommer
+      name: Mieux consommer
+    - id: mieux-produire
+      name: Mieux produire
+    - id: mieux-preserver-valoriser-ecosystemes
+      name: Mieux préserver et valoriser nos ecosystèmes
+    - id: mieux-se-deplacer
+      name: Mieux se déplacer
+    - id: mieux-se-loger
+      name: Mieux se loger
+    - id: mieux-se-nourrir
+      name: Mieux se nourrir
+    - id: autre
+      name: Autre
+
 # Configuration format for pages:
 #
 # pages:
@@ -346,21 +364,7 @@ pages:
         # TODO: use a dedicated config for the form?
         form:
           required: true
-        values:
-          - id: consommer
-            name: Mieux consommer
-          - id: produire
-            name: Mieux produire
-          - id: preserver
-            name: Mieux préserver et valoriser nos ecosystèmes
-          - id: se-deplacer
-            name: Mieux se déplacer
-          - id: se-loger
-            name: Mieux se loger
-          - id: se-nourrir
-            name: Mieux se nourrir
-          - id: chantiers-transverses
-            name: Autre
+        values: *fnv_themes
       - name: Couverture territoriale
         default_option:
         id: geozone
@@ -396,21 +400,7 @@ pages:
         type: select
         color: green-menthe
         use_tag_prefix: true
-        values:
-          - id: mieux-consommer
-            name: Mieux consommer
-          - id: mieux-produire
-            name: Mieux produire
-          - id: mieux-preserver-valoriser-ecosystemes
-            name: Mieux préserver et valoriser nos ecosystèmes
-          - id: mieux-se-deplacer
-            name: Mieux se déplacer
-          - id: mieux-se-loger
-            name: Mieux se loger
-          - id: mieux-se-nourrir
-            name: Mieux se nourrir
-          - id: autre
-            name: Autre
+        values: *fnv_themes
       - name: Enjeu
         default_option: Tous les enjeux
         id: enjeu

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -348,19 +348,19 @@ pages:
           required: true
         values:
           - id: se-loger
-            name: Se loger
+            name: Mieux se loger
           - id: produire
-            name: Produire
+            name: Mieux produire
           - id: se-nourrir
-            name: Se nourrir
+            name: Mieux se nourrir
           - id: consommer
-            name: Consommer
+            name: Mieux consommer
           - id: preserver
-            name: Préserver
+            name: Mieux préserver et valoriser nos ecosystèmes
           - id: se-deplacer
-            name: Se déplacer
+            name: Mieux se déplacer
           - id: chantiers-transverses
-            name: Chantiers transverses
+            name: Autre
       - name: Couverture territoriale
         default_option:
         id: geozone


### PR DESCRIPTION
Reprend les labels des thématiques des indicateurs (sans changer les identifiants, pour éviter une migration des tags). Reprend aussi l'ordre des indicateurs, sauf "Autre" qui passe en bas des deux listes.

Fix https://github.com/ecolabdata/ecospheres/issues/552