### PR TITLE
chore: pnpm@10.30.3, feat: auto upgrade pnpm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    allow:
+      - dependency-name: 'pnpm'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    allow:
-      - dependency-name: 'pnpm'

--- a/.github/workflows/update-pnpm.yml
+++ b/.github/workflows/update-pnpm.yml
@@ -1,10 +1,6 @@
 name: Update pnpm
 
 on:
-  # FIXME: remove push trigger before merging to main
-  push:
-    branches:
-      - chore/upgrade-pnpm
   schedule:
     - cron: '0 9 * * 1'
   workflow_dispatch:

--- a/.github/workflows/update-pnpm.yml
+++ b/.github/workflows/update-pnpm.yml
@@ -1,0 +1,29 @@
+name: Update pnpm
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  update-pnpm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20.x
+
+      - name: Update pnpm via corepack
+        run: |
+          corepack enable
+          corepack use pnpm@latest
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          commit-message: 'chore: update pnpm'
+          title: 'chore: update pnpm'
+          branch: chore/update-pnpm
+          body: Automated pnpm version bump via `corepack use pnpm@latest`.

--- a/.github/workflows/update-pnpm.yml
+++ b/.github/workflows/update-pnpm.yml
@@ -1,6 +1,10 @@
 name: Update pnpm
 
 on:
+  # FIXME: remove push trigger before merging to main
+  push:
+    branches:
+      - chore/upgrade-pnpm
   schedule:
     - cron: '0 9 * * 1'
   workflow_dispatch:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.24.0",
+  "packageManager": "pnpm@10.30.2",
   "engines": {
     "node": ">= 20.0.0",
     "npm": "please-use-pnpm",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.30.2",
+  "packageManager": "pnpm@10.30.3",
   "engines": {
     "node": ">= 20.0.0",
     "npm": "please-use-pnpm",


### PR DESCRIPTION
This should upgrade pnpm through dependanbot in the future (and we'll still get the security upgrades we have now for the rest).

I'm hoping upgrading pnpm regularly will sync the behavior on various dev machines and avoid huge lock diffs for no reason.