### PR TITLE
fix: bring back spatial coverage to TopicForm

### DIFF
--- a/src/components/forms/topic/TopicForm.vue
+++ b/src/components/forms/topic/TopicForm.vue
@@ -28,9 +28,6 @@ const props = defineProps({
   }
 })
 
-const hasSpatialCoverage = pageConf.filters.some(
-  (f) => f.type === 'spatial_zone'
-)
 const spatialCoverage = useSpatialCoverage(topic)
 
 const filters = pageConf.filters.filter((f) => f.form != null)
@@ -206,7 +203,7 @@ defineExpose({
     />
   </div>
   <!-- Spatial coverage -->
-  <div v-if="hasSpatialCoverage" class="fr-select-group">
+  <div class="fr-select-group">
     <label class="fr-label" for="select-spatial-coverage"
       >Couverture territoriale (facultatif)</label
     >


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/940

Spatial coverage on TopicForm was disabled on ecologie.data.gouv.fr by #1058 because of a way-too-smart condition on the existence of a spatial filter.

I removed that condition, since we need the field on ecologie.data.gouv.fr anyway, and the other verticals that use the TopicForm won't mind a non-mandatory field 🤞.