### PR TITLE
docs: update docs about deployment

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -20,6 +20,7 @@ jobs:
           - logistique
           # - defis
           # - hackathon
+          # - simplifions
     permissions:
       deployments: write
     # only run if the PR is from the same repo

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Le déploiement des verticales thématiques s'effectue via un workflow GitHub qu
 ```
 
 **Paramètres :**
-- **ENV** : `prod` ou `demo`
+- **ENV** : `prod` ou, soit `demo` soit `preprod` suivant la verticale
 - **CONFIG_NAME** : nom de la configuration (actuellement `ecologie`, `meteo`, `defis` ou `simplifions`)
 - **VERSION_PART** : `major`, `minor` ou `patch`
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Plus précisément, le [workflow de déploiement](.github/workflows/create-deplo
 4. **Création et push d'un nouveau tag** selon la partie de version spécifiée
 5. **Déclenchement d'un pipeline GitLab CI/CD**
 
+**Note** : Pour cette raison il n'est pas encore possible de suivre le détail de l'avancement du déploiement directement depuis GitHub Actions (#TODO)
+
 ## Librairies et plugins utilisés
 
 ### Librairies

--- a/README.md
+++ b/README.md
@@ -64,6 +64,51 @@ npm run hint
 npm run format
 ```
 
+## Déploiement
+
+### Workflow GitHub pour le déploiement
+
+Le déploiement des verticales thématiques s'effectue via un workflow GitHub qui se déclenche automatiquement à partir du message de commit. Le format du message de commit doit être :
+
+```
+[<env>:<config_name>:<version_part>] <description>
+```
+
+**Paramètres :**
+- **ENV** : `prod` ou `demo`
+- **CONFIG_NAME** : nom de la configuration (actuellement `ecologie`, `meteo`, `defis` ou `simplifions`)
+- **VERSION_PART** : `major`, `minor` ou `patch`
+
+**Exemple :**
+```
+[prod:ecologie:minor] nouvelle fonctionnalité incroyable
+```
+
+Le workflow se déclenche sur tous les push vers toutes les branches, mais ne s'exécute que si le message de commit commence par `[` (condition `startsWith(github.event.head_commit.message, '[')`). Cette condition n'est pas parfaite mais GitHub Actions ne supporte pas directement le déclenchement de workflows basé sur des expressions régulières dans les messages de commit.
+
+Toutes les variables et secrets nécessaires pour ce workflow sont listés dans la section `env:` du [workflow de déploiement](.github/workflows/create-deploy-release.yml).
+
+### Actions du workflow
+
+Le workflow est responsable de :
+
+1. **Configuration de l'environnement** : variables et accès aux dépôts
+2. **Clonage des dépôts** : scaffolding et application
+3. **Récupération de la configuration** basée sur le message de commit
+4. **Création et push d'un nouveau tag** selon la partie de version spécifiée
+5. **Déclenchement d'un pipeline GitLab CI/CD**
+
+Le tag créé sera utilisé lors de la construction de l'image et pendant le déploiement.
+
+### Architecture de déploiement
+
+Pour des raisons de sécurité, le déploiement est effectué par un dépôt privé GitLab dédié à l'infrastructure. Le processus fonctionne en deux étapes :
+
+1. **GitHub Actions** : Les commits sur GitHub déclenchent le workflow qui fait des appels à l'API GitLab via un script téléchargé depuis le dépôt "scaffolding"
+2. **GitLab CI/CD** : Le script déclenche ensuite le pipeline de déploiement sur GitLab
+
+**Note** : Pour cette raison il n'est pas possible de suivre le détail de l'avancement du déploiement directement depuis GitHub Actions.
+
 ## Librairies et plugins utilisés
 
 ### Librairies

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Le déploiement des verticales thématiques s'effectue via un workflow GitHub qu
 ```
 
 **Paramètres :**
-- **ENV** : `prod` ou, soit `demo` soit `preprod` suivant la verticale
+- **ENV** : `prod` ou `demo`/`preprod` suivant la verticale
 - **CONFIG_NAME** : nom de la configuration (actuellement `ecologie`, `meteo`, `defis` ou `simplifions`)
 - **VERSION_PART** : `major`, `minor` ou `patch`
 
@@ -88,26 +88,21 @@ Le workflow se déclenche sur tous les push vers toutes les branches, mais ne s'
 
 Toutes les variables et secrets nécessaires pour ce workflow sont listés dans la section `env:` du [workflow de déploiement](.github/workflows/create-deploy-release.yml).
 
-### Actions du workflow
-
-Le workflow est responsable de :
-
-1. **Configuration de l'environnement** : variables et accès aux dépôts
-2. **Clonage des dépôts** : scaffolding et application
-3. **Récupération de la configuration** basée sur le message de commit
-4. **Création et push d'un nouveau tag** selon la partie de version spécifiée
-5. **Déclenchement d'un pipeline GitLab CI/CD**
-
-Le tag créé sera utilisé lors de la construction de l'image et pendant le déploiement.
+Le tag créé est utilisé lors de la construction de l'image et pendant le déploiement.
 
 ### Architecture de déploiement
 
-Pour des raisons de sécurité, le déploiement est effectué par un dépôt privé GitLab dédié à l'infrastructure. Le processus fonctionne en deux étapes :
+Pour des raisons de sécurité, le déploiement est effectué par un dépôt privé GitLab dédié à l'infrastructure. Le processus fonctionne en deux temps :
 
 1. **GitHub Actions** : Les commits sur GitHub déclenchent le workflow qui fait des appels à l'API GitLab via un script téléchargé depuis le dépôt "scaffolding"
 2. **GitLab CI/CD** : Le script déclenche ensuite le pipeline de déploiement sur GitLab
 
-**Note** : Pour cette raison il n'est pas possible de suivre le détail de l'avancement du déploiement directement depuis GitHub Actions.
+Plus précisément, le [workflow de déploiement](.github/workflows/create-deploy-release.yml) est responsable de :
+1. **Configuration de l'environnement** : variables et accès aux dépôts
+2. **Clonage du dépôt "scaffolding" du script d'appel à l'infrastructure**
+3. **Récupération de la configuration** basée sur le message de commit
+4. **Création et push d'un nouveau tag** selon la partie de version spécifiée
+5. **Déclenchement d'un pipeline GitLab CI/CD**
 
 ## Librairies et plugins utilisés
 


### PR DESCRIPTION
# Add deployment section to README

## Description

Adds a comprehensive deployment section to document the automated deployment process for thematic verticals.

## Context

Some users of this repository expressed confusion about how to deploy and how the deployment process works. This PR addresses those questions by providing clear documentation.

## Changes

- **New "Déploiement" section** explaining the GitHub workflow triggered by commit message format
- **Deployment parameters** documentation (ENV, CONFIG_NAME, VERSION_PART)
- **Commit message format** with example: `[prod:ecologie:minor] new feature`
- **Workflow steps** and **deployment architecture** (GitHub → GitLab for security)
- **Direct link** to workflow file and **deployment tracking limitations**

## Key points

- Automatic deployment triggered by commit message format
- Secure architecture with GitHub (code) / GitLab (infrastructure) separation
- Deployment tracking only available via GitLab interface
- Supports configurations: `ecologie`, `meteo`, `defis`, `simplifions`