### PR TITLE
fix(rgaa): empty p blocks

### DIFF
--- a/src/custom/ecospheres/components/indicators/informations/InformationPanelSection.vue
+++ b/src/custom/ecospheres/components/indicators/informations/InformationPanelSection.vue
@@ -10,7 +10,7 @@ defineProps({
 <template>
   <div class="fr-py-2w fr-mb-3w border-bottom border-default-grey">
     <h2 v-if="title" class="subtitle subtitle--uppercase">{{ title }}</h2>
-    <p><slot name="description" /></p>
+    <p v-if="$slots.description"><slot name="description" /></p>
     <div class="fr-m-0">
       <div class="fr-grid-row fr-grid-row--gutters">
         <slot />


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/685

Je n'ai pas trouvé de double `<br>` et le rapport n'en montre pas.