### PR TITLE
feat(seo): inject tags as meta keywords

### DIFF
--- a/src/views/topics/TopicDetailView.vue
+++ b/src/views/topics/TopicDetailView.vue
@@ -207,6 +207,14 @@ const metaDescription = (): string | undefined => {
   return topic.value?.description ?? ''
 }
 
+const metaKeywords = computed(() => {
+  const tags = topic.value?.tags
+  if (!tags?.length) return undefined
+  const prefix = pageConf.filter_prefix
+  const keywords = prefix ? tags.filter((t) => !t.startsWith(prefix)) : tags
+  return keywords.length ? keywords.join(', ') : undefined
+})
+
 const metaTitle = computed(() => {
   return topic.value?.name
 })
@@ -234,6 +242,9 @@ useHead({
     },
     { name: 'description', content: metaDescription() },
     { property: 'og:description', content: metaDescription() },
+    ...(metaKeywords.value != null
+      ? [{ name: 'keywords', content: metaKeywords.value }]
+      : []),
     ...(topic.value?.private
       ? [{ name: 'robots', content: 'noindex, nofollow' }]
       : [])


### PR DESCRIPTION
This injects the Topic's tags into meta keywords, filtering out the tags used for filtering.

<img width="1106" height="402" alt="Capture d’écran 2026-02-25 à 09 54 09" src="https://github.com/user-attachments/assets/9298a9d6-c35d-4f02-aa81-ede62087869d" />
