### PR TITLE
fix(rgaa): title on search fields

### DIFF
--- a/src/components/SearchComponent.vue
+++ b/src/components/SearchComponent.vue
@@ -104,6 +104,7 @@ const clear = () => {
       type="search"
       :label-visible="labelVisible"
       :placeholder="!labelVisible ? searchLabel : undefined"
+      :title="!labelVisible ? searchLabel : undefined"
     >
       <template #before-input>
         <VIconCustom name="search-line" class="search-icon" />
@@ -111,6 +112,7 @@ const clear = () => {
     </DsfrInputGroup>
   </search>
 
+  <!-- FIXME: nested input needs a title attribute for a11y, but not supported by DsfrSearchBar -->
   <DsfrSearchBar
     v-else-if="!dropdown.length"
     v-model="query"
@@ -141,7 +143,8 @@ const clear = () => {
       :clear-on-search="true"
       :clear-on-blur="true"
       :close-on-select="true"
-      placeholder="Rechercher"
+      :placeholder="searchLabel"
+      :title="searchLabel"
       aria-owns=""
       :aria="{
         'aria-describedby': `${id}-description`,

--- a/src/components/header/HeaderComponent.vue
+++ b/src/components/header/HeaderComponent.vue
@@ -14,7 +14,7 @@ type Props = {
 withDefaults(defineProps<DsfrHeaderProps & Props>(), {
   operatorImgAlt: '',
   operatorImgStyle: () => ({}),
-  searchLabel: 'Recherche',
+  searchLabel: 'Rechercher',
   quickLinks: () => [],
   showSearch: config.website.header_search.display,
   customSearch: false
@@ -93,7 +93,7 @@ const dropdown = config.website.header_search.dropdown ?? undefined
         class="custom-search"
         :search-label="searchLabel"
         :dropdown="dropdown"
-        placeholder="Rechercher"
+        :placeholder="searchLabel"
         @do-search="closeModal"
       />
     </template>


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/654
Fix https://github.com/ecolabdata/ecospheres/issues/677

Ajoute un attribut `title` aux champs de recherche, avec la même valeur que `placeholder`. Pas possible pour `DsfrSearchBar` (non utilisé sur ecologie.data.gouv.fr), donc FIXME.