### PR TITLE
fix(simplifions): better mockCasUsage

### DIFF
--- a/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
+++ b/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
@@ -1,10 +1,10 @@
 import {
-  mockApidatasetRecommandations,
+  buildApidatasetRecommandations,
+  buildSolutionRecommandation,
   mockApiOrDatasetUtiles,
   mockApisOrDatasets,
   mockCasUsage,
-  mockSolution,
-  mockSolutionRecommandation
+  mockSolution
 } from '../../../support/factories/custom/simplifions/simplifions_mocks'
 
 import './support'
@@ -13,13 +13,12 @@ describe("Simplifions Cas d'usages Show Page", () => {
   beforeEach(() => {
     cy.baseMocksForSimplifions()
 
-    const { gristRecommandation } = mockSolutionRecommandation({
+    const { gristRecommandation } = buildSolutionRecommandation({
       API_et_datasets_utiles_fournis: [],
       Descriptions_des_API_et_datasets_utiles_fournis: [],
       Ces_logiciels_l_integrent_deja: []
     })
     const { topicCasUsage } = mockCasUsage(
-      {},
       {
         slug: 'aides-publiques-entreprises-sourcage',
         name: 'Aides publiques entreprises | Sourçage',
@@ -88,7 +87,7 @@ describe("Simplifions Cas d'usages Show Page", () => {
 
   describe('with an access link in recommandation grist data', () => {
     beforeEach(() => {
-      const { gristRecommandation } = mockSolutionRecommandation({
+      const { gristRecommandation } = buildSolutionRecommandation({
         API_et_datasets_utiles_fournis: [],
         Descriptions_des_API_et_datasets_utiles_fournis: [],
         Ces_logiciels_l_integrent_deja: [],
@@ -96,7 +95,6 @@ describe("Simplifions Cas d'usages Show Page", () => {
       })
 
       const { topicCasUsage } = mockCasUsage(
-        {},
         {
           slug: 'aides-publiques-entreprises-sourcage',
           name: 'Aides publiques entreprises | Sourçage',
@@ -121,9 +119,8 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
   beforeEach(() => {
     cy.baseMocksForSimplifions()
 
-    const { gristRecommandations } = mockApidatasetRecommandations(2)
+    const { gristRecommandations } = buildApidatasetRecommandations(2)
     const { topicCasUsage } = mockCasUsage(
-      {},
       {
         slug: 'aides-publiques-entreprises-sourcage',
         name: 'Aides publiques entreprises | Sourçage',
@@ -148,11 +145,10 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
 
   describe('with an access link in recommandation grist data', () => {
     beforeEach(() => {
-      const { gristRecommandations } = mockApidatasetRecommandations(1, {
+      const { gristRecommandations } = buildApidatasetRecommandations(1, {
         access_link_with_fallback: 'https://example.com'
       })
       const { topicCasUsage } = mockCasUsage(
-        {},
         {
           slug: 'aides-publiques-entreprises-sourcage',
           name: 'Aides publiques entreprises | Sourçage',
@@ -177,7 +173,7 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
       cy.baseMocksForSimplifions()
 
       const { gristRecommandations, dataservicesOrDatasets } =
-        mockApidatasetRecommandations(
+        buildApidatasetRecommandations(
           1,
           {},
           { Type: 'API' },
@@ -185,7 +181,6 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
         )
 
       const { topicCasUsage } = mockCasUsage(
-        {},
         {
           slug: 'dataservice-auth-test',
           name: 'Test with Dataservice Auth',
@@ -211,7 +206,7 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
       cy.baseMocksForSimplifions()
 
       const { gristRecommandations, dataservicesOrDatasets } =
-        mockApidatasetRecommandations(
+        buildApidatasetRecommandations(
           1,
           {
             access_link_with_fallback: 'https://recommandation-url.example.com'
@@ -221,7 +216,6 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
         )
 
       const { topicCasUsage } = mockCasUsage(
-        {},
         {
           slug: 'priority-test',
           name: 'Test URL Priority',
@@ -256,13 +250,13 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
       }
     )
 
-    const { gristRecommandation } = mockSolutionRecommandation({
+    const { gristRecommandation } = buildSolutionRecommandation({
       API_et_datasets_utiles_fournis: gristApisAndDatasets.map((a) => a.id),
       Descriptions_des_API_et_datasets_utiles_fournis:
         gristApiOrDatasetUtiles.map((a) => a.id),
       Ces_logiciels_l_integrent_deja: []
     })
-    const { topicCasUsage } = mockCasUsage({}, {}, [gristRecommandation])
+    const { topicCasUsage } = mockCasUsage({}, [gristRecommandation])
 
     cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
   })
@@ -294,7 +288,7 @@ describe("Simplifions Cas d'usages Show page for cas d'usage with integrating so
       Nom: 'The Best Editor Solution'
     })
 
-    const { gristRecommandation } = mockSolutionRecommandation({
+    const { gristRecommandation } = buildSolutionRecommandation({
       API_et_datasets_utiles_fournis: [],
       Descriptions_des_API_et_datasets_utiles_fournis: [],
       Ces_logiciels_l_integrent_deja: [],
@@ -302,7 +296,7 @@ describe("Simplifions Cas d'usages Show page for cas d'usage with integrating so
         gristEditorSolution.id
       ]
     })
-    const { topicCasUsage } = mockCasUsage({}, {}, [gristRecommandation])
+    const { topicCasUsage } = mockCasUsage({}, [gristRecommandation])
 
     cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
   })

--- a/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
+++ b/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
@@ -26,7 +26,8 @@ describe("Simplifions Cas d'usages Show Page", () => {
         slug: 'aides-publiques-entreprises-sourcage',
         name: 'Aides publiques entreprises | Sourçage',
         description: 'Lorem ipsum dolor sit amet'
-      }
+      },
+      [gristRecommandation]
     )
 
     cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
@@ -104,7 +105,8 @@ describe("Simplifions Cas d'usages Show Page", () => {
           slug: 'aides-publiques-entreprises-sourcage',
           name: 'Aides publiques entreprises | Sourçage',
           description: 'Lorem ipsum dolor sit amet'
-        }
+        },
+        [gristRecommandation]
       )
 
       cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
@@ -132,7 +134,8 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
         slug: 'aides-publiques-entreprises-sourcage',
         name: 'Aides publiques entreprises | Sourçage',
         description: 'Lorem ipsum dolor sit amet'
-      }
+      },
+      gristRecommandations
     )
 
     cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
@@ -162,7 +165,8 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
           slug: 'aides-publiques-entreprises-sourcage',
           name: 'Aides publiques entreprises | Sourçage',
           description: 'Lorem ipsum dolor sit amet'
-        }
+        },
+        gristRecommandations
       )
 
       cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
@@ -196,7 +200,8 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
           slug: 'dataservice-auth-test',
           name: 'Test with Dataservice Auth',
           description: 'Testing authorization_request_url'
-        }
+        },
+        gristRecommandations
       )
 
       cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
@@ -233,7 +238,8 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
           slug: 'priority-test',
           name: 'Test URL Priority',
           description: 'Testing URL priority'
-        }
+        },
+        gristRecommandations
       )
 
       cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
@@ -268,9 +274,11 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
         gristApiOrDatasetUtiles.map((a) => a.id),
       Ces_logiciels_l_integrent_deja: []
     })
-    const { topicCasUsage } = mockCasUsage({
-      Recommandations: [gristRecommandation.id]
-    })
+    const { topicCasUsage } = mockCasUsage(
+      { Recommandations: [gristRecommandation.id] },
+      {},
+      [gristRecommandation]
+    )
 
     cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
   })
@@ -310,9 +318,11 @@ describe("Simplifions Cas d'usages Show page for cas d'usage with integrating so
         gristEditorSolution.id
       ]
     })
-    const { topicCasUsage } = mockCasUsage({
-      Recommandations: [gristRecommandation.id]
-    })
+    const { topicCasUsage } = mockCasUsage(
+      { Recommandations: [gristRecommandation.id] },
+      {},
+      [gristRecommandation]
+    )
 
     cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
   })

--- a/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
+++ b/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
@@ -19,9 +19,7 @@ describe("Simplifions Cas d'usages Show Page", () => {
       Ces_logiciels_l_integrent_deja: []
     })
     const { topicCasUsage } = mockCasUsage(
-      {
-        Recommandations: [gristRecommandation.id]
-      },
+      {},
       {
         slug: 'aides-publiques-entreprises-sourcage',
         name: 'Aides publiques entreprises | Sourçage',
@@ -98,9 +96,7 @@ describe("Simplifions Cas d'usages Show Page", () => {
       })
 
       const { topicCasUsage } = mockCasUsage(
-        {
-          Recommandations: [gristRecommandation.id]
-        },
+        {},
         {
           slug: 'aides-publiques-entreprises-sourcage',
           name: 'Aides publiques entreprises | Sourçage',
@@ -127,9 +123,7 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
 
     const { gristRecommandations } = mockApidatasetRecommandations(2)
     const { topicCasUsage } = mockCasUsage(
-      {
-        Recommandations: gristRecommandations.map((reco) => reco.id)
-      },
+      {},
       {
         slug: 'aides-publiques-entreprises-sourcage',
         name: 'Aides publiques entreprises | Sourçage',
@@ -158,9 +152,7 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
         access_link_with_fallback: 'https://example.com'
       })
       const { topicCasUsage } = mockCasUsage(
-        {
-          Recommandations: gristRecommandations.map((reco) => reco.id)
-        },
+        {},
         {
           slug: 'aides-publiques-entreprises-sourcage',
           name: 'Aides publiques entreprises | Sourçage',
@@ -193,9 +185,7 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
         )
 
       const { topicCasUsage } = mockCasUsage(
-        {
-          Recommandations: gristRecommandations.map((reco) => reco.id)
-        },
+        {},
         {
           slug: 'dataservice-auth-test',
           name: 'Test with Dataservice Auth',
@@ -231,9 +221,7 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
         )
 
       const { topicCasUsage } = mockCasUsage(
-        {
-          Recommandations: gristRecommandations.map((reco) => reco.id)
-        },
+        {},
         {
           slug: 'priority-test',
           name: 'Test URL Priority',
@@ -274,11 +262,7 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
         gristApiOrDatasetUtiles.map((a) => a.id),
       Ces_logiciels_l_integrent_deja: []
     })
-    const { topicCasUsage } = mockCasUsage(
-      { Recommandations: [gristRecommandation.id] },
-      {},
-      [gristRecommandation]
-    )
+    const { topicCasUsage } = mockCasUsage({}, {}, [gristRecommandation])
 
     cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
   })
@@ -318,11 +302,7 @@ describe("Simplifions Cas d'usages Show page for cas d'usage with integrating so
         gristEditorSolution.id
       ]
     })
-    const { topicCasUsage } = mockCasUsage(
-      { Recommandations: [gristRecommandation.id] },
-      {},
-      [gristRecommandation]
-    )
+    const { topicCasUsage } = mockCasUsage({}, {}, [gristRecommandation])
 
     cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
   })

--- a/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
+++ b/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
@@ -1,10 +1,10 @@
 import {
-  buildApidatasetRecommandations,
-  buildSolutionRecommandation,
+  mockApidatasetRecommandations,
   mockApiOrDatasetUtiles,
   mockApisOrDatasets,
   mockCasUsage,
-  mockSolution
+  mockSolution,
+  mockSolutionRecommandation
 } from '../../../support/factories/custom/simplifions/simplifions_mocks'
 
 import './support'
@@ -13,7 +13,7 @@ describe("Simplifions Cas d'usages Show Page", () => {
   beforeEach(() => {
     cy.baseMocksForSimplifions()
 
-    const { gristRecommandation } = buildSolutionRecommandation({
+    const { gristRecommandation } = mockSolutionRecommandation({
       API_et_datasets_utiles_fournis: [],
       Descriptions_des_API_et_datasets_utiles_fournis: [],
       Ces_logiciels_l_integrent_deja: []
@@ -87,7 +87,7 @@ describe("Simplifions Cas d'usages Show Page", () => {
 
   describe('with an access link in recommandation grist data', () => {
     beforeEach(() => {
-      const { gristRecommandation } = buildSolutionRecommandation({
+      const { gristRecommandation } = mockSolutionRecommandation({
         API_et_datasets_utiles_fournis: [],
         Descriptions_des_API_et_datasets_utiles_fournis: [],
         Ces_logiciels_l_integrent_deja: [],
@@ -119,7 +119,7 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
   beforeEach(() => {
     cy.baseMocksForSimplifions()
 
-    const { gristRecommandations } = buildApidatasetRecommandations(2)
+    const { gristRecommandations } = mockApidatasetRecommandations(2)
     const { topicCasUsage } = mockCasUsage(
       {
         slug: 'aides-publiques-entreprises-sourcage',
@@ -145,7 +145,7 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
 
   describe('with an access link in recommandation grist data', () => {
     beforeEach(() => {
-      const { gristRecommandations } = buildApidatasetRecommandations(1, {
+      const { gristRecommandations } = mockApidatasetRecommandations(1, {
         access_link_with_fallback: 'https://example.com'
       })
       const { topicCasUsage } = mockCasUsage(
@@ -173,7 +173,7 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
       cy.baseMocksForSimplifions()
 
       const { gristRecommandations, dataservicesOrDatasets } =
-        buildApidatasetRecommandations(
+        mockApidatasetRecommandations(
           1,
           {},
           { Type: 'API' },
@@ -206,7 +206,7 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
       cy.baseMocksForSimplifions()
 
       const { gristRecommandations, dataservicesOrDatasets } =
-        buildApidatasetRecommandations(
+        mockApidatasetRecommandations(
           1,
           {
             access_link_with_fallback: 'https://recommandation-url.example.com'
@@ -250,7 +250,7 @@ describe("Simplifions Cas d'usages Show Page for cas d'usage with APIs or datase
       }
     )
 
-    const { gristRecommandation } = buildSolutionRecommandation({
+    const { gristRecommandation } = mockSolutionRecommandation({
       API_et_datasets_utiles_fournis: gristApisAndDatasets.map((a) => a.id),
       Descriptions_des_API_et_datasets_utiles_fournis:
         gristApiOrDatasetUtiles.map((a) => a.id),
@@ -288,7 +288,7 @@ describe("Simplifions Cas d'usages Show page for cas d'usage with integrating so
       Nom: 'The Best Editor Solution'
     })
 
-    const { gristRecommandation } = buildSolutionRecommandation({
+    const { gristRecommandation } = mockSolutionRecommandation({
       API_et_datasets_utiles_fournis: [],
       Descriptions_des_API_et_datasets_utiles_fournis: [],
       Ces_logiciels_l_integrent_deja: [],

--- a/cypress/support/factories/custom/simplifions/simplifions_mocks.ts
+++ b/cypress/support/factories/custom/simplifions/simplifions_mocks.ts
@@ -24,6 +24,7 @@ export const mockCasUsage = (
   const gristCasUsage = gristCasUsageFactory.one({
     overrides: {
       fields: {
+        Recommandations: recommandations.map((r) => r.id),
         ...gristCasUsageFields
       }
     }

--- a/cypress/support/factories/custom/simplifions/simplifions_mocks.ts
+++ b/cypress/support/factories/custom/simplifions/simplifions_mocks.ts
@@ -17,15 +17,13 @@ import {
 import { topicCasUsageFactory, topicSolutionFactory } from './topics_factory'
 
 export const mockCasUsage = (
-  gristCasUsageFields = {},
   topicFields = {},
   recommandations: { id: number }[] = []
 ) => {
   const gristCasUsage = gristCasUsageFactory.one({
     overrides: {
       fields: {
-        Recommandations: recommandations.map((r) => r.id),
-        ...gristCasUsageFields
+        Recommandations: recommandations.map((r) => r.id)
       }
     }
   })
@@ -53,7 +51,7 @@ export const mockCasUsage = (
   return { gristCasUsage, topicCasUsage }
 }
 
-export const mockSolutionRecommandation = (recommandationFields = {}) => {
+export const buildSolutionRecommandation = (recommandationFields = {}) => {
   const gristRecommandation = gristRecommandationFactory.one({
     overrides: {
       fields: {
@@ -103,7 +101,7 @@ export const mockSolutionRecommandation = (recommandationFields = {}) => {
   return { gristRecommandation, topicSolution: topicSolutionRecommandee }
 }
 
-export const mockApidatasetRecommandations = (
+export const buildApidatasetRecommandations = (
   amount = 2,
   recommandationFields = {},
   apiOrDatasetFields = {},

--- a/cypress/support/factories/custom/simplifions/simplifions_mocks.ts
+++ b/cypress/support/factories/custom/simplifions/simplifions_mocks.ts
@@ -16,7 +16,11 @@ import {
 } from './grist_factory'
 import { topicCasUsageFactory, topicSolutionFactory } from './topics_factory'
 
-export const mockCasUsage = (gristCasUsageFields = {}, topicFields = {}) => {
+export const mockCasUsage = (
+  gristCasUsageFields = {},
+  topicFields = {},
+  recommandations: { id: number }[] = []
+) => {
   const gristCasUsage = gristCasUsageFactory.one({
     overrides: {
       fields: {
@@ -36,6 +40,7 @@ export const mockCasUsage = (gristCasUsageFields = {}, topicFields = {}) => {
     }
   })
 
+  cy.mockGristRecords('Recommandations', recommandations)
   cy.mockGristRecords('Cas_d_usages', [gristCasUsage])
   cy.mockDatagouvObject('topics', topicCasUsage.slug, topicCasUsage)
   cy.mockDatagouvObjectListWithTags(
@@ -82,7 +87,6 @@ export const mockSolutionRecommandation = (recommandationFields = {}) => {
     }
   }
 
-  cy.mockGristRecords('Recommandations', [gristRecommandation])
   cy.mockGristRecord('Solutions', gristSolutionRecommandee)
   cy.mockDatagouvObject(
     'topics',
@@ -123,8 +127,6 @@ export const mockApidatasetRecommandations = (
       }
     })
   })
-
-  cy.mockGristRecords('Recommandations', gristRecommandations)
 
   return { gristApisAndDatasets, gristRecommandations, dataservicesOrDatasets }
 }

--- a/cypress/support/factories/custom/simplifions/simplifions_mocks.ts
+++ b/cypress/support/factories/custom/simplifions/simplifions_mocks.ts
@@ -51,7 +51,7 @@ export const mockCasUsage = (
   return { gristCasUsage, topicCasUsage }
 }
 
-export const buildSolutionRecommandation = (recommandationFields = {}) => {
+export const mockSolutionRecommandation = (recommandationFields = {}) => {
   const gristRecommandation = gristRecommandationFactory.one({
     overrides: {
       fields: {
@@ -101,7 +101,7 @@ export const buildSolutionRecommandation = (recommandationFields = {}) => {
   return { gristRecommandation, topicSolution: topicSolutionRecommandee }
 }
 
-export const buildApidatasetRecommandations = (
+export const mockApidatasetRecommandations = (
   amount = 2,
   recommandationFields = {},
   apiOrDatasetFields = {},


### PR DESCRIPTION
Clearer mock of recommendation linked to cas d'usage, the caller is now responsible for creating the recommendation and passing it to the mock.

Avoid flaky tests failures like https://github.com/opendatateam/udata-front-kit/actions/runs/25809310577/job/75820843981?pr=1196.