### PR TITLE
fix(indicators): no data handling in viz

### DIFF
--- a/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
@@ -2,7 +2,7 @@ import type { Indicator } from '@/custom/ecospheres/model/indicator'
 import type { Dataservice, Reuse } from '@datagouv/components-next'
 import { dataserviceFactory } from 'cypress/support/factories/dataservices_factory'
 import { reuseFactory } from 'cypress/support/factories/reuses_factory'
-import { createIndicator, createIndicatorResource } from './support'
+import { createIndicator } from './support'
 
 describe('Indicator Detail View', () => {
   let indicator: Indicator
@@ -142,56 +142,6 @@ describe('Indicator Detail View', () => {
       cy.contains(
         "Il n'y a pas encore de réutilisation pour cet indicateur."
       ).should('be.visible')
-    })
-  })
-
-  describe('No Datavisualisation Configured', () => {
-    it('should not display the previsualisation', () => {
-      cy.visit(`/indicators/${indicator.id}`)
-      cy.contains('Prévisualisation').should('not.exist')
-    })
-  })
-
-  describe('Prévisualisation Tab', () => {
-    it('should display an error when the tabular API fails', () => {
-      const indicatorWithViz = createIndicator(
-        {},
-        { enable_visualization: true }
-      )
-      const vizResource = createIndicatorResource()
-      cy.mockDatasetAndRelatedObjects(indicatorWithViz, [vizResource])
-      cy.intercept(
-        'GET',
-        `https://tabular-api*.data.gouv.fr/api/resources/${vizResource.id}/data/**`,
-        { statusCode: 500, body: 'Internal Server Error' }
-      )
-      cy.visit(`/indicators/${indicatorWithViz.id}`)
-      cy.contains('Prévisualisation').click()
-      cy.contains('Erreur lors du chargement').should('be.visible')
-      cy.contains('k: millier, M: million, Md: milliard').should('not.exist')
-    })
-
-    it('should display the previsualisation when enabled', () => {
-      const indicatorWithViz = createIndicator(
-        {},
-        { enable_visualization: true }
-      )
-      const vizResource = createIndicatorResource()
-      cy.mockDatasetAndRelatedObjects(indicatorWithViz, [vizResource])
-      cy.intercept(
-        'GET',
-        `https://tabular-api*.data.gouv.fr/api/resources/${vizResource.id}/data/**`,
-        {
-          statusCode: 200,
-          body: {
-            data: []
-          }
-        }
-      ).as(`tabular_api`)
-      cy.visit(`/indicators/${indicatorWithViz.id}`)
-      cy.contains('Prévisualisation').click()
-      // Check if the visualization element appears
-      cy.get('[data-testid="indicator-viz-chart"]').should('be.visible')
     })
   })
 })

--- a/cypress/e2e/custom/ecospheres/indicators/support.ts
+++ b/cypress/e2e/custom/ecospheres/indicators/support.ts
@@ -64,12 +64,12 @@ export function createIndicator(
   }
 }
 
