### PR TITLE
fix: mandatory title when not dataset_editorialization

### DIFF
--- a/src/components/forms/dataset/FactorEditModal.vue
+++ b/src/components/forms/dataset/FactorEditModal.vue
@@ -47,10 +47,6 @@ const formErrors: Ref<AllowedInput[]> = ref([])
 
 const validateFields = () => {
   const modalFactor = modalData.value.factor
-  if (!modalFactor?.title.trim()) {
-    formErrors.value.push('title')
-  }
-
   if (props.datasetEditorialization) {
     if (!modalFactor?.title.trim()) {
       formErrors.value.push('title')


### PR DESCRIPTION
Do not make title mandatory when dataset_editorialization is not enabled.