### PR TITLE
feat(dataset): use harvested dates and proper wording

### DIFF
--- a/src/components/datasets/DatasetInformationPanel.vue
+++ b/src/components/datasets/DatasetInformationPanel.vue
@@ -6,10 +6,11 @@ import {
   DatasetInformationSection,
   DatasetSchemaSection,
   DatasetSpatialSection,
-  DatasetTemporalitySection,
   ExtraAccordion
 } from '@datagouv/components-next'
+
 import { storeToRefs } from 'pinia'
+import DatasetTemporalitySection from './DatasetTemporalitySection.vue'
 
 import LeafletMap from './LeafletMap.vue'
 

--- a/src/components/datasets/DatasetTemporalitySection.vue
+++ b/src/components/datasets/DatasetTemporalitySection.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import type {
+  ExtendedDatasetV2WithFullObject,
+  TypedHarvest
+} from '@/model/dataset'
+import {
+  DateRangeDetails,
+  DescriptionListDetails,
+  DescriptionListTerm,
+  useFormatDate
+} from '@datagouv/components-next'
+
+const props = defineProps<{
+  dataset: ExtendedDatasetV2WithFullObject
+}>()
+
+const { formatDate } = useFormatDate()
+
+const harvest = props.dataset.harvest as TypedHarvest
+const harvestCreatedAt = harvest?.created_at
+const harvestIssuedAt = harvest?.issued_at
+const harvestModifiedAt = harvest?.modified_at
+</script>
+
+<template>
+  <div class="space-y-1 py-6">
+    <h3 class="uppercase text-gray-plain text-sm font-bold">Temporalité</h3>
+    <dl class="grid grid-cols-1 md:grid-cols-3 gap-6 p-0">
+      <div>
+        <DescriptionListTerm>Création</DescriptionListTerm>
+        <DescriptionListDetails>{{
+          formatDate(harvestCreatedAt ?? dataset.created_at)
+        }}</DescriptionListDetails>
+      </div>
+      <div v-if="harvestIssuedAt">
+        <DescriptionListTerm>Publication</DescriptionListTerm>
+        <DescriptionListDetails>{{
+          formatDate(harvestIssuedAt)
+        }}</DescriptionListDetails>
+      </div>
+      <div>
+        <DescriptionListTerm>Dernière révision</DescriptionListTerm>
+        <DescriptionListDetails>{{
+          formatDate(harvestModifiedAt ?? dataset.last_update)
+        }}</DescriptionListDetails>
+      </div>
+      <div v-if="dataset.frequency">
+        <DescriptionListTerm>Fréquence</DescriptionListTerm>
+        <DescriptionListDetails>{{
+          dataset.frequency.label
+        }}</DescriptionListDetails>
+      </div>
+      <div v-if="dataset.temporal_coverage">
+        <DescriptionListTerm>Couverture temporelle</DescriptionListTerm>
+        <DescriptionListDetails>
+          <DateRangeDetails :range="dataset.temporal_coverage" />
+        </DescriptionListDetails>
+      </div>
+    </dl>
+  </div>
+</template>

--- a/src/components/datasets/ExtendedInformationPanel.vue
+++ b/src/components/datasets/ExtendedInformationPanel.vue
@@ -3,7 +3,6 @@ import type {
   ExtendedDatasetV2WithFullObject,
   TypedHarvest
 } from '@/model/dataset'
-import { useFormatDate } from '@datagouv/components-next'
 import ExtendedInformationPanelItem from './ExtendedInformationPanelItem.vue'
 
 const props = defineProps({
@@ -13,14 +12,9 @@ const props = defineProps({
   }
 })
 
-const { formatDate } = useFormatDate()
-
 const dcatExtras = props.dataset.extras?.dcat
 const harvest = props.dataset.harvest as TypedHarvest
 const uri = harvest?.uri
-const harvestCreatedAt = harvest?.created_at
-const harvestIssuedAt = harvest?.issued_at
-const harvestModifiedAt = harvest?.modified_at
 </script>
 
 <template>
@@ -32,26 +26,6 @@ const harvestModifiedAt = harvest?.modified_at
         :items="[uri]"
         title="Identifiant de ressource unique"
       />
-      <div class="fr-grid-row">
-        <ExtendedInformationPanelItem
-          v-if="harvestCreatedAt"
-          class="fr-col-12 fr-col-md-4"
-          :items="[formatDate(harvestCreatedAt)]"
-          title="Création"
-        />
-        <ExtendedInformationPanelItem
-          v-if="harvestIssuedAt"
-          class="fr-col-12 fr-col-md-4"
-          :items="[formatDate(harvestIssuedAt)]"
-          title="Publication"
-        />
-        <ExtendedInformationPanelItem
-          v-if="harvestModifiedAt"
-          :items="[formatDate(harvestModifiedAt)]"
-          class="fr-col-12 fr-col-md-4"
-          title="Dernière révision"
-        />
-      </div>
       <ExtendedInformationPanelItem
         :items="dcatExtras?.accessRights"
         title="Conditions d'accès et d'utilisation"


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/810

This replaces the dates in the previously upstreamed `DatasetTemporalitySection.vue` with ones that make more sense from ecologie.data.gouv.fr's perspective (at least). It mostly takes harvested dates into account and normalize wording with "geo-world" specifications.

- Création : `harvestCreatedAt ?? dataset.created_at`
- Publication (facultatif) : `harvestIssuedAt`
- Dernière révision : `harvestModifiedAt ?? dataset.last_update`

Those dates were previously added on top of informations, they're now removed from there.

This probably could be upstreamed, I'll start a discussion.

### Before

<img width="1215" height="661" alt="Capture d’écran 2026-03-05 à 10 32 07" src="https://github.com/user-attachments/assets/0ecd0d59-55c3-4bcf-a1f1-68e7f0675aa2" />

### After

<img width="1223" height="645" alt="Capture d’écran 2026-03-05 à 10 31 48" src="https://github.com/user-attachments/assets/786bd2b2-f9d6-4847-a655-da855409112f" />
