### PR TITLE
feat(indicators): mega search

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -52,10 +52,10 @@ website:
     dropdown:
       - text: Rechercher {} dans les <strong>jeux de données</strong>
         route: datasets
-      - text: Rechercher {} dans les <strong>bouquets</strong>
-        route: bouquets
       - text: Rechercher {} dans les <strong>indicateurs</strong>
         route: indicators
+      - text: Rechercher {} dans les <strong>bouquets</strong>
+        route: bouquets
   search_bar:
     display: true
     placeholder: Rechercher une donnée environnementale

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -54,6 +54,8 @@ website:
         route: datasets
       - text: Rechercher {} dans les <strong>bouquets</strong>
         route: bouquets
+      - text: Rechercher {} dans les <strong>indicateurs</strong>
+        route: indicators
   search_bar:
     display: true
     placeholder: Rechercher une donnée environnementale


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/564

Active la recherche depuis le "mega search" dans les indicateurs.

<img width="887" height="394" alt="Capture d’écran 2025-08-05 à 09 53 31" src="https://github.com/user-attachments/assets/6f0882af-09e4-41b2-ac3e-c70fdf1350d3" />
