### PR TITLE
fix: force page remount when switching detail pages

### DIFF
--- a/src/custom/simplifions/components/SimplifionsRecoSolutions.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutions.vue
@@ -12,12 +12,15 @@
           <div class="fr-tile__body">
             <div class="fr-tile__content">
               <p class="fr-tile__title fr-text--lead">
-                <a
+                <router-link
                   class="solution-link"
-                  :href="`/solutions/${reco_solution.solution_topic_id}`"
+                  :to="{
+                    name: 'solutions_detail',
+                    params: { item_id: reco_solution.solution_topic_id }
+                  }"
                 >
                   {{ reco_solution.Nom_de_la_solution_publique }}
-                </a>
+                </router-link>
                 <br />
                 En savoir plus
               </p>

--- a/src/custom/simplifions/components/SimplifionsSolutionDescription.vue
+++ b/src/custom/simplifions/components/SimplifionsSolutionDescription.vue
@@ -201,12 +201,15 @@
           <div class="fr-tile__body">
             <div class="fr-tile__content">
               <h3 class="fr-tile__title">
-                <a
-                  :href="`/cas-d-usages/${casUsage.slug}`"
+                <router-link
+                  :to="{
+                    name: 'cas-d-usages_detail',
+                    params: { item_id: casUsage.slug }
+                  }"
                   class="cas-d-usage-link"
                 >
                   {{ casUsage.name }}
-                </a>
+                </router-link>
               </h3>
               <p class="fr-tile__detail">
                 {{ casUsage.description || 'Aucune description disponible' }}

--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -166,7 +166,11 @@ export const useSearchPageRoutes = ({
           pageKey,
           descriptionComponent
         },
-        props: props || {}
+        props: () => ({
+          // this forces the component to be recreated when switching page type
+          key: pageKey,
+          ...props
+        })
       }
     ]
   }


### PR DESCRIPTION
Injecting `pageKey` in props forces the detail page to remount when switching page type.