### PR TITLE
fix(seo): canonical urls, indicators slug, meta description length

### DIFF
--- a/src/components/datasets/ContactPoints.vue
+++ b/src/components/datasets/ContactPoints.vue
@@ -40,7 +40,7 @@ onMounted(() => {
   >
     <a
       :href="getLink(contactPoint)"
-      rel="ugc nofollow noopener"
+      rel="ugc noopener"
       target="_blank"
       class="fr-text--sm fr-link text-grey-50 text-overflow-ellipsis overflow-hidden"
     >

--- a/src/custom/ecospheres/components/datasets/DatasetOrIndicatorCard.vue
+++ b/src/custom/ecospheres/components/datasets/DatasetOrIndicatorCard.vue
@@ -15,7 +15,7 @@ const datasetIsIndicator = isIndicator(toRef(props, 'dataset'))
 
 const url = computed(() =>
   datasetIsIndicator.value
-    ? { name: 'indicators_detail', params: { item_id: props.dataset.id } }
+    ? { name: 'indicators_detail', params: { item_id: props.dataset.slug } }
     : props.datasetUrl
 )
 </script>

--- a/src/custom/ecospheres/components/indicators/IndicatorCard.vue
+++ b/src/custom/ecospheres/components/indicators/IndicatorCard.vue
@@ -18,7 +18,10 @@ defineProps({
         <IndicatorTags :indicator="dataset" :show-default-value="false" />
         <h3 class="fr-card__title fr-mb-1w">
           <RouterLink
-            :to="{ name: 'indicators_detail', params: { item_id: dataset.id } }"
+            :to="{
+              name: 'indicators_detail',
+              params: { item_id: dataset.slug }
+            }"
             >{{ dataset.title }}</RouterLink
           >
         </h3>

--- a/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
+++ b/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
@@ -23,12 +23,14 @@ import { useUserStore } from '@/store/UserStore'
 import { descriptionFromMarkdown } from '@/utils'
 import { usePageConf } from '@/utils/config'
 import { useLabels } from '@/utils/labels'
+import { toMetaDescription, useCanonical } from '@/utils/seo'
 import IndicatorInformationPanel from '../../components/indicators/IndicatorInformationPanel.vue'
 import IndicatorSourcesList from '../../components/indicators/IndicatorSourcesList.vue'
 import type { Indicator } from '../../model/indicator'
 
 const route = useRouteParamsAsString()
 const indicatorId = route.params.item_id
+const router = useRouter()
 
 const datasetStore = useDatasetStore()
 const userStore = useUserStore()
@@ -90,8 +92,8 @@ const activeTab = ref(0)
 
 const description = computed(() => descriptionFromMarkdown(indicator))
 
-const metaDescription = (): string | undefined => {
-  return indicator.value?.description ?? ''
+const metaDescription = (): string => {
+  return toMetaDescription(indicator.value?.description)
 }
 
 const metaTitle = computed(() => {
@@ -109,11 +111,27 @@ useHead({
   ]
 })
 
+useCanonical(() => {
+  const slug = indicator.value?.slug
+  if (!slug) return null
+  const resolved = router.resolve({
+    name: 'indicators_detail',
+    params: { item_id: slug }
+  })
+  return `${window.location.origin}${resolved.href}`
+})
+
 onMounted(() => {
   datasetStore
     .load(indicatorId, { toasted: false, redirectNotFound: true })
     .then(() => {
       setAccessibilityProperties(indicator.value?.title)
+      if (indicator.value?.slug && indicator.value.slug !== indicatorId) {
+        router.push({
+          name: 'indicators_detail',
+          params: { item_id: indicator.value.slug }
+        })
+      }
     })
 })
 </script>

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,0 +1,26 @@
+import { useHead } from '@unhead/vue'
+import type { MaybeRefOrGetter } from 'vue'
+import { toValue } from 'vue'
+
+import { stripFromMarkdown } from '@/utils'
+
+// Google displays ~160 chars; 155 gives a safe margin before it truncates
+const META_DESCRIPTION_MAX_LENGTH = 155
+
+export function toMetaDescription(value: string | null | undefined): string {
+  if (!value) return ''
+  const plain = stripFromMarkdown(value)
+  if (plain.length <= META_DESCRIPTION_MAX_LENGTH) return plain
+  return plain.slice(0, META_DESCRIPTION_MAX_LENGTH).trimEnd() + '…'
+}
+
+export function useCanonical(
+  href: MaybeRefOrGetter<string | undefined | null>
+) {
+  useHead({
+    link: () => {
+      const url = toValue(href)
+      return url ? [{ rel: 'canonical', href: url }] : []
+    }
+  })
+}

--- a/src/views/dataservices/DataserviceDetailView.vue
+++ b/src/views/dataservices/DataserviceDetailView.vue
@@ -21,6 +21,7 @@ import { useCurrentPageConf, useRouteParamsAsString } from '@/router/utils'
 import { useDataserviceStore } from '@/store/DataserviceStore'
 import { descriptionFromMarkdown, formatDate } from '@/utils'
 import { useAsyncComponent } from '@/utils/component'
+import { useCanonical } from '@/utils/seo'
 import SwaggerClient from '@datagouv/components-next/src/components/ResourceAccordion/Swagger.client.vue'
 
 const route = useRouteParamsAsString()
@@ -106,6 +107,8 @@ const goToBusinessDocumentation = () => {
 const getDatasetPage = (id: string) => {
   return { name: 'datasets_detail', params: { item_id: id } }
 }
+
+useCanonical(() => dataservice.value?.self_web_url)
 
 onMounted(() => {
   dataserviceStore

--- a/src/views/datasets/DatasetDetailView.vue
+++ b/src/views/datasets/DatasetDetailView.vue
@@ -26,6 +26,7 @@ import { useLabels } from '@/utils/labels'
 import type { OgcLayerInfo } from '@/utils/ogcServices'
 import { fetchAllOgcResources } from '@/utils/ogcServices'
 import { openInQgis } from '@/utils/qgis'
+import { useCanonical } from '@/utils/seo'
 
 const route = useRouteParamsAsString()
 const datasetIdOrSlug = route.params.item_id
@@ -133,6 +134,8 @@ const exploreUrl = computed(() => {
     mainResources?.resources.find((r) => r.preview_url)?.preview_url ?? null
   )
 })
+
+useCanonical(() => dataset.value?.page)
 
 onMounted(() => {
   datasetStore

--- a/src/views/organizations/OrganizationDetailView.vue
+++ b/src/views/organizations/OrganizationDetailView.vue
@@ -15,6 +15,7 @@ import { useRouteParamsAsString } from '@/router/utils'
 import { useDatasetStore } from '@/store/OrganizationDatasetStore'
 import { useOrganizationStore } from '@/store/OrganizationStore'
 import { descriptionFromMarkdown } from '@/utils'
+import { useCanonical } from '@/utils/seo'
 
 const route = useRouteParamsAsString()
 const organizationId = route.params.oid
@@ -40,6 +41,8 @@ const selectedSort: Ref<string | undefined> = ref(undefined)
 const setAccessibilityProperties = inject(
   AccessibilityPropertiesKey
 ) as AccessibilityPropertiesType
+
+useCanonical(() => org.value?.page)
 
 onMounted(() => {
   orgStore

--- a/src/views/topics/TopicDetailView.vue
+++ b/src/views/topics/TopicDetailView.vue
@@ -37,6 +37,7 @@ import { descriptionFromMarkdown, formatDate } from '@/utils'
 import { getOwnerAvatar } from '@/utils/avatar'
 import { useAsyncComponent } from '@/utils/component'
 import { useLabels } from '@/utils/labels'
+import { toMetaDescription, useCanonical } from '@/utils/seo'
 import { useSpatialCoverage } from '@/utils/spatial'
 import { useTagsByRef } from '@/utils/tags'
 import { useExtras, useTopicFactors } from '@/utils/topic'
@@ -193,8 +194,8 @@ const togglePublish = () => {
     .finally(() => loader.hide())
 }
 
-const metaDescription = (): string | undefined => {
-  return topic.value?.description ?? ''
+const metaDescription = (): string => {
+  return toMetaDescription(topic.value?.description)
 }
 
 const metaKeywords = computed(() => {
@@ -208,14 +209,6 @@ const metaKeywords = computed(() => {
 const metaTitle = computed(() => {
   return topic.value?.name
 })
-
-const metaLink = (): string => {
-  const resolved = router.resolve({
-    name: `${pageKey}_detail`,
-    params: { item_id: topic.value?.slug }
-  })
-  return `${window.location.origin}${resolved.href}`
-}
 
 const handleNavigateToFactor = (elementId: string) => {
   activeTab.value = 0
@@ -238,8 +231,17 @@ useHead({
     ...(topic.value?.private
       ? [{ name: 'robots', content: 'noindex, nofollow' }]
       : [])
-  ],
-  link: [{ rel: 'canonical', href: metaLink }]
+  ]
+})
+
+useCanonical(() => {
+  const slug = topic.value?.slug
+  if (!slug) return null
+  const resolved = router.resolve({
+    name: `${pageKey}_detail`,
+    params: { item_id: slug }
+  })
+  return `${window.location.origin}${resolved.href}`
 })
 
 // Handle factor deeplinks: #factor-{id} switches to Données tab and scrolls to factor


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1070
Fix https://github.com/ecolabdata/ecospheres/issues/1071
Fix https://github.com/ecolabdata/ecospheres/issues/1072
Related https://github.com/ecolabdata/ecospheres/issues/999
Related https://github.com/opendatateam/udata-front-kit/issues/915

- Add auto-canonical URLs to objects owned by vertical: Topics for all, indicators for ecologie
- Add canonical URLs to objects owned by data.gouv.fr: dataset, organization, dataservice
- Truncate meta descriptions injected to sensible default
- Use slugs for indicators URLs + redirect (coherent with Topic and what's currently in sitemap)
- Remove `nofollow` on attributions