### PR TITLE
chore: pin github actions shas

### DIFF
--- a/.github/workflows/deploy-review-from-comment.yml
+++ b/.github/workflows/deploy-review-from-comment.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Get PR branch
         if: steps.parse.outputs.should_deploy == 'true'
         id: get_pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -53,7 +53,7 @@ jobs:
 
       - name: React to comment
         if: steps.parse.outputs.should_deploy == 'true'
-        uses: peter-evans/create-or-update-comment@v4.0.0
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           comment-id: ${{ github.event.comment.id }}
@@ -65,7 +65,7 @@ jobs:
     if: needs.check_comment.outputs.should_deploy == 'true'
     steps:
       - name: Trigger review app workflow
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Check if review app exists
         id: check_app
         continue-on-error: true
-        uses: appleboy/ssh-action@v1.2.2
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0 # v1.2.4
         with:
           host: ${{ secrets.REVIEW_APP_SSH_HOST }}
           username: dokku
@@ -126,13 +126,13 @@ jobs:
 
       - name: Cloning repo
         if: env.SHOULD_DEPLOY == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Start deployment
         if: env.SHOULD_DEPLOY == 'true'
-        uses: chrnorm/deployment-action@v2
+        uses: chrnorm/deployment-action@55729fcebec3d284f60f5bcabbd8376437d696b1 # v2.0.7
         id: deployment
         with:
           token: ${{ github.token }}
@@ -142,7 +142,7 @@ jobs:
 
       - name: Create the review app
         if: env.SHOULD_CREATE == 'true'
-        uses: dokku/github-action@master
+        uses: dokku/github-action@823c08b33e974704528c7c7f3d3d8002426e7634 # v1.9.0
         with:
           command: review-apps:create
           git_remote_url: ${{ secrets.REVIEW_APP_SSH_URL }}
@@ -153,7 +153,7 @@ jobs:
 
       - name: Set site id as build arg
         if: env.SHOULD_DEPLOY == 'true'
-        uses: appleboy/ssh-action@v1.2.2
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0 # v1.2.4
         with:
           host: ${{ secrets.REVIEW_APP_SSH_HOST }}
           username: dokku
@@ -164,7 +164,7 @@ jobs:
 
       - name: Push to dokku
         if: env.SHOULD_DEPLOY == 'true'
-        uses: dokku/github-action@v1.0.0
+        uses: dokku/github-action@823c08b33e974704528c7c7f3d3d8002426e7634 # v1.9.0
         with:
           git_remote_url: ${{ secrets.REVIEW_APP_SSH_URL }}
           review_app_name: deploy-preview-${{ env.PR_NUMBER }}--${{ env.SITE }}
@@ -174,7 +174,7 @@ jobs:
 
       - name: Enable SSL with Let's Encrypt
         if: env.SHOULD_CREATE == 'true'
-        uses: appleboy/ssh-action@v1.2.2
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0 # v1.2.4
         with:
           host: ${{ secrets.REVIEW_APP_SSH_HOST }}
           username: dokku
@@ -185,7 +185,7 @@ jobs:
 
       - name: Destroy the review app
         if: github.event.action == 'closed' && env.SHOULD_DESTROY == 'true'
-        uses: dokku/github-action@master
+        uses: dokku/github-action@823c08b33e974704528c7c7f3d3d8002426e7634 # v1.9.0
         with:
           command: review-apps:destroy
           git_remote_url: ${{ secrets.REVIEW_APP_SSH_URL }}
@@ -194,7 +194,7 @@ jobs:
 
       - name: Update deployment status
         if: env.SHOULD_DEPLOY == 'true'
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@9a72af4586197112e0491ea843682b5dc280d806 # v2.0.3
         with:
           token: ${{ github.token }}
           environment-url: https://deploy-preview-${{ env.PR_NUMBER }}--${{ env.SITE }}.sandbox.data.developpement-durable.gouv.fr

--- a/.github/workflows/robots.yml
+++ b/.github/workflows/robots.yml
@@ -14,11 +14,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20.x
           cache: 'pnpm'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
     name: Lint and type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20.x
           cache: 'pnpm'
@@ -29,11 +29,11 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20.x
           cache: 'pnpm'
@@ -57,11 +57,11 @@ jobs:
             culture
           ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20.x
           cache: 'pnpm'


### PR DESCRIPTION
This pins all GitHub Actions to know SHAs (latest patch release of previously specified versions), protecting us from a supply chain attack on tags forgeries or malicious new releases. The hypothesis is that our current versions are sane...

Putting the version in comment makes it more palatable and should allow [dependabot to propose security fixes](https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#supported-ecosystems-and-repositories) (maybe we should auto update the versions proactively at some point, but this can be more dangerous than not).

Cf https://mattermost.incubateur.net/betagouv/pl/qwdzknumuibedn4ckw8td9sjre