### PR TITLE
ci: fix CI deploy bug

### DIFF
--- a/.github/workflows/create-deploy-release.yml
+++ b/.github/workflows/create-deploy-release.yml
@@ -39,6 +39,11 @@ on:
       - '*'
 jobs:
   deploy-release:
+    # Only run this job for:
+    # - Manual workflow dispatch (workflow_dispatch)
+    # - Push to branches with commit messages starting with '[' (deployment commits)
+    # This prevents the job from running on normal commits and saves resources
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && startsWith(github.event.head_commit.message, '['))
     runs-on: ubuntu-latest
     env:
       # variables to be defined
@@ -57,6 +62,9 @@ jobs:
       ENV: ${{ github.event.inputs.environment }}
       VERSION_PART: ${{ github.event.inputs.version_type }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Debug event and inputs
         run: |
           echo "Event name: ${{ github.event_name }}"
@@ -75,7 +83,6 @@ jobs:
           fi
 
       - name: Parse commit message and set deployment variables
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
         shell: bash
         run: |
           LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%s)

--- a/.github/workflows/create-deploy-release.yml
+++ b/.github/workflows/create-deploy-release.yml
@@ -92,7 +92,6 @@ jobs:
           echo "ENV=$ENV" >> $GITHUB_ENV
           echo "CONFIG_NAME=$CONFIG_NAME" >> $GITHUB_ENV
           echo "VERSION_PART=$VERSION_PART" >> $GITHUB_ENV
-        working-directory: ${{ env.APP_NAME }}
 
       - name: Setup SSH keys and Git configuration
         shell: bash

--- a/.github/workflows/create-deploy-release.yml
+++ b/.github/workflows/create-deploy-release.yml
@@ -62,9 +62,6 @@ jobs:
       ENV: ${{ github.event.inputs.environment }}
       VERSION_PART: ${{ github.event.inputs.version_type }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Debug event and inputs
         run: |
           echo "Event name: ${{ github.event_name }}"
@@ -81,6 +78,12 @@ jobs:
             echo "Tag-based trigger:"
             echo "Tag: ${{ github.ref_name }}"
           fi
+
+      - name: Clone this repo and the scaffold script repository
+        shell: bash
+        run: |
+          git clone --quiet --depth 1 -b ${{ env.REPO_CURRENT_BRANCH }} ${{ env.REPO_SSH_URL }}
+          git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL ${{ env.SCAFFOLD_DIR }}
 
       - name: Parse commit message and set deployment variables
         shell: bash
@@ -99,6 +102,7 @@ jobs:
           echo "ENV=$ENV" >> $GITHUB_ENV
           echo "CONFIG_NAME=$CONFIG_NAME" >> $GITHUB_ENV
           echo "VERSION_PART=$VERSION_PART" >> $GITHUB_ENV
+        working-directory: ${{ env.APP_NAME }}
 
       - name: Setup SSH keys and Git configuration
         shell: bash
@@ -117,12 +121,6 @@ jobs:
           # Configure Git identity
           git config --global user.email "root@data.gouv.fr"
           git config --global user.name "datagouv"
-
-      - name: Clone this repo and the scaffold script repository
-        shell: bash
-        run: |
-          git clone --quiet --depth 1 -b ${{ env.REPO_CURRENT_BRANCH }} ${{ env.REPO_SSH_URL }}
-          git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL ${{ env.SCAFFOLD_DIR }}
 
       - name: Set next release version
         shell: bash


### PR DESCRIPTION
Tentative pour résoudre le bug de CI mentionné ici : https://github.com/opendatateam/udata-front-kit/pull/810#issuecomment-3117521750

L'étape "Parse commit message" utilise working-directory: ${{ env.APP_NAME }} mais cette étape s'exécute avant que le repository soit cloné.

Ajout aussi d'une condition pour lancer le CI job uniquement si c'est via un input manuel ou bien si c'est un push avec un message de commit qui commence par "[".

