### PR TITLE
fix(rgaa): topic add form error block

### DIFF
--- a/src/components/forms/ErrorSummary.vue
+++ b/src/components/forms/ErrorSummary.vue
@@ -21,10 +21,11 @@ defineProps({
   <div
     v-show="formErrors.length"
     class="fr-my-4w fr-p-2w error-status"
-    role="group"
+    role="alert"
     aria-labelledby="error-summary-title"
+    tabindex="-1"
   >
-    <component :is="headingLevel" id="error-summary-title" tabindex="-1">
+    <component :is="headingLevel" id="error-summary-title">
       Il y a {{ formErrors.length }} erreur<span v-if="formErrors.length > 1"
         >s</span
       >

--- a/src/views/topics/TopicFormView.vue
+++ b/src/views/topics/TopicFormView.vue
@@ -180,11 +180,11 @@ const onSubmit = async () => {
   await formFields.value.onSubmit()
   if (formErrors.value.length > 0) {
     setTimeout(() => {
+      errorSummary.value.$el.focus({ preventScroll: true })
       errorSummary.value.$el.scrollIntoView({
         behavior: 'smooth',
         block: 'start'
       })
-      errorSummary.value.$el.focus()
     }, 0)
   } else {
     save()


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/678
Fix https://github.com/ecolabdata/ecospheres/issues/679

- Ajoute le role `alert` au bloc d'erreur
- Fix le focus vers ce bloc à la présence d'erreur : focus sur le bloc, puis (tab) sur la première erreur