### PR TITLE
feat(codeowners): use teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,5 +18,6 @@
 **/hackathon/     @geoffreyaldebert
 **/logistique/    @johanricher
 **/meteo-france/  @geoffreyaldebert @pierlou
-**/simplifions/   @abulte
+**/simplifions/   @opendatateam/simplifions
 **/accessibilite/ @opendatateam/accessibilite
+**/culture/       @opendatateam/culture


### PR DESCRIPTION
This reflects the new teams defined for access management on the repo.