### PR TITLE
Introduce mode-specific config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env.local
+.env.*.local
 .eslintcache
 .idea
 TODO.md

--- a/configs/simplifions/config.production.yaml
+++ b/configs/simplifions/config.production.yaml
@@ -1,0 +1,6 @@
+datagouvfr:
+  base_url: https://www.data.gouv.fr
+  oauth_client_id: 676452675336109a436f8f73
+website:
+  notice:
+    display: false

--- a/configs/simplifions/config.production.yaml
+++ b/configs/simplifions/config.production.yaml
@@ -1,3 +1,6 @@
+# This config is specific to the production mode.
+# It is merged with the default config
+
 datagouvfr:
   base_url: https://www.data.gouv.fr
   oauth_client_id: 676452675336109a436f8f73

--- a/configs/simplifions/config.yaml
+++ b/configs/simplifions/config.yaml
@@ -1,4 +1,4 @@
-# config file for simplifions
+# Default config file for simplifions
 
 # used as extras key
 site_id: simplifions

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@vueuse/core": "^12.4.0",
         "@vueuse/integrations": "^12.4.0",
         "axios": "^1.11.0",
+        "deepmerge": "^4.3.1",
         "dompurify": "^3.2.3",
         "maplibre-gl": "^5.3.0",
         "marked": "^15.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "unplugin-yaml": "^1.3.0",
         "vite": "^6.3.4",
         "vite-plugin-dynamic-import": "^1.6.0",
+        "vite-plugin-restart": "^1.0.0",
         "vite-plugin-vue-devtools": "^7.7.0",
         "vitest": "^3.0.9",
         "vue-tsc": "^2.2.0"
@@ -13611,6 +13612,22 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/vite-plugin-restart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-restart/-/vite-plugin-restart-1.0.0.tgz",
+      "integrity": "sha512-t2ktkTOa+DQX05TEZm/3FE0DyrYEyFXdhG5gLcta5p71zOpg9yG3DeRcHWJVLJgWNoaVtOr4fUlr1kKu+WfXyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromatch": "^4.0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vite": "^2.9.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/vite-plugin-vue-devtools": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@vueuse/core": "^12.4.0",
     "@vueuse/integrations": "^12.4.0",
     "axios": "^1.11.0",
+    "deepmerge": "^4.3.1",
     "dompurify": "^3.2.3",
     "maplibre-gl": "^5.3.0",
     "marked": "^15.0.6",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "unplugin-yaml": "^1.3.0",
     "vite": "^6.3.4",
     "vite-plugin-dynamic-import": "^1.6.0",
+    "vite-plugin-restart": "^1.0.0",
     "vite-plugin-vue-devtools": "^7.7.0",
     "vitest": "^3.0.9",
     "vue-tsc": "^2.2.0"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,31 @@
 import config from '@siteConfig/config.yaml'
 
-export default config
+const mode = import.meta.env.MODE
+const site_id = import.meta.env.VITE_SITE_ID
+
+// Use Vite's import.meta.glob to conditionally load mode-specific configs
+const modeConfigs = import.meta.glob('@siteConfig/config.*.yaml', {
+  eager: true
+})
+
+console.log(modeConfigs)
+
+// Try to find and merge mode-specific config
+let finalConfig = config
+const modeConfigKey = `/configs/${site_id}/config.${mode}.yaml`
+
+if (modeConfigs[modeConfigKey]) {
+  console.log(
+    `Loading and merging config for ${mode} with the default config of ${site_id}`
+  )
+  const configForMode = modeConfigs[modeConfigKey] as any
+  finalConfig = { ...config, ...configForMode.default }
+} else {
+  console.log(
+    `No specific config found for ${mode}, using default config of ${site_id}`
+  )
+}
+
+console.log(finalConfig)
+
+export default finalConfig

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,31 +1,5 @@
-import config from '@siteConfig/config.yaml'
-import merge from 'deepmerge'
-
-const mode = import.meta.env.MODE
-const site_id = import.meta.env.VITE_SITE_ID
-
-// Use Vite's import.meta.glob to conditionally load mode-specific configs
-// This will actually only include the specific config file of the current mode
-// thanks to vite.config.mts dynamicImport plugin
-const modeConfigs = import.meta.glob('@siteConfig/config.*.yaml', {
-  eager: true
-})
-
-// Try to find and merge mode-specific config
-let finalConfig = config
-const modeConfigKey = `/configs/${site_id}/config.${mode}.yaml`
-
-if (modeConfigs[modeConfigKey]) {
-  console.log(
-    `Loading and merging config for ${mode} with the default config of ${site_id}`
-  )
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const configForMode = (modeConfigs[modeConfigKey] as any).default
-  finalConfig = merge(config, configForMode)
-} else {
-  console.log(
-    `No specific config found for ${mode}, using default config of ${site_id}`
-  )
-}
-
-export default finalConfig
+// __APP_CONFIG__ is exported from {site_id}/config.*.yaml files in vite.config.mts
+// TODO: we should type the entire config here
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const __APP_CONFIG__: any
+export default __APP_CONFIG__

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import config from '@siteConfig/config.yaml'
+import merge from 'deepmerge'
 
 const mode = import.meta.env.MODE
 const site_id = import.meta.env.VITE_SITE_ID
