### PR TITLE
fix(topic): clone button visibility

### DIFF
--- a/src/views/topics/TopicDetailView.vue
+++ b/src/views/topics/TopicDetailView.vue
@@ -57,8 +57,7 @@ const userStore = useUserStore()
 const canEdit = computed(() => {
   return userStore.hasEditPermissions(topic.value)
 })
-const { canAddTopic } = storeToRefs(userStore)
-const isAdmin = computed(() => userStore.isAdmin)
+const { isAdmin, canAddTopic } = storeToRefs(userStore)
 
 const { pageKey, pageConf } = useCurrentPageConf()
 const showDiscussions = pageConf.discussions.display

--- a/src/views/topics/TopicDetailView.vue
+++ b/src/views/topics/TopicDetailView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { OrganizationNameWithCertificate, ReadMore } from '@datagouv/components'
 import { useHead } from '@unhead/vue'
+import { storeToRefs } from 'pinia'
 import type { Ref } from 'vue'
 import { computed, inject, ref, watch } from 'vue'
 import { useLoading } from 'vue-loading-overlay'
@@ -51,10 +52,13 @@ const setAccessibilityProperties = inject(
 ) as AccessibilityPropertiesType
 
 const description = computed(() => descriptionFromMarkdown(topic))
+
+const userStore = useUserStore()
 const canEdit = computed(() => {
-  return useUserStore().hasEditPermissions(topic.value)
+  return userStore.hasEditPermissions(topic.value)
 })
-const isAdmin = computed(() => useUserStore().isAdmin)
+const { canAddTopic } = storeToRefs(userStore)
+const isAdmin = computed(() => userStore.isAdmin)
 
 const { pageKey, pageConf } = useCurrentPageConf()
 const showDiscussions = pageConf.discussions.display
@@ -265,6 +269,7 @@ watch(
             class="fr-mt-1v fr-col-auto fr-grid-row fr-grid-row--middle flex-gap"
           >
             <DsfrButton
+              v-if="canAddTopic"
               secondary
               size="md"
               label="Cloner"


### PR DESCRIPTION
Depuis https://github.com/opendatateam/udata-front-kit/pull/745, le bouton "Cloner" est visible par tous sur ecologie.data.gouv.fr, sans même être connecté.

Toutefois, l'affichage du bouton Cloner doit être conditionné au fait que la configuration du site permet d'ajouter des Topics.