### PR TITLE
fix: add node_modules to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Prevent https://github.com/opendatateam/udata-front-kit/blob/36998b6fc957f5be3991ad3559ccde42d5837385/Dockerfile#L14 from copying node_modules (could trigger failure by conflict, and will make the copy faster).