### PR TITLE
fix(ci): review app existence check

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -46,13 +46,14 @@ jobs:
     steps:
       - name: Check if review app exists
         id: check_app
+        continue-on-error: true
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.REVIEW_APP_SSH_HOST }}
           username: dokku
           key: ${{ secrets.REVIEW_APP_SSH_PRIVATE_KEY }}
           port: 22
-          script: dokku apps:exists deploy-preview-${{ github.event.pull_request.number }}--${{ matrix.site }}
+          script: apps:exists deploy-preview-${{ github.event.pull_request.number }}--${{ matrix.site }}
 
       - name: Set APP_EXISTS variable
         run: |

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -44,7 +44,23 @@ jobs:
     # Run for all PRs including forks and for manual triggers
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
-      - name: Determine deployment strategy and check review app existence
+      - name: Check if review app exists
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.REVIEW_APP_SSH_HOST }}
+          username: dokku
+          key: ${{ secrets.REVIEW_APP_SSH_PRIVATE_KEY }}
+          port: 22
+          script: |
+            if dokku apps:exists deploy-preview-${{ github.event.pull_request.number }}--${{ matrix.site }}; then
+              echo "APP_EXISTS=true" >> $GITHUB_ENV
+              echo "Review app exists"
+            else
+              echo "APP_EXISTS=false" >> $GITHUB_ENV
+              echo "Review app does not exist"
+            fi
+
+      - name: Determine deployment strategy
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # For manual deployment, only process the selected site
@@ -64,15 +80,6 @@ jobs:
             # Set defaults (no deployment, no creation)
             echo "SHOULD_DEPLOY=false" >> $GITHUB_ENV
             echo "SHOULD_CREATE=false" >> $GITHUB_ENV
-
-            # Check app existence
-            if ssh -o StrictHostKeyChecking=no dokku@${{ secrets.REVIEW_APP_SSH_HOST }} apps:exists deploy-preview-${{ github.event.pull_request.number }}--${{ matrix.site }}; then
-              APP_EXISTS=true
-              echo "Review app exists"
-            else
-              APP_EXISTS=false
-              echo "Review app does not exist"
-            fi
 
             # Override defaults based on event type
             if [ "${{ github.event.action }}" = "synchronize" ]; then
@@ -101,6 +108,7 @@ jobs:
           echo "Site: ${{ env.SITE }}"
           echo "PR number: ${{ env.PR_NUMBER }}"
           echo "Event action: ${{ env.EVENT_ACTION }}"
+          echo "App exists: ${{ env.APP_EXISTS }}"
           echo "Should deploy: ${{ env.SHOULD_DEPLOY }}"
           echo "Should create: ${{ env.SHOULD_CREATE }}"
           echo "Should destroy: ${{ env.SHOULD_DESTROY }}"

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Check if review app exists
         id: check_app
         continue-on-error: true
-        uses: appleboy/ssh-action@v1.0.0
+        uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.REVIEW_APP_SSH_HOST }}
           username: dokku
@@ -151,7 +151,7 @@ jobs:
 
       - name: Set site id as build arg
         if: env.SHOULD_DEPLOY == 'true'
-        uses: appleboy/ssh-action@v1.0.0
+        uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.REVIEW_APP_SSH_HOST }}
           username: dokku
@@ -172,7 +172,7 @@ jobs:
 
       - name: Enable SSL with Let's Encrypt
         if: env.SHOULD_CREATE == 'true'
-        uses: appleboy/ssh-action@v1.0.0
+        uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.REVIEW_APP_SSH_HOST }}
           username: dokku

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -45,20 +45,22 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Check if review app exists
+        id: check_app
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.REVIEW_APP_SSH_HOST }}
           username: dokku
           key: ${{ secrets.REVIEW_APP_SSH_PRIVATE_KEY }}
           port: 22
-          script: |
-            if dokku apps:exists deploy-preview-${{ github.event.pull_request.number }}--${{ matrix.site }}; then
-              echo "APP_EXISTS=true" >> $GITHUB_ENV
-              echo "Review app exists"
-            else
-              echo "APP_EXISTS=false" >> $GITHUB_ENV
-              echo "Review app does not exist"
-            fi
+          script: dokku apps:exists deploy-preview-${{ github.event.pull_request.number }}--${{ matrix.site }}
+
+      - name: Set APP_EXISTS variable
+        run: |
+          if [ ${{ steps.check_app.outcome }} == 'success' ]; then
+            echo "APP_EXISTS=true" >> $GITHUB_ENV
+          else
+            echo "APP_EXISTS=false" >> $GITHUB_ENV
+          fi
 
       - name: Determine deployment strategy
         run: |


### PR DESCRIPTION
`app:exists` n'était pas appelé avec les bons arguments SSH (clé privée). On utilise ici l'action `appleboy/ssh-action` déjà utilisée dans le script pour récupérer le code retour de `app:exists` puis alimenter `$APP_EXISTS`.