### PR TITLE
feat: add md titles anchors

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "dompurify": "^3.2.3",
     "maplibre-gl": "^5.3.0",
     "marked": "^15.0.6",
+    "marked-gfm-heading-id": "^4.1.3",
     "pinia": "^2.3.0",
     "string-strip-html": "^13.4.8",
     "vite-plugin-html": "^3.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       marked:
         specifier: ^15.0.6
         version: 15.0.12
+      marked-gfm-heading-id:
+        specifier: ^4.1.3
+        version: 4.1.3(marked@15.0.12)
       pinia:
         specifier: ^2.3.0
         version: 2.3.1(typescript@5.7.3)(vue@3.5.25(typescript@5.7.3))
@@ -3029,8 +3032,8 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.23:
-    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+  lodash-es@4.17.22:
+    resolution: {integrity: sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==}
 
   lodash._reinterpolate@3.0.0:
     resolution: {integrity: sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==}
@@ -3051,8 +3054,8 @@ packages:
   lodash.templatesettings@4.2.0:
     resolution: {integrity: sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -3120,6 +3123,11 @@ packages:
     resolution: {integrity: sha512-eOsq7EGd3asV0oBfmyqngeEIhrbkc7XVP63OwcJBIhH2EpG2PzFcbZdhy1jutXSlRBBVMNXHvMtSr5LAxSUvUg==}
     engines: {node: '>=0.10.0'}
     hasBin: true
+
+  marked-gfm-heading-id@4.1.3:
+    resolution: {integrity: sha512-aR0i63LmFbuxU/gAgrgz1Ir+8HK6zAIFXMlckeKHpV+qKbYaOP95L4Ux5Gi+sKmCZU5qnN2rdKpvpb7PnUBIWg==}
+    peerDependencies:
+      marked: '>=13 <18'
 
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
@@ -6545,7 +6553,7 @@ snapshots:
       is-installed-globally: 0.4.0
       lazy-ass: 1.6.0
       listr2: 3.14.0(enquirer@2.4.1)
-      lodash: 4.17.23
+      lodash: 4.17.21
       log-symbols: 4.1.0
       minimist: 1.2.8
       ospath: 1.2.2
@@ -6806,7 +6814,7 @@ snapshots:
 
   eslint-plugin-json@4.0.1:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.17.21
       vscode-json-languageservice: 4.2.1
 
   eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1))(eslint@9.39.1)(prettier@3.6.2):
@@ -7823,7 +7831,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.23: {}
+  lodash-es@4.17.22: {}
 
   lodash._reinterpolate@3.0.0: {}
 
@@ -7842,7 +7850,7 @@ snapshots:
     dependencies:
       lodash._reinterpolate: 3.0.0
 
-  lodash@4.17.23: {}
+  lodash@4.17.21: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -7944,6 +7952,11 @@ snapshots:
       remarkable: 1.7.4
       repeat-string: 1.6.1
       strip-color: 0.1.0
+
+  marked-gfm-heading-id@4.1.3(marked@15.0.12):
+    dependencies:
+      github-slugger: 2.0.0
+      marked: 15.0.12
 
   marked@15.0.12: {}
 
@@ -9059,7 +9072,7 @@ snapshots:
       '@types/lodash-es': 4.17.12
       codsen-utils: 1.7.0
       html-entities: 2.6.0
-      lodash-es: 4.17.23
+      lodash-es: 4.17.22
       ranges-apply: 7.1.0
       ranges-push: 7.1.0
       string-left-right: 6.1.0
@@ -9682,7 +9695,7 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.6.0
-      lodash: 4.17.23
+      lodash: 4.17.21
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
@@ -9737,7 +9750,7 @@ snapshots:
     dependencies:
       axios: 1.13.2(debug@4.4.3)
       joi: 18.0.2
-      lodash: 4.17.23
+      lodash: 4.17.21
       minimist: 1.2.8
       rxjs: 7.8.2
     transitivePeerDependencies:

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,13 +1,14 @@
 import DOMPurify from 'dompurify'
 import { marked } from 'marked'
+import { gfmHeadingId } from 'marked-gfm-heading-id'
 import { stripHtml } from 'string-strip-html'
 import type { Ref } from 'vue'
 
+marked.use(gfmHeadingId())
+
 const markedOptions = {
   gfm: true,
-  breaks: true,
-  mangle: false,
-  headerIds: false
+  breaks: true
 }
 
 /**


### PR DESCRIPTION
Add anchors generation through `marked-gfm-heading-id` and remove deprecated marked config attributes: `mangle` and `headerIds`.