### PR TITLE
feat(simplifions): filter fournisseurs de services

### DIFF
--- a/src/custom/simplifions/components/SimplifionsTags.vue
+++ b/src/custom/simplifions/components/SimplifionsTags.vue
@@ -76,11 +76,13 @@ const filteredFournisseursDeService = computed(() => {
   )
   const rootElement = 'Tous les acteurs publics'
   const topLevelElements = names
-    .filter((name) => name !== rootElement)
-    // Include generic elements, like "Toutes les collectivités"
-    .filter((name) => !name.match(/^Tou(t|s|tes)/))
-    // Include "État"
-    .filter((name) => name !== 'État')
+    .filter((name) => {
+      return (
+        name !== rootElement &&
+        // Include generic elements like "Tous les..." and "Etat"
+        (name.match(/^Tou(t|s|tes)/) || name === 'État')
+      )
+    })
     .sort()
   const specificElements = names
     .filter((name) => !topLevelElements.includes(name) && name !== rootElement)


### PR DESCRIPTION
Fix https://linear.app/pole-api/issue/API-6154/afficher-les-nouveaux-libelles-a-destination-de-dans-les-solutions-et

L'idéal aurait été d'afficher directement le contenu du champ "A destination de", mais n'ayant pas accès aux données du Grist à l'affichage dans les cartes, j'ai opté pour un hack qui supprime les valeurs de type "Tous les...", "Toutes les..." des valeurs affichées pour les fournisseurs de services.

Faut-il également filtrer "Etat" ?

A voir si ça fait le taf ou s'il faut partir sur quelque chose de plus compliqué, comme envoyer les valeurs en tant qu'extras du Topic depuis le DAG.

Aussi, je crois qu'on n'a plus de valeurs "Autres" à traiter, donc j'ai supprimé cette partie. Tu me diras @DorineLam.