### PR TITLE
chore(splf): remove sentry from default config

### DIFF
--- a/configs/simplifions/config.yaml
+++ b/configs/simplifions/config.yaml
@@ -4,14 +4,14 @@
 site_id: simplifions
 # Error tracker : Sentry
 
-sentry:
-  domain_url: 'https://errors.data.gouv.fr/'
-  dsn: 'https://c8268303ac0799edda45ced7faa7e0a0@errors.data.gouv.fr/38'
-  environment: 'preprod'
-  tracePropagationTargets: []
-  tracesSampleRate: 1.0
-  replaysSessionSampleRate: 0.1
-  replaysOnErrorSampleRate: 1.0
+# sentry:
+#   domain_url: 'https://errors.data.gouv.fr/'
+#   dsn: 'https://c8268303ac0799edda45ced7faa7e0a0@errors.data.gouv.fr/38'
+#   environment: 'preprod'
+#   tracePropagationTargets: []
+#   tracesSampleRate: 1.0
+#   replaysSessionSampleRate: 0.1
+#   replaysOnErrorSampleRate: 1.0
 
 datagouvfr:
   # data.gouv.fr base URL (use www subdomain on prod)


### PR DESCRIPTION
Fix https://linear.app/pole-api/issue/API2-514/enlever-sentry-en-local

This disables the sentry config from default conf (and thus local env).

I'm still unsure about having sentry on preprod, but it will be handled when merging to `simplifions-preprod` anyway.
