### PR TITLE
Add filter Organization by json

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
-VITE_SITE_ID=ecospheres
+# VITE_SITE_ID=ecospheres
 # VITE_SITE_ID=meteo-france
 # VITE_SITE_ID=defis
 # VITE_SITE_ID=hackathon
 # VITE_SITE_ID=logistique
 # VITE_SITE_ID=simplifions
-# VITE_SITE_ID=culture
+VITE_SITE_ID=culture

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-VITE_SITE_ID=ecospheres
+VITE_SITE_ID=culture

--- a/configs/culture/config.yaml
+++ b/configs/culture/config.yaml
@@ -141,7 +141,10 @@ website:
       everyone: true
       authorized_users:
 
-organizations: https://grist.numerique.gouv.fr/api/docs/jT6Q2SSUUder/tables/Table1/records
+  # Grist organisations ministère de la Culture https://grist.numerique.gouv.fr/api/docs/jT6Q2SSUUder/tables/Table1/records
+  # Organisations transversale des données ouvertes de la culture
+organizations:
+  datasets: https://raw.githubusercontent.com/datagouv/portail-culture/refs/heads/Documentation/data/organizations-datasets.json
 
 pages:
   # DATASETS
@@ -216,3 +219,7 @@ pages:
             id: association
           - name: Entreprise
             id: company
+      - name: Organisation
+        default_option: Toutes les organisations
+        id: organization
+        type: organization


### PR DESCRIPTION
Bonjour, 
Pour PR, voici une modification pour permettre aux utilisateurs de filtrer les jeux de données selon l’organisation productrice, pour mieux naviguer dans les contenus d’une verticale (ex. culture, défis, etc.).

Elle reprend le processus / méthode développée par @abulte : https://github.com/opendatateam/udata-front-kit/issues/953#issuecomment-3520341440

Le fichier json est actuellement hébergé dans un autre dépôt, faut-il pour des questions de performance l'ajouter au sein d'un de
https://github.com/opendatateam/udata-front-kit/tree/main/src/custom/culture : 
/data (fichier json)
/script (ici dans le cas d'un hébergement du script)

Par avance merci !
Très bonne journée