### PR TITLE
chore: expose config in tests

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,4 +1,6 @@
 import { defineConfig } from 'cypress'
+import { readFileSync } from 'fs'
+import { load } from 'js-yaml'
 
 export default defineConfig({
   e2e: {
@@ -12,6 +14,13 @@ export default defineConfig({
     setupNodeEvents(on, config) {
       // Dynamically exclude custom site tests that don't match current VITE_SITE_ID
       const siteId = process.env.VITE_SITE_ID
+
+      // Load site config and make it available to tests
+      if (siteId) {
+        const configPath = `./configs/${siteId}/config.yaml`
+        const siteConfig = load(readFileSync(configPath, 'utf-8'))
+        config.env.siteConfig = siteConfig
+      }
 
       if (siteId) {
         // Only include tests for the specific site

--- a/cypress/e2e/custom/ecospheres/topics/create.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/create.cy.ts
@@ -1,6 +1,9 @@
 import type { Topic } from '@/model/topic'
 
 describe('Ecospheres - Topic (Bouquet) Creation', () => {
+  const universeTag =
+    Cypress.env('siteConfig').pages.bouquets.universe_query.tag
+
   beforeEach(() => {
     cy.mockMatomo()
     cy.mockStaticDatagouv()
@@ -64,7 +67,7 @@ describe('Ecospheres - Topic (Bouquet) Creation', () => {
       expect(requestBody.tags).to.include('ecospheres-theme-mieux-consommer')
 
       // The tags should also include the universe query tag
-      expect(requestBody.tags).to.include('ecospheres')
+      expect(requestBody.tags).to.include(universeTag)
     })
 
     // Verify redirect to the detail page (optional but good practice)

--- a/cypress/e2e/custom/ecospheres/topics/list.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/list.cy.ts
@@ -4,6 +4,9 @@ import { mockUniverseOrganizations } from '../mocks'
 
 describe('Topics - List Page', () => {
   let testTopics: Topic[]
+  const universeTag =
+    Cypress.env('siteConfig').pages.bouquets.universe_query.tag
+  const universeTagRegex = new RegExp(`[?&]tag=${universeTag}(?:&|$)`)
 
   beforeEach(() => {
     cy.mockMatomo()
@@ -21,7 +24,7 @@ describe('Topics - List Page', () => {
       cy.visit('/bouquets')
       cy.wait('@get_topics_list').then((interception) => {
         // Verify the API call includes the universe query tag
-        expect(interception.request.url).to.match(/[?&]tag=ecospheres(?:&|$)/)
+        expect(interception.request.url).to.match(universeTagRegex)
       })
 
       // Check that all topics are displayed
@@ -55,7 +58,7 @@ describe('Topics - List Page', () => {
         expect(interception.request.url).to.match(
           /[?&]organization=534fff4ca3a7292c64a77c95(?:&|$)/
         )
-        expect(interception.request.url).to.match(/[?&]tag=ecospheres(?:&|$)/)
+        expect(interception.request.url).to.match(universeTagRegex)
       })
     })
 
@@ -83,7 +86,7 @@ describe('Topics - List Page', () => {
         expect(interception.request.url).to.match(
           /[?&]tag=ecospheres-theme-mieux-consommer(?:&|$)/
         )
-        expect(interception.request.url).to.match(/[?&]tag=ecospheres(?:&|$)/)
+        expect(interception.request.url).to.match(universeTagRegex)
       })
     })
 
@@ -118,7 +121,7 @@ describe('Topics - List Page', () => {
         expect(interception.request.url).to.match(
           /[?&]geozone=fr:commune:75056(?:&|$)/
         )
-        expect(interception.request.url).to.match(/[?&]tag=ecospheres(?:&|$)/)
+        expect(interception.request.url).to.match(universeTagRegex)
       })
     })
   })
@@ -161,7 +164,7 @@ describe('Topics - List Page', () => {
         expect(interception.request.url).to.match(
           /[?&]include_private=true(?:&|$)/
         )
-        expect(interception.request.url).to.match(/[?&]tag=ecospheres(?:&|$)/)
+        expect(interception.request.url).to.match(universeTagRegex)
       })
 
       // Initially, include_private should not be in URL (default value)
@@ -184,7 +187,7 @@ describe('Topics - List Page', () => {
         expect(interception.request.url).to.not.match(
           /[?&]include_private=true(?:&|$)/
         )
-        expect(interception.request.url).to.match(/[?&]tag=ecospheres(?:&|$)/)
+        expect(interception.request.url).to.match(universeTagRegex)
       })
 
       // Click again to show drafts
@@ -198,7 +201,7 @@ describe('Topics - List Page', () => {
         expect(interception.request.url).to.match(
           /[?&]include_private=true(?:&|$)/
         )
-        expect(interception.request.url).to.match(/[?&]tag=ecospheres(?:&|$)/)
+        expect(interception.request.url).to.match(universeTagRegex)
       })
     })
   })

--- a/cypress/support/generic_mocks.js
+++ b/cypress/support/generic_mocks.js
@@ -8,7 +8,8 @@ const allowedDomains = [
   'clientservices.googleapis.com',
   'www.google.com',
   'android.clients.google.com',
-  'safebrowsing.googleapis.com'
+  'safebrowsing.googleapis.com',
+  'accounts.google.com'
 ]
 
 Cypress.Commands.add('catchUnmockedRequests', () => {


### PR DESCRIPTION
Expose config in tests and parametrize the universe tag name of écologie. Fix https://github.com/opendatateam/udata-front-kit/actions/runs/19641449342/job/56245716763?pr=977 on prod.