### PR TITLE
feat(topics): segmented drafts view

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -446,13 +446,6 @@ pages:
         display: true
     editable: true
     filters:
-      - name: Afficher les brouillons
-        id: include_private
-        type: checkbox
-        default_option:
-        default_value: true
-        authenticated: true
-        values: []
       - name: Organisation
         default_option: Toutes les organisations
         id: organization

--- a/configs/simplifions/config.yaml
+++ b/configs/simplifions/config.yaml
@@ -267,13 +267,6 @@ pages:
         display: false
     editable: false
     filters: # ATTENTION : Ces filtres ont des ids qui correspondent à des valeurs dans Grist
-      - name: Afficher les brouillons
-        id: include_private
-        type: checkbox
-        default_option:
-        default_value: false
-        authenticated: true
-        values: []
       - name: 'À destination de :'
         id: fournisseurs-de-service
         type: select
@@ -324,13 +317,6 @@ pages:
         display: false
     editable: false
     filters: # ATTENTION : Ces filtres ont des ids qui correspondent à des valeurs dans Grist
-      - name: Afficher les brouillons
-        id: include_private
-        type: checkbox
-        default_option:
-        default_value: false
-        authenticated: true
-        values: []
       - name: 'À destination de :'
         id: fournisseurs-de-service
         type: select

--- a/cypress/e2e/custom/ecospheres/topics/list.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/list.cy.ts
@@ -90,17 +90,16 @@ describe('Topics - List Page', () => {
     })
   })
 
