### PR TITLE
fix: escape ci comment

### DIFF
--- a/.github/workflows/deploy-review-from-comment.yml
+++ b/.github/workflows/deploy-review-from-comment.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Parse comment
         id: parse
         run: |
-          COMMENT="${{ github.event.comment.body }}"
+          COMMENT=$(cat << 'EOF'
+          ${{ github.event.comment.body }}
+          EOF
+          )
           echo "Comment: $COMMENT"
 
           # Extract /deploy command and site


### PR DESCRIPTION
Writing a comment with `xxx` and a /deploy somewhere would execute the xxx command 😬 

Eg https://github.com/opendatateam/udata-front-kit/pull/830#issuecomment-3460461687