### PR TITLE
fix(ecologie): hp search reset

### DIFF
--- a/src/custom/ecospheres/components/home/HomeHero.vue
+++ b/src/custom/ecospheres/components/home/HomeHero.vue
@@ -10,8 +10,9 @@ const router = useRouter()
 const searchQuery = ref('')
 
 const doSearch = (q: string) => {
-  router.push({ name: 'datasets', query: { q } })
-  searchQuery.value = ''
+  router
+    .push({ name: 'datasets', query: { q } })
+    .then(() => (searchQuery.value = ''))
 }
 </script>
 


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1025

Due to double submit in DsfrSearchBar when using Enter: one when pressing Enter, one for form submit. No FIXME because our code stays clean.
