### PR TITLE
feat: indicators dataviz yStartAtZero and ignoreFormatBigNumber

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "dependencies": {
         "@datagouv/components": "^2.0.7",
-        "@ecolabdata/tabular-dataviz": "^1.0.1",
+        "@ecolabdata/tabular-dataviz": "file:../ecospheres-tabular-dataviz",
         "@gouvfr/dsfr": "1.11.2",
         "@gouvminint/vue-dsfr": "^8.6.0",
         "@json2csv/plainjs": "^7.0.6",
@@ -72,6 +72,25 @@
       "engines": {
         "node": ">= 20.0.0",
         "npm": ">= 10.0.0"
+      }
+    },
+    "../ecospheres-tabular-dataviz": {
+      "name": "@ecolabdata/tabular-dataviz",
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "choices.js": "^11.1.0"
+      },
+      "devDependencies": {
+        "@rollup/plugin-node-resolve": "^15.0.0",
+        "rollup": "^4.0.0",
+        "rollup-plugin-postcss": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "chart.js": "^4.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -666,19 +685,8 @@
       }
     },
     "node_modules/@ecolabdata/tabular-dataviz": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@ecolabdata/tabular-dataviz/-/tabular-dataviz-1.0.1.tgz",
-      "integrity": "sha512-cD51pFylDCyNMQFJxQv8giFlzCtg0dRVXPLWK3qIlYPxtZrbFc+equtYZ6eZEG1hFEv9Vhrnth2ikKooxGhU/g==",
-      "license": "MIT",
-      "dependencies": {
-        "choices.js": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "chart.js": "^4.5.0"
-      }
+      "resolved": "../ecospheres-tabular-dataviz",
+      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.8",
@@ -4711,15 +4719,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/choices.js": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-11.1.0.tgz",
-      "integrity": "sha512-mIt0uLhedHg2ea/K2PACrVpt391vRGHuOoctPAiHcyemezwzNMxj7jOzNEk8e7EbjLh0S0sspDkSCADOKz9kcw==",
-      "license": "MIT",
-      "dependencies": {
-        "fuse.js": "^7.0.0"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -6866,6 +6865,8 @@
       "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
       "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@datagouv/components": "^2.0.7",
-    "@ecolabdata/tabular-dataviz": "^1.0.1",
+    "@ecolabdata/tabular-dataviz": "^1.2.0",
     "@gouvfr/dsfr": "1.11.2",
     "@gouvminint/vue-dsfr": "^8.6.0",
     "@json2csv/plainjs": "^7.0.6",

--- a/src/custom/ecospheres/views/indicators/IndicatorVisualisation.vue
+++ b/src/custom/ecospheres/views/indicators/IndicatorVisualisation.vue
@@ -55,7 +55,9 @@ const indicatorForGraph = computed(() => {
     id: props.indicator.id,
     unite: metadata?.unite ?? 'na',
     summable: metadata?.summable ?? false,
-    enableVisualisation: metadata?.['enable_visualization'] ?? false
+    enableVisualisation: metadata?.['enable_visualization'] ?? false,
+    yStartAtZero: metadata?.['y_start_at_zero'] ?? false,
+    ignoreFormatBigNumber: metadata?.['ignore_format_big_number'] ?? false
   }
 
   return formatted


### PR DESCRIPTION
Depends https://github.com/ecolabdata/ecospheres-tabular-dataviz/pull/2
Fix https://github.com/ecolabdata/ecospheres/issues/780

WIP, will need `@ecolabdata/tabular-dataviz@1.2.0` publication and package-lock generation.