### PR TITLE
fix(ci): --no-tags in set next release version

### DIFF
--- a/.github/workflows/create-deploy-release.yml
+++ b/.github/workflows/create-deploy-release.yml
@@ -145,7 +145,9 @@ jobs:
           pattern="${CONFIG_NAME}-${ENV}-[0-9]+\.[0-9]+\.[0-9]+$"
           tags=$(git ls-remote --tags origin | grep -Eo "refs/tags/${pattern}" | sed 's#refs/tags/##' || true)
           if [ -n "$tags" ]; then
-              for tag in $tags; do git fetch origin tag $tag; done
+              # --no-tags prevents git from auto-following related tags,
+              # which would cause "tag already exists" errors on subsequent fetches
+              for tag in $tags; do git fetch --no-tags origin tag $tag; done
           fi
           RELEASE_VERSION=$(../${{ env.SCAFFOLD_DIR }}/scripts/bump_version_non_semver.sh $CONFIG_NAME $ENV $VERSION_TYPE)
 


### PR DESCRIPTION
Ran into a problem in https://github.com/opendatateam/udata-front-kit/actions/runs/21430426770/job/61708336525

This makes sure we only fetch the tags we care about. Worked in https://github.com/opendatateam/udata-front-kit/actions/runs/21430677247/job/61709062128.

Also, I don't have access to `bump_version_non_semver.sh` somehow, but couldn't that script rely on `git ls-remote --tags origin` too, instead of locally cloned tags?