### PR TITLE
chore(ci): use npm ci in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG VITE_SITE_ID
 # only set the environment variable if the build arg was provided
 ENV VITE_SITE_ID=${VITE_SITE_ID:-}
 
-RUN npm install
+RUN npm ci
 RUN echo "$(date)" && \
     export $(cat /app/*.env | xargs) && \
     npm run build


### PR DESCRIPTION
This will use locked versions from `package-lock.json`, more coherent and more secure.