### PR TITLE
fix: prune in deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -142,9 +142,9 @@ cmd_prepare() {
   info "Preparing deployment: $source_branch → $target_branch"
   info "Using merge branch: $merge_branch"
 
-  # Fetch latest refs
+  # Fetch latest refs (--prune removes stale remote-tracking refs)
   info "Fetching latest from origin..."
-  git fetch origin
+  git fetch --prune origin
 
   # Check target branch exists
   if ! remote_branch_exists "$target_branch"; then


### PR DESCRIPTION
Avoid errors like

```
❯ ./scripts/deploy.sh prepare ecospheres demo minor
Preparing deployment: main → ecospheres-demo
Using merge branch: ecospheres-demo-minor-merge
Fetching latest from origin...
Merge branch 'ecospheres-demo-minor-merge' exists on origin.
Delete it and start fresh? [y/N] y
erreur : suppression de 'ecospheres-demo-minor-merge' impossible : la
référence distante n'existe pas
erreur : impossible de pousser des références vers
'github.com:opendatateam/udata-front-kit.git'
```