### PR TITLE
make the SolutionTag more resilient

### DIFF
--- a/src/custom/simplifions/components/SimplifionsSolutionTag.vue
+++ b/src/custom/simplifions/components/SimplifionsSolutionTag.vue
@@ -29,7 +29,7 @@ const solution = computed(
 )
 
 const isPublic = computed(() => {
-  return solution.value.Public_ou_prive === 'Public'
+  return solution.value?.Public_ou_prive === 'Public'
 })
 
 const tagText = computed(() => {
@@ -37,7 +37,7 @@ const tagText = computed(() => {
 })
 
 const operatorName = computed(() => {
-  return solution.value.Nom_de_l_operateur?.[0]
+  return solution.value?.Nom_de_l_operateur?.[0]
 })
 </script>
 


### PR DESCRIPTION
When we got from cas d'usage list to solution list, the card components change before the list of topics is updated, which triggers errors because solution topic's cards can't find its extra key in a cas d'usage topic's extras.