@@ -8,8 +9,6 @@ const modeConfigs = import.meta.glob('@siteConfig/config.*.yaml', {
   eager: true
 })
 
-console.log(modeConfigs)
-
 // Try to find and merge mode-specific config
 let finalConfig = config
 const modeConfigKey = `/configs/${site_id}/config.${mode}.yaml`
@@ -18,14 +17,12 @@ if (modeConfigs[modeConfigKey]) {
   console.log(
     `Loading and merging config for ${mode} with the default config of ${site_id}`
   )
-  const configForMode = modeConfigs[modeConfigKey] as any
-  finalConfig = { ...config, ...configForMode.default }
+  const configForMode = (modeConfigs[modeConfigKey] as any).default
+  finalConfig = merge(config, configForMode)
 } else {
   console.log(
     `No specific config found for ${mode}, using default config of ${site_id}`
   )
 }
-
-console.log(finalConfig)
 
 export default finalConfig

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,8 @@ const mode = import.meta.env.MODE
 const site_id = import.meta.env.VITE_SITE_ID
 
 // Use Vite's import.meta.glob to conditionally load mode-specific configs
+// This will actually only include the specific config file of the current mode
+// thanks to vite.config.mts dynamicImport plugin
 const modeConfigs = import.meta.glob('@siteConfig/config.*.yaml', {
   eager: true
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ if (modeConfigs[modeConfigKey]) {
   console.log(
     `Loading and merging config for ${mode} with the default config of ${site_id}`
   )
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const configForMode = (modeConfigs[modeConfigKey] as any).default
   finalConfig = merge(config, configForMode)
 } else {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -90,6 +90,15 @@ export default defineConfig(({ mode }) => {
               routeFile.includes(`custom/${env.VITE_SITE_ID}/routes.ts`)
             )
           }
+          // Include only the current mode's config file in the bundle
+          // to prevent /src/config.ts from including all config files before picking the right one
+          if (id.includes('/src/config.ts')) {
+            return files.filter((configFile) =>
+              configFile.includes(
+                `configs/${env.VITE_SITE_ID}/config.${mode}.yaml`
+              )
+            )
+          }
         }
       })
     ],


### PR DESCRIPTION
:warning: This needs to be viewed by the Ops team, especially @jordanguedj :point_down: 

1. Override the `VITE_DATAGOUV_BASE_URL` and `VITE_DATAGOUV_OAUTH_CLIENT_ID` in your deployments scripts, the same way you already override the `VITE_SITE_ID`.

2. You can find the suitable values of `VITE_DATAGOUV_OAUTH_CLIENT_ID` for each site in their respective config (Except ecospheres which has 2 values for demo and prod in their respective branches).

Here is all the links to all the existing oauth_client_ids (before merging this PR) : 

[ecospheres demo](https://github.com/opendatateam/udata-front-kit/blob/ecospheres-prod/configs/ecospheres/config.yaml#L10)
[ecospheres prod](https://github.com/opendatateam/udata-front-kit/blob/ecospheres-demo/configs/ecospheres/config.yaml#L10)
[meteo-france](https://github.com/opendatateam/udata-front-kit/blob/main/configs/meteo-france/config.yaml#L9)
[defis](https://github.com/opendatateam/udata-front-kit/blob/main/configs/defis/config.yaml#L9)
[hackathon](https://github.com/opendatateam/udata-front-kit/blob/main/configs/hackathon/config.yaml#L9)
[logistique](https://github.com/opendatateam/udata-front-kit/blob/main/configs/logistique/config.yaml#L9)
[simplifions](https://github.com/opendatateam/udata-front-kit/blob/main/configs/simplifions/config.yaml#L10)