-  describe('Draft Checkbox', () => {
-    it('should not show "Afficher les brouillons" checkbox when disconnected', () => {
+  describe('Segmented view control', () => {
+    it('should not be visible to disconnected users', () => {
       cy.visit('/bouquets')
       cy.wait('@get_topics_list')
 
-      // Verify the checkbox does not exist
-      cy.contains('Afficher les brouillons').should('not.exist')
+      cy.contains('Publiés').should('not.exist')
+      cy.contains('Brouillons').should('not.exist')
     })
 
-    it('should show "Afficher les brouillons" checkbox when connected', () => {
-      // Simulate connected user
+    it('should be visible to connected users', () => {
       cy.simulateConnectedUser({
         id: 'test-user-id',
         first_name: 'Test',
@@ -110,12 +109,11 @@ describe('Topics - List Page', () => {
       cy.visit('/bouquets')
       cy.wait('@get_topics_list')
 
-      // Verify the checkbox exists and is visible
-      cy.contains('Afficher les brouillons').should('be.visible')
+      cy.contains('Publiés').should('be.visible')
+      cy.contains('Brouillons').should('be.visible')
     })
 
-    it('should update URL parameter when clicking "Afficher les brouillons"', () => {
-      // Simulate connected user
+    it('should send private=false to the API in published mode', () => {
       cy.simulateConnectedUser({
         id: 'test-user-id',
         first_name: 'Test',
@@ -124,48 +122,24 @@ describe('Topics - List Page', () => {
 
       cy.visit('/bouquets')
       cy.wait('@get_topics_list').then((interception) => {
-        // By default, include_private should be true (from default_value in config)
-        expect(interception.request.url).to.match(
-          /[?&]include_private=true(?:&|$)/
-        )
-        expect(interception.request.url).to.match(universeTagRegex)
+        expect(interception.request.url).to.match(/[?&]private=false(?:&|$)/)
+      })
+    })
+
+    it('should send private=true to the API after clicking "Brouillons"', () => {
+      cy.simulateConnectedUser({
+        id: 'test-user-id',
+        first_name: 'Test',
+        last_name: 'User'
       })
 
-      // Initially, include_private should not be in URL (default value)
-      cy.url().should('not.include', 'include_private')
+      cy.visit('/bouquets')
+      cy.wait('@get_topics_list')
 
-      // Verify the checkbox is checked by default
-      cy.contains('Afficher les brouillons')
-        .parent()
-        .find('input[type="checkbox"]')
-        .should('be.checked')
+      cy.contains('Brouillons').click()
 
-      // Click the checkbox to hide drafts
-      cy.contains('Afficher les brouillons').click()
-
-      // Verify URL includes include_private=false
-      cy.url().should('include', 'include_private=false')
-
-      // Wait for the API call with the new parameter
       cy.wait('@get_topics_list').then((interception) => {
-        expect(interception.request.url).to.not.match(
-          /[?&]include_private=true(?:&|$)/
-        )
-        expect(interception.request.url).to.match(universeTagRegex)
-      })
-
-      // Click again to show drafts
-      cy.contains('Afficher les brouillons').click()
-
-      // Verify URL includes include_private=true
-      cy.url().should('include', 'include_private=true')
-
-      // Wait for the API call with the new parameter
-      cy.wait('@get_topics_list').then((interception) => {
-        expect(interception.request.url).to.match(
-          /[?&]include_private=true(?:&|$)/
-        )
-        expect(interception.request.url).to.match(universeTagRegex)
+        expect(interception.request.url).to.match(/[?&]private=true(?:&|$)/)
       })
     })
   })

--- a/src/components/topics/TopicList.vue
+++ b/src/components/topics/TopicList.vue
@@ -22,6 +22,10 @@ const props = defineProps({
   page: {
     type: String,
     default: '1'
+  },
+  isDraftsView: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -61,13 +65,14 @@ const clearFilters = () => {
 
 const executeQuery = async () => {
   const loader = useLoading().show({ enforceFocus: false })
-  // get filters parameters from route
   return topicStore
     .query(
       {
         ...route.query,
-        ...props,
-        sort: route.query.sort || pageConf.default_sort
+        query: props.query,
+        page: props.page,
+        sort: route.query.sort || pageConf.default_sort,
+        private: props.isDraftsView ? 'true' : 'false'
       } as Parameters<typeof topicStore.query>[0],
       pageKey
     )
@@ -100,6 +105,11 @@ watch(
   () => route.query,
   () => executeQuery(),
   { immediate: true, deep: true }
+)
+
+watch(
+  () => props.isDraftsView,
+  () => executeQuery()
 )
 
 defineExpose({

--- a/src/store/TopicStore.ts
+++ b/src/store/TopicStore.ts
@@ -17,6 +17,7 @@ interface QueryArgs {
   query: string
   page: string
   include_private?: string
+  private?: string
   page_size?: string
   featured?: string
 }

--- a/src/views/topics/TopicsListView.vue
+++ b/src/views/topics/TopicsListView.vue
@@ -37,6 +37,17 @@ useAccessibilityProperties(toRef(props, 'query'), searchResultsMessage)
 
 const userStore = useUserStore()
 
+const isDraftsView = ref(false)
+
+const segmentedOptions = [
+  { value: 'published', label: 'Publiés' },
+  { value: 'drafts', label: 'Brouillons' }
+]
+
+const setView = (value: string | number) => {
+  isDraftsView.value = value === 'drafts'
+}
+
 const links = [
   { to: '/', text: 'Accueil' },
   { text: pageConf.breadcrumb_title || pageConf.title }
@@ -124,10 +135,19 @@ onMounted(() => {
           </div>
         </nav>
         <div className="fr-col-12 fr-col-md-8">
+          <div v-if="userStore.isLoggedIn" class="fr-mb-2w">
+            <DsfrSegmentedSet
+              name="topic-view"
+              :model-value="isDraftsView ? 'drafts' : 'published'"
+              :options="segmentedOptions"
+              @update:model-value="setView"
+            />
+          </div>
           <TopicList
             ref="topicListComp"
             :query="props.query"
             :page="props.page"
+            :is-drafts-view="isDraftsView"
           />
         </div>
       </div>


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/984

This introduces a segmented drafts view for Topics.

It's based on TBD API on data.gouv.fr's side that supports `private=true|false` param.

<img width="1235" height="653" alt="Capture d’écran 2026-03-19 à 11 34 51" src="https://github.com/user-attachments/assets/e970f8bb-21ba-4280-928d-895e359fa23c" />
