### PR TITLE
fix: mock grist on home page tests

### DIFF
--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -3,6 +3,8 @@ describe('Home Page', () => {
     // Visit the home page before each test
     cy.mockMatomo()
     cy.mockStaticDatagouv()
+    // some site home pages use Grist (eg culture), loosely mock records fetching
+    cy.mockGristRecords('*')
     cy.visit('/')
   })
 


### PR DESCRIPTION
Fix random failures like https://github.com/opendatateam/udata-front-kit/actions/runs/19424443711/job/55568560660?pr=933