-export function createIndicatorResource() {
+export function createIndicatorResource(maille: string = 'region') {
   return resourceFactory.one({
     overrides: {
       extras: {
         'ecospheres-indicateurs': {
-          maille: 'region',
+          maille,
           'value-column': 'value',
           axes: {
             annee: ['2020', '2021', '2022'],

--- a/cypress/e2e/custom/ecospheres/indicators/viz.cy.ts
+++ b/cypress/e2e/custom/ecospheres/indicators/viz.cy.ts
@@ -1,0 +1,79 @@
+import { createIndicator, createIndicatorResource } from './support'
+
+describe('Indicator Viz', () => {
+  beforeEach(() => {
+    cy.mockMatomo()
+    cy.mockStaticDatagouv()
+  })
+
+  describe('No Datavisualisation Configured', () => {
+    it('should not display the previsualisation', () => {
+      const indicator = createIndicator({}, { enable_visualization: false })
+      cy.mockDatasetAndRelatedObjects(indicator)
+      cy.visit(`/indicators/${indicator.id}`)
+      cy.contains('Prévisualisation').should('not.exist')
+    })
+  })
+
+  describe('Prévisualisation Tab', () => {
+    it('should display an error when the tabular API fails', () => {
+      const indicatorWithViz = createIndicator(
+        {},
+        { enable_visualization: true }
+      )
+      const vizResource = createIndicatorResource()
+      cy.mockDatasetAndRelatedObjects(indicatorWithViz, [vizResource])
+      cy.intercept(
+        'GET',
+        `https://tabular-api*.data.gouv.fr/api/resources/${vizResource.id}/data/**`,
+        { statusCode: 500, body: 'Internal Server Error' }
+      )
+      cy.visit(`/indicators/${indicatorWithViz.id}`)
+      cy.contains('Prévisualisation').click()
+      cy.contains('Erreur lors du chargement').should('be.visible')
+      cy.contains('k: millier, M: million, Md: milliard').should('not.exist')
+    })
+
+    it('should display a no-data message when the API returns no data', () => {
+      const indicatorWithViz = createIndicator(
+        {},
+        { enable_visualization: true }
+      )
+      const vizResource = createIndicatorResource('fr')
+      cy.mockDatasetAndRelatedObjects(indicatorWithViz, [vizResource])
+      cy.intercept(
+        'GET',
+        `https://tabular-api*.data.gouv.fr/api/resources/${vizResource.id}/data/**`,
+        { statusCode: 200, body: { data: [] } }
+      )
+      cy.visit(`/indicators/${indicatorWithViz.id}`)
+      cy.contains('Prévisualisation').click()
+      cy.contains(
+        'Aucune donnée disponible pour le territoire sélectionné.'
+      ).should('be.visible')
+      cy.get('canvas').should('not.exist')
+    })
+
+    it('should display the previsualisation when enabled', () => {
+      const indicatorWithViz = createIndicator(
+        {},
+        { enable_visualization: true }
+      )
+      const vizResource = createIndicatorResource()
+      cy.mockDatasetAndRelatedObjects(indicatorWithViz, [vizResource])
+      cy.intercept(
+        'GET',
+        `https://tabular-api*.data.gouv.fr/api/resources/${vizResource.id}/data/**`,
+        {
+          statusCode: 200,
+          body: {
+            data: []
+          }
+        }
+      ).as(`tabular_api`)
+      cy.visit(`/indicators/${indicatorWithViz.id}`)
+      cy.contains('Prévisualisation').click()
+      cy.get('[data-testid="indicator-viz-chart"]').should('be.visible')
+    })
+  })
+})

--- a/cypress/e2e/custom/ecospheres/indicators/viz.cy.ts
+++ b/cypress/e2e/custom/ecospheres/indicators/viz.cy.ts
@@ -34,7 +34,7 @@ describe('Indicator Viz', () => {
       cy.contains('k: millier, M: million, Md: milliard').should('not.exist')
     })
 
-    it('should display a no-data message when the API returns no data', () => {
+    it('should display a no-data message when viz is enabled and the API returns no data', () => {
       const indicatorWithViz = createIndicator(
         {},
         { enable_visualization: true }
@@ -52,28 +52,6 @@ describe('Indicator Viz', () => {
         'Aucune donnée disponible pour le territoire sélectionné.'
       ).should('be.visible')
       cy.get('canvas').should('not.exist')
-    })
-
-    it('should display the previsualisation when enabled', () => {
-      const indicatorWithViz = createIndicator(
-        {},
-        { enable_visualization: true }
-      )
-      const vizResource = createIndicatorResource()
-      cy.mockDatasetAndRelatedObjects(indicatorWithViz, [vizResource])
-      cy.intercept(
-        'GET',
-        `https://tabular-api*.data.gouv.fr/api/resources/${vizResource.id}/data/**`,
-        {
-          statusCode: 200,
-          body: {
-            data: []
-          }
-        }
-      ).as(`tabular_api`)
-      cy.visit(`/indicators/${indicatorWithViz.id}`)
-      cy.contains('Prévisualisation').click()
-      cy.get('[data-testid="indicator-viz-chart"]').should('be.visible')
     })
   })
 })

--- a/src/custom/ecospheres/components/indicators/viz/IndicatorVizChart.vue
+++ b/src/custom/ecospheres/components/indicators/viz/IndicatorVizChart.vue
@@ -105,7 +105,12 @@ const isOneYear = computed(
 const chartCanvas = useTemplateRef<HTMLCanvasElement>('chartCanvas')
 const chartTitle = computed(() => props.indicator.title ?? '')
 
-useIndicatorVizChart(chartCanvas, series, indicatorExtras, chartTitle)
+const { hasNoData } = useIndicatorVizChart(
+  chartCanvas,
+  series,
+  indicatorExtras,
+  chartTitle
+)
 
 onMounted(() => {
   debug.log(`🔍 Indicator ${props.indicator.id} extras:`, indicatorExtras.value)
@@ -139,7 +144,11 @@ onMounted(() => {
         Erreur lors du chargement : <em>{{ error }}</em>
       </div>
 
-      <div v-if="!isOneYear && !error" class="canvas-container">
+      <div v-else-if="hasNoData && !isLoading" class="no-data-container">
+        Aucune donnée disponible pour le territoire sélectionné.
+      </div>
+
+      <div v-else-if="!isOneYear" class="canvas-container">
         <div v-if="isLoading" class="loading-overlay">
           <span class="loading-text">Chargement...</span>
         </div>
@@ -150,7 +159,7 @@ onMounted(() => {
       </div>
 
       <IndicatorVizOneYearValue
-        v-if="isOneYear && series[0]?.data[0]"
+        v-else-if="isOneYear && series[0]?.data[0]"
         :year="series[0].data[0].x"
         :value="series[0].data[0].y"
         :unite="indicatorExtras.unite"
@@ -229,7 +238,8 @@ onMounted(() => {
   color: #666;
 }
 
-.error-container {
+.error-container,
+.no-data-container {
   margin-top: 32px;
   margin-bottom: 32px;
 }

--- a/src/custom/ecospheres/components/indicators/viz/IndicatorVizChart.vue
+++ b/src/custom/ecospheres/components/indicators/viz/IndicatorVizChart.vue
@@ -75,12 +75,8 @@ const { rawData, availableAxisValues, isLoading, error } = useTabularData(
 const axisFilters = ref<Record<string, string[]>>({})
 const groupedAxis = ref<Record<string, boolean>>({})
 
-watch(availableAxisValues, (axisValues, oldAxisValues) => {
-  const newKeys = Object.keys(axisValues).sort().join(',')
-  const oldKeys = Object.keys(oldAxisValues ?? {})
-    .sort()
-    .join(',')
-  if (newKeys === oldKeys) return
+watch(availableAxisValues, (axisValues) => {
+  if (Object.keys(axisValues).length === 0) return
   axisFilters.value = { ...axisValues }
   groupedAxis.value = Object.fromEntries(
     Object.keys(axisValues).map((axis) => [axis, summable.value])
@@ -100,6 +96,12 @@ const series = computed(() =>
 
 const isOneYear = computed(
   () => series.value.length === 1 && series.value[0].data.length === 1
+)
+
+const hasNoAxisSelected = computed(
+  () =>
+    Object.keys(availableAxisValues.value).length > 0 &&
+    Object.values(axisFilters.value).some((v) => v.length === 0)
 )
 
 const chartCanvas = useTemplateRef<HTMLCanvasElement>('chartCanvas')
@@ -144,6 +146,14 @@ onMounted(() => {
         v-if="error"
         type="error"
         :description="`Erreur lors du chargement : ${error}`"
+        :small="true"
+        class="fr-mt-4w"
+      />
+
+      <DsfrAlert
+        v-else-if="hasNoAxisSelected && !isLoading"
+        type="info"
+        description="Aucune valeur d'axe sélectionnée."
         :small="true"
         class="fr-mt-4w"
       />

--- a/src/custom/ecospheres/components/indicators/viz/IndicatorVizChart.vue
+++ b/src/custom/ecospheres/components/indicators/viz/IndicatorVizChart.vue
@@ -140,13 +140,21 @@ onMounted(() => {
         />
       </div>
 
-      <div v-if="error" class="error-container">
-        Erreur lors du chargement : <em>{{ error }}</em>
-      </div>
+      <DsfrAlert
+        v-if="error"
+        type="error"
+        :description="`Erreur lors du chargement : ${error}`"
+        :small="true"
+        class="fr-mt-4w"
+      />
 
-      <div v-else-if="hasNoData && !isLoading" class="no-data-container">
-        Aucune donnée disponible pour le territoire sélectionné.
-      </div>
+      <DsfrAlert
+        v-else-if="hasNoData && !isLoading"
+        type="info"
+        description="Aucune donnée disponible pour le territoire sélectionné."
+        :small="true"
+        class="fr-mt-4w"
+      />
 
       <div v-else-if="!isOneYear" class="canvas-container">
         <div v-if="isLoading" class="loading-overlay">
@@ -236,12 +244,6 @@ onMounted(() => {
 .loading-text {
   font-size: 0.875rem;
   color: #666;
-}
-
-.error-container,
-.no-data-container {
-  margin-top: 32px;
-  margin-bottom: 32px;
 }
 
 :deep(label) {

--- a/src/custom/ecospheres/components/indicators/viz/useIndicatorVizChart.ts
+++ b/src/custom/ecospheres/components/indicators/viz/useIndicatorVizChart.ts
@@ -104,6 +104,7 @@ export function useIndicatorVizChart(
   let chartInstance: Chart | null = null
   let currentType: 'bar' | 'line' | null = null
   let currentIsMultiSeries: boolean | null = null
+  const hasNoData = ref(false)
 
   function destroyChart() {
     if (chartInstance) {
@@ -115,10 +116,11 @@ export function useIndicatorVizChart(
   }
 
   function createOrUpdateChart(newSeries: IndicatorVizChartSeries[]) {
-    const hasNoData =
+    const noData =
       newSeries.length === 0 || newSeries.every((s) => s.data.length === 0)
-    if (!canvasRef.value || hasNoData) {
-      if (hasNoData) debug.warn('No data to display')
+    hasNoData.value = noData
+    if (!canvasRef.value || noData) {
+      if (noData) debug.warn('No data to display')
       return
     }
     debug.log(`⚙️ Computing chart`, { datasetsCount: newSeries.length })
@@ -152,7 +154,10 @@ export function useIndicatorVizChart(
   })
   watch(canvasRef, (canvas) => {
     if (!canvas) destroyChart()
+    else createOrUpdateChart(series.value)
   })
 
   onBeforeUnmount(destroyChart)
+
+  return { hasNoData }
 }

--- a/src/custom/ecospheres/components/indicators/viz/useTabularData.ts
+++ b/src/custom/ecospheres/components/indicators/viz/useTabularData.ts
@@ -52,7 +52,9 @@ export function useTabularData(
       resource.extras['ecospheres-indicateurs']?.axes ?? {}
     )
     return axisKeys.reduce<Record<string, string[]>>((acc, axis) => {
-      acc[axis] = [...new Set(rawData.value.map((row) => String(row[axis])))]
+      acc[axis] = [
+        ...new Set(rawData.value.map((row) => String(row[axis])))
+      ].sort()
       return acc
     }, {})
   })


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1040

Handles the case where no data is available for a given territory.

Lightweight solution to https://github.com/ecolabdata/ecospheres/issues/1040, I didn't do:
- auto-switch to filled-in territory
- filtering out territories with no data

It maybe feels a bit over-engineered (after all, we only need data for Auvergne Rhone Alpes for the feature to become quite useless), plus it might be disturbing for the user to not find its territory in the list without explanation. Also, would be not trivial to implement with interesting edge cases (an empty file would fire a query for all territories for example). WDYT @lcolumelli @Thesauruv?

<img width="1204" height="443" alt="Capture d’écran 2026-05-06 à 08 20 43" src="https://github.com/user-attachments/assets/a67a3a5e-9745-4bd1-853c-7d34e2034786" />

<img width="2396" height="738" alt="image" src="https://github.com/user-attachments/assets/80e8a483-7bd1-44b0-9c5d-89476cd9367b" />

Example: https://deploy-preview-1173--ecospheres.sandbox.data.developpement-durable.gouv.fr/indicators/69e0e67708ce9429e6c4b551