### PR TITLE
feat: disable npm and yarn install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -11,3 +11,6 @@ node-linker=hoisted
 # Security: Only install packages released at least 4 days ago
 # Protects against supply-chain attacks by giving community time to detect malicious releases
 minimum-release-age=5760
+
+# Enforce pnpm usage - fail if npm or yarn is used
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "packageManager": "pnpm@10.23.0",
   "engines": {
     "node": ">= 20.0.0",
+    "npm": "please-use-pnpm",
+    "yarn": "please-use-pnpm",
     "pnpm": ">= 10.0.0"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1214,6 +1214,7 @@ packages:
       }
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution:
@@ -1222,6 +1223,7 @@ packages:
       }
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution:
@@ -1230,6 +1232,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution:
@@ -1238,6 +1241,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution:
@@ -1246,6 +1250,7 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution:
@@ -1254,6 +1259,7 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution:
@@ -1262,6 +1268,7 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution:
@@ -1270,6 +1277,7 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution:
@@ -1278,6 +1286,7 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution:
@@ -1286,6 +1295,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution:
@@ -1294,6 +1304,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution:
@@ -3985,6 +3996,7 @@ packages:
         integrity: sha512-TC0NKVHcJZ9QvkEDyuMB327lT0xQIcZoIE3aSNOHN4Bkt1TcF+D/zAMQTl2AVTAYdrLAqFl6bhTWn5r7VJvkpw==
       }
     engines: { node: '>=20' }
+    bundledDependencies: []
 
   geotiff@2.1.3:
     resolution:


### PR DESCRIPTION
This prevents `npm` and `yarn` from working on this project (force `pnpm`).

Somehow the official solution does not work on my machine https://pnpm.io/only-allow-pnpm. This one doesn't need npx anyway.

```
❯ npm i vue-script
npm warn Unknown project config "side-effects-cache". This will stop working in the next major version of npm.
npm warn Unknown project config "strict-peer-dependencies". This will stop working in the next major version of npm.
npm warn Unknown project config "node-linker". This will stop working in the next major version of npm.
npm warn Unknown project config "minimum-release-age". This will stop working in the next major version of npm.
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: udata-front-kit@0.4.0
npm error notsup Not compatible with your version of node/npm: udata-front-kit@0.4.0
npm error notsup Required: {"node":">= 20.0.0","npm":"please-use-pnpm","yarn":"please-use-pnpm","pnpm":">= 10.0.0"}
npm error notsup Actual:   {"npm":"11.6.0","node":"v24.9.0"}
npm error A complete log of this run can be found in: /Users/alexandre/.npm/_logs/2025-12-04T17_19_12_054Z-debug-0.log

ecospheres-front on  feat/disable-npm [$!] via  v24.9.0
❯ npm i
npm warn Unknown project config "side-effects-cache". This will stop working in the next major version of npm.
npm warn Unknown project config "strict-peer-dependencies". This will stop working in the next major version of npm.
npm warn Unknown project config "node-linker". This will stop working in the next major version of npm.
npm warn Unknown project config "minimum-release-age". This will stop working in the next major version of npm.
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: udata-front-kit@0.4.0
npm error notsup Not compatible with your version of node/npm: udata-front-kit@0.4.0
npm error notsup Required: {"node":">= 20.0.0","npm":"please-use-pnpm","yarn":"please-use-pnpm","pnpm":">= 10.0.0"}
npm error notsup Actual:   {"npm":"11.6.0","node":"v24.9.0"}
npm error A complete log of this run can be found in: /Users/alexandre/.npm/_logs/2025-12-04T17_19_24_335Z-debug-0.log
```