### PR TITLE
feat(simplifions): count nb APIs per solution

### DIFF
--- a/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
+++ b/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
@@ -1,3 +1,4 @@
+import { apiOrDatasetFactory } from '../../../support/factories/custom/simplifions/grist_factory'
 import {
   mockApidatasetRecommandations,
   mockApiOrDatasetUtiles,
@@ -306,6 +307,95 @@ describe("Simplifions Cas d'usages Show page for cas d'usage with integrating so
     cy.get('.solution-integratrice-card').should(
       'contain.text',
       'The Best Editor Solution'
+    )
+  })
+})
+
+describe("Simplifions Cas d'usages Show page - integration score on solution cards", () => {
+  // Creates 3 API records, mocks the APIs_et_datasets table, and returns their IDs.
+  // The component fetches these records to render the "API et données utiles" accordion.
+  const mockUsefulApis = () => {
+    const gristApis = apiOrDatasetFactory.many(3)
+    cy.mockGristRecords('APIs_et_datasets', gristApis)
+    return gristApis.map((a) => a.id)
+  }
+
+  const setup = (recommandationOverrides = {}) => {
+    cy.baseMocksForSimplifions()
+    const usefulApiIds = mockUsefulApis()
+
+    // Integrating solution: integrates 2 of the 3 useful APIs, plus 1 unrelated
+    const { gristSolution: gristIntegrateur } = mockSolution({
+      Nom: 'Solution Intégratrice',
+      Visible_sur_simplifions: true,
+      API_ou_datasets_integres: [usefulApiIds[0], usefulApiIds[1], 99999],
+      liste_categories_de_solution: ['Logiciel métier'],
+      Type_de_solution: ['Logiciel métier']
+    })
+
+    const { gristRecommandation } = mockSolutionRecommandation({
+      API_et_datasets_utiles_fournis: usefulApiIds,
+      Descriptions_des_API_et_datasets_utiles_fournis: [],
+      Ces_logiciels_l_integrent_deja: [],
+      Solutions_integratrices_categorie_logiciel_metier: [gristIntegrateur.id],
+      ...recommandationOverrides
+    })
+
+    const { topicCasUsage } = mockCasUsage({}, [gristRecommandation])
+    cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
+  }
+
+  it('should display the X/Y integration score on the card', () => {
+    setup()
+    cy.get('.integration-indicator').should('exist')
+    cy.get('.integration-indicator__count').should('contain.text', '2/3')
+  })
+
+  it('should not display a score when the recommandation has no useful APIs', () => {
+    cy.baseMocksForSimplifions()
+
+    const { gristSolution: gristIntegrateur } = mockSolution({
+      Nom: 'Solution Sans Score',
+      Visible_sur_simplifions: true,
+      API_ou_datasets_integres: [101, 102],
+      liste_categories_de_solution: ['Logiciel métier']
+    })
+
+    const { gristRecommandation } = mockSolutionRecommandation({
+      API_et_datasets_utiles_fournis: [],
+      Descriptions_des_API_et_datasets_utiles_fournis: [],
+      Ces_logiciels_l_integrent_deja: [],
+      Solutions_integratrices_categorie_logiciel_metier: [gristIntegrateur.id]
+    })
+
+    const { topicCasUsage } = mockCasUsage({}, [gristRecommandation])
+    cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
+
+    cy.get('.integration-indicator').should('not.exist')
+  })
+
+  it('should use "API" label when Type_de_recommandation is API', () => {
+    setup({ Type_de_recommandation: 'API' })
+    cy.get('.integration-indicator__label').should('contain.text', 'API')
+    cy.get('.integration-indicator__label').should(
+      'not.contain.text',
+      'jeu de données'
+    )
+  })
+
+  it('should use "jeu de données" label when Type_de_recommandation is Jeu de données', () => {
+    setup({ Type_de_recommandation: 'Jeu de données' })
+    cy.get('.integration-indicator__label').should(
+      'contain.text',
+      'jeu de données'
+    )
+  })
+
+  it('should fall back to "API ou jeu de données" label when Type_de_recommandation is null', () => {
+    setup({ Type_de_recommandation: null })
+    cy.get('.integration-indicator__label').should(
+      'contain.text',
+      'API ou jeu de données'
     )
   })
 })

--- a/cypress/e2e/custom/simplifions/solutions_integratices.cy.ts
+++ b/cypress/e2e/custom/simplifions/solutions_integratices.cy.ts
@@ -230,7 +230,10 @@ describe('Solutions intégratrices block', () => {
 
     cy.get('.cas-usage-card').should('have.length', 1)
     cy.get('.cas-usage-card').should('contain.text', 'Marchés publics')
-    cy.get('.cas-usage-card .indicator-count').should('contain.text', '2/3')
+    cy.get('.cas-usage-card .integration-indicator__count').should(
+      'contain.text',
+      '2/3'
+    )
   })
 
   it('should group solutions by category in tabs', () => {

--- a/cypress/support/factories/custom/simplifions/grist_factory.ts
+++ b/cypress/support/factories/custom/simplifions/grist_factory.ts
@@ -59,7 +59,8 @@ export const gristRecommandationFactory = build<RecommandationRecord>({
       access_link_with_fallback: '',
       Solutions_integratrices_categorie_logiciel_metier: [],
       Solutions_integratrices_categorie_briques_techniques: [],
-      Solutions_integratrices_categorie_portail_de_consultation: []
+      Solutions_integratrices_categorie_portail_de_consultation: [],
+      Type_de_recommandation: null
     }
   }
 })

--- a/src/components/TooltipWrapper.vue
+++ b/src/components/TooltipWrapper.vue
@@ -3,16 +3,24 @@
     <span class="tooltip-trigger">
       <slot name="trigger" />
     </span>
-    <span class="tooltip-content">
+    <span
+      :class="[
+        'tooltip-content',
+        isTop ? 'tooltip-content--top' : 'tooltip-content--bottom'
+      ]"
+    >
       <slot />
     </span>
   </span>
 </template>
 
 <script setup lang="ts">
-defineProps<{
+const props = defineProps<{
   maxWidth?: string
+  placement?: 'top' | 'bottom'
 }>()
+
+const isTop = computed(() => props.placement === 'top')
 </script>
 
 <style scoped>
@@ -28,7 +36,6 @@ defineProps<{
 .tooltip-content {
   display: none;
   position: absolute;
-  top: calc(100% + 0.5rem);
   left: 50%;
   transform: translateX(-50%);
   background: white;
@@ -45,7 +52,15 @@ defineProps<{
   line-height: 1.4;
 }
 
-.tooltip-content::before {
+.tooltip-content--bottom {
+  top: calc(100% + 0.5rem);
+}
+
+.tooltip-content--top {
+  bottom: calc(100% + 0.5rem);
+}
+
+.tooltip-content--bottom::before {
   content: '';
   position: absolute;
   bottom: 100%;
@@ -53,6 +68,16 @@ defineProps<{
   transform: translateX(-50%);
   border: 6px solid transparent;
   border-bottom-color: white;
+}
+
+.tooltip-content--top::before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: white;
 }
 
 .tooltip-wrapper:hover .tooltip-content {

--- a/src/custom/simplifions/components/SimplifionsIntegrateurCard.vue
+++ b/src/custom/simplifions/components/SimplifionsIntegrateurCard.vue
@@ -78,9 +78,15 @@
                       >API ou jeux de données intégrés</span
                     >
                   </template>
-                  {{ casUsage.integratedCount }} API et jeux de données "{{
-                    nomFournisseur
-                  }}" sur les {{ casUsage.totalCount }} utiles pour ce cas
+                  <span
+                    :class="[
+                      'integration-indicator__count fr-text--sm fr-text--bold',
+                      casUsage.colorClass
+                    ]"
+                    >{{ casUsage.integratedCount }}</span
+                  >
+                  API et jeux de données "<strong>{{ nomFournisseur }}</strong
+                  >" sur les {{ casUsage.totalCount }} utiles pour ce cas
                   d'usage ont été intégrés par cette solution.
                 </TooltipWrapper>
               </div>

--- a/src/custom/simplifions/components/SimplifionsIntegrateurCard.vue
+++ b/src/custom/simplifions/components/SimplifionsIntegrateurCard.vue
@@ -63,10 +63,10 @@
               <span class="fr-text--xs fr-text--bold fr-mb-1v">{{
                 casUsage.name
               }}</span>
-              <div class="cas-usage-card__indicator fr-p-1w">
+              <div class="integration-indicator fr-p-1w">
                 <span
                   :class="[
-                    'fr-text--sm fr-text--bold indicator-count',
+                    'fr-text--sm fr-text--bold integration-indicator__count',
                     casUsage.colorClass
                   ]"
                 >
@@ -74,21 +74,14 @@
                 </span>
                 <TooltipWrapper>
                   <template #trigger>
-                    <span class="fr-text--xs indicator-label"
+                    <span class="fr-text--xs integration-indicator__label"
                       >API ou jeux de données intégrés</span
                     >
                   </template>
-                  <span
-                    :class="[
-                      'fr-text--sm fr-text--bold indicator-count',
-                      casUsage.colorClass
-                    ]"
-                    >{{ casUsage.integratedCount }} API et jeux de données
-                    "<strong>{{ nomFournisseur }}</strong
-                    >"</span
-                  >
-                  sur les {{ casUsage.totalCount }} utiles pour ce cas d'usage
-                  ont été intégrés par cette solution.
+                  {{ casUsage.integratedCount }} API et jeux de données "{{
+                    nomFournisseur
+                  }}" sur les {{ casUsage.totalCount }} utiles pour ce cas
+                  d'usage ont été intégrés par cette solution.
                 </TooltipWrapper>
               </div>
             </div>
@@ -198,6 +191,8 @@ const casUsagesWithIndicators = computed(() => {
 </script>
 
 <style scoped>
+@import './integration-indicator.css';
+
 .integrateur-card-link {
   display: block;
   text-decoration: none;
@@ -243,39 +238,8 @@ const casUsagesWithIndicators = computed(() => {
   flex-direction: column;
 }
 
-.cas-usage-card__indicator {
-  display: flex;
-  align-items: baseline;
-  gap: 0.5rem;
+.cas-usage-card .integration-indicator {
   margin-top: auto;
-  background-color: var(--background-alt-grey);
-  border-radius: 4px;
-}
-
-.cas-usage-card__indicator > * {
-  margin: 0 !important;
-}
-
-.indicator-label {
-  color: var(--text-mention-grey);
-  text-decoration: underline dotted;
-  text-underline-offset: 2px;
-}
-
-.indicator-count.indicator--green {
-  background-color: rgb(184, 254, 201);
-}
-
-.indicator-count.indicator--yellow {
-  background-color: rgb(254, 240, 184);
-}
-
-.indicator-count.indicator--orange {
-  background-color: rgb(254, 224, 184);
-}
-
-.indicator-count.indicator--red {
-  background-color: rgb(254, 201, 201);
 }
 
 @media (max-width: 767px) {

--- a/src/custom/simplifions/components/SimplifionsRecoSolutions.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutions.vue
@@ -283,7 +283,6 @@
 import { fromMarkdown } from '@/utils'
 import { grist } from '../grist.ts'
 import type {
-  ApiEtDatasetsIntegresRecord,
   ApiOrDatasetRecord,
   ApiOrDatasetUtiles,
   ApiOrDatasetUtilesRecord,
@@ -430,45 +429,28 @@ if (
   })
 }
 
-const apiEtDatasetsIntegres = ref<ApiEtDatasetsIntegresRecord[]>([])
-
-if (recommandation.Solution_recommandee) {
-  grist
-    .getRecords('API_et_datasets_integres', {
-      Solution_fournisseur: [recommandation.Solution_recommandee]
-    })
-    .then((data) => {
-      apiEtDatasetsIntegres.value = data as ApiEtDatasetsIntegresRecord[]
-    })
-}
+const usefulApiIds = new Set(
+  recommandation.API_et_datasets_utiles_fournis ?? []
+)
 
 const integrationScorePerSolution = computed(() => {
-  const map = new Map<number, { integratedCount: number; totalCount: number }>()
-  const usefulApiIds = recommandation.API_et_datasets_utiles_fournis ?? []
-  const totalCount = usefulApiIds.length
-  if (totalCount === 0) return map
-
-  const casUsageId = recommandation.Cas_d_usage
-  const relevantIntegrations = apiEtDatasetsIntegres.value.filter(
-    (i) =>
-      i.fields.Integre_pour_les_cas_d_usages?.includes(casUsageId) &&
-      usefulApiIds.includes(i.fields.API_ou_dataset_integre)
-  )
-
-  const allSolutionIds = [
-    ...(recommandation.Solutions_integratrices_categorie_logiciel_metier ?? []),
-    ...(recommandation.Solutions_integratrices_categorie_briques_techniques ??
-      []),
-    ...(recommandation.Solutions_integratrices_categorie_portail_de_consultation ??
-      [])
+  const totalCount = usefulApiIds.size
+  const allSolutions = [
+    ...integratingSolutionsLogicielsMetiers.value,
+    ...integratingSolutionsBriquesTechniques.value,
+    ...integratingSolutionsPortailsConsultation.value
   ]
-  allSolutionIds.forEach((solutionId) => {
-    const integratedCount = relevantIntegrations.filter(
-      (i) => i.fields.Solution_integratrice === solutionId
-    ).length
-    map.set(solutionId, { integratedCount, totalCount })
-  })
-  return map
+  return new Map(
+    allSolutions.map((solution) => [
+      solution.id,
+      {
+        integratedCount: (
+          solution.fields.API_ou_datasets_integres ?? []
+        ).filter((id) => usefulApiIds.has(id)).length,
+        totalCount
+      }
+    ])
+  )
 })
 
 const typeLabel = computed(() => {

--- a/src/custom/simplifions/components/SimplifionsRecoSolutions.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutions.vue
@@ -177,6 +177,11 @@
                   >
                     <SimplifionsRecoSolutionsIntegratricesCard
                       :solution="solution"
+                      :integration-score="
+                        integrationScorePerSolution.get(solution.id)
+                      "
+                      :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+                      :type-label="typeLabel"
                     />
                   </div>
                 </div>
@@ -207,6 +212,11 @@
                   >
                     <SimplifionsRecoSolutionsIntegratricesCard
                       :solution="solution"
+                      :integration-score="
+                        integrationScorePerSolution.get(solution.id)
+                      "
+                      :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+                      :type-label="typeLabel"
                     />
                   </div>
                 </div>
@@ -245,6 +255,11 @@
                   >
                     <SimplifionsRecoSolutionsIntegratricesCard
                       :solution="solution"
+                      :integration-score="
+                        integrationScorePerSolution.get(solution.id)
+                      "
+                      :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+                      :type-label="typeLabel"
                     />
                   </div>
                 </div>
@@ -268,6 +283,7 @@
 import { fromMarkdown } from '@/utils'
 import { grist } from '../grist.ts'
 import type {
+  ApiEtDatasetsIntegresRecord,
   ApiOrDatasetRecord,
   ApiOrDatasetUtiles,
   ApiOrDatasetUtilesRecord,
@@ -413,6 +429,54 @@ if (
     integratingSolutionsPortailsConsultation.value = solutions
   })
 }
+
+const apiEtDatasetsIntegres = ref<ApiEtDatasetsIntegresRecord[]>([])
+
+if (recommandation.Solution_recommandee) {
+  grist
+    .getRecords('API_et_datasets_integres', {
+      Solution_fournisseur: [recommandation.Solution_recommandee]
+    })
+    .then((data) => {
+      apiEtDatasetsIntegres.value = data as ApiEtDatasetsIntegresRecord[]
+    })
+}
+
+const integrationScorePerSolution = computed(() => {
+  const map = new Map<number, { integratedCount: number; totalCount: number }>()
+  const usefulApiIds = recommandation.API_et_datasets_utiles_fournis ?? []
+  const totalCount = usefulApiIds.length
+  if (totalCount === 0) return map
+
+  const casUsageId = recommandation.Cas_d_usage
+  const relevantIntegrations = apiEtDatasetsIntegres.value.filter(
+    (i) =>
+      i.fields.Integre_pour_les_cas_d_usages?.includes(casUsageId) &&
+      usefulApiIds.includes(i.fields.API_ou_dataset_integre)
+  )
+
+  const allSolutionIds = [
+    ...(recommandation.Solutions_integratrices_categorie_logiciel_metier ?? []),
+    ...(recommandation.Solutions_integratrices_categorie_briques_techniques ??
+      []),
+    ...(recommandation.Solutions_integratrices_categorie_portail_de_consultation ??
+      [])
+  ]
+  allSolutionIds.forEach((solutionId) => {
+    const integratedCount = relevantIntegrations.filter(
+      (i) => i.fields.Solution_integratrice === solutionId
+    ).length
+    map.set(solutionId, { integratedCount, totalCount })
+  })
+  return map
+})
+
+const typeLabel = computed(() => {
+  const t = recommandation.Type_de_recommandation
+  if (t === 'API') return 'API'
+  if (t === 'Jeu de données') return 'jeu de données'
+  return 'API ou jeu de données'
+})
 
 const activeApiAccordion = ref(-1)
 const activeIntegratingAccordion = ref(0)

--- a/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
@@ -60,9 +60,9 @@
             integrationScore.totalCount
           }}
         </span>
-        <TooltipWrapper placement="top">
+        <TooltipWrapper placement="top" class="integration-indicator__label">
           <template #trigger>
-            <span class="integration-indicator__label fr-text--xs">
+            <span class="fr-text--xs">
               {{ typeLabel ?? 'API' }} utiles {{ nomFournisseur }}
             </span>
           </template>
@@ -199,6 +199,11 @@ const getShortLabelSimplificationTag = (name: string) => {
 
 .solution-integratrice-card__arrow .fr-icon-arrow-right-line {
   color: var(--blue-france-sun-113-625);
+}
+
+.integration-indicator__label {
+  line-height: 0.1;
+  margin-bottom: 0;
 }
 
 .fr-tags-group {

--- a/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
@@ -151,7 +151,7 @@ const getShortLabelSimplificationTag = (name: string) => {
 .solution-integratrice-card {
   background-color: white;
   border-bottom: 4px solid var(--blue-france-sun-113-625);
-  padding: 1.5rem;
+  padding: 1.5rem 1.5rem 4rem;
   position: relative;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 }

--- a/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
@@ -45,7 +45,7 @@
         </div>
       </div>
 
-      <!-- Score d'intégration -->
+      <!-- Integration score -->
       <div
         v-if="integrationScore && integrationScore.totalCount > 0"
         class="integration-indicator fr-p-1w fr-mt-2w"

--- a/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
@@ -45,6 +45,31 @@
         </div>
       </div>
 
+      <!-- Score d'intégration -->
+      <div
+        v-if="integrationScore && integrationScore.totalCount > 0"
+        class="solution-integratrice-card__score fr-mt-2w"
+      >
+        <div class="score-indicator fr-p-1w">
+          <span :class="['score-count fr-text--sm fr-text--bold', colorClass]">
+            {{ integrationScore.integratedCount }}/{{
+              integrationScore.totalCount
+            }}
+          </span>
+          <TooltipWrapper placement="top">
+            <template #trigger>
+              <span class="score-label fr-text--xs">
+                {{ typeLabel ?? 'API' }} utiles {{ nomFournisseur }}
+              </span>
+            </template>
+            {{ integrationScore.integratedCount }} {{ typeLabel ?? 'API' }} "{{
+              nomFournisseur
+            }}" sur les {{ integrationScore.totalCount }} utiles pour ce cas
+            d'usage ont été intégrées par cette solution.
+          </TooltipWrapper>
+        </div>
+      </div>
+
       <!-- Arrow -->
       <div class="solution-integratrice-card__arrow fr-mt-0">
         <span
@@ -63,6 +88,7 @@
 </template>
 
 <script setup lang="ts">
+import TooltipWrapper from '@/components/TooltipWrapper.vue'
 import type { Topic } from '@/model/topic'
 import { useTagsByRef } from '@/utils/tags'
 import type { SolutionRecord } from '../model/grist'
@@ -71,6 +97,9 @@ import SimplifionsSolutionOperateurTag from './SimplifionsSolutionOperateurTag.v
 
 const props = defineProps<{
   solution: SolutionRecord
+  integrationScore?: { integratedCount: number; totalCount: number }
+  nomFournisseur?: string
+  typeLabel?: string
 }>()
 
 const solutionTopic = ref<Topic | undefined>(undefined)
@@ -87,6 +116,16 @@ const topicTags = useTagsByRef('solutions', solutionTopic)
 
 const simplificationTags = computed(() => {
   return topicTags.value.filter((tag) => tag.type === 'types-de-simplification')
+})
+
+const colorClass = computed(() => {
+  if (!props.integrationScore) return ''
+  const { integratedCount, totalCount } = props.integrationScore
+  const pct = totalCount > 0 ? (integratedCount / totalCount) * 100 : 0
+  if (pct >= 75) return 'indicator--green'
+  if (pct >= 50) return 'indicator--yellow'
+  if (pct >= 25) return 'indicator--orange'
+  return 'indicator--red'
 })
 
 const getShortLabelSimplificationTag = (name: string) => {
@@ -158,6 +197,40 @@ const getShortLabelSimplificationTag = (name: string) => {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+}
+
+.score-indicator {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  background-color: var(--background-alt-grey);
+  border-radius: 4px;
+}
+
+.score-indicator > * {
+  margin: 0 !important;
+}
+
+.score-label {
+  color: var(--text-mention-grey);
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
+}
+
+.score-count.indicator--green {
+  background-color: rgb(184, 254, 201);
+}
+
+.score-count.indicator--yellow {
+  background-color: rgb(254, 240, 184);
+}
+
+.score-count.indicator--orange {
+  background-color: rgb(254, 224, 184);
+}
+
+.score-count.indicator--red {
+  background-color: rgb(254, 201, 201);
 }
 
 @media (max-width: 767px) {

--- a/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
@@ -66,9 +66,15 @@
               {{ typeLabel ?? 'API' }} utiles {{ nomFournisseur }}
             </span>
           </template>
-          {{ integrationScore.integratedCount }} {{ typeLabel ?? 'API' }} "{{
-            nomFournisseur
-          }}" sur les {{ integrationScore.totalCount }} utiles pour ce cas
+          <span
+            :class="[
+              'integration-indicator__count fr-text--sm fr-text--bold',
+              colorClass
+            ]"
+            >{{ integrationScore.integratedCount }}</span
+          >
+          {{ typeLabel ?? 'API' }} "<strong>{{ nomFournisseur }}</strong
+          >" sur les {{ integrationScore.totalCount }} utiles pour ce cas
           d'usage ont été intégrées par cette solution.
         </TooltipWrapper>
       </div>

--- a/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
@@ -48,26 +48,29 @@
       <!-- Score d'intégration -->
       <div
         v-if="integrationScore && integrationScore.totalCount > 0"
-        class="solution-integratrice-card__score fr-mt-2w"
+        class="integration-indicator fr-p-1w fr-mt-2w"
       >
-        <div class="score-indicator fr-p-1w">
-          <span :class="['score-count fr-text--sm fr-text--bold', colorClass]">
-            {{ integrationScore.integratedCount }}/{{
-              integrationScore.totalCount
-            }}
-          </span>
-          <TooltipWrapper placement="top">
-            <template #trigger>
-              <span class="score-label fr-text--xs">
-                {{ typeLabel ?? 'API' }} utiles {{ nomFournisseur }}
-              </span>
-            </template>
-            {{ integrationScore.integratedCount }} {{ typeLabel ?? 'API' }} "{{
-              nomFournisseur
-            }}" sur les {{ integrationScore.totalCount }} utiles pour ce cas
-            d'usage ont été intégrées par cette solution.
-          </TooltipWrapper>
-        </div>
+        <span
+          :class="[
+            'integration-indicator__count fr-text--sm fr-text--bold',
+            colorClass
+          ]"
+        >
+          {{ integrationScore.integratedCount }}/{{
+            integrationScore.totalCount
+          }}
+        </span>
+        <TooltipWrapper placement="top">
+          <template #trigger>
+            <span class="integration-indicator__label fr-text--xs">
+              {{ typeLabel ?? 'API' }} utiles {{ nomFournisseur }}
+            </span>
+          </template>
+          {{ integrationScore.integratedCount }} {{ typeLabel ?? 'API' }} "{{
+            nomFournisseur
+          }}" sur les {{ integrationScore.totalCount }} utiles pour ce cas
+          d'usage ont été intégrées par cette solution.
+        </TooltipWrapper>
       </div>
 
       <!-- Arrow -->
@@ -137,6 +140,8 @@ const getShortLabelSimplificationTag = (name: string) => {
 </script>
 
 <style scoped>
+@import './integration-indicator.css';
+
 .solution-integratrice-card-link {
   display: block;
   text-decoration: none;
@@ -152,11 +157,11 @@ const getShortLabelSimplificationTag = (name: string) => {
 }
 
 .solution-integratrice-card:hover {
-  background-color: #f9f9f9;
+  background-color: var(--background-alt-grey);
 }
 
 .solution-integratrice-card--loading {
-  background-color: #f9f9f9;
+  background-color: var(--background-alt-grey);
   padding: 2rem;
 }
 
@@ -197,40 +202,6 @@ const getShortLabelSimplificationTag = (name: string) => {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-}
-
-.score-indicator {
-  display: flex;
-  align-items: baseline;
-  gap: 0.5rem;
-  background-color: var(--background-alt-grey);
-  border-radius: 4px;
-}
-
-.score-indicator > * {
-  margin: 0 !important;
-}
-
-.score-label {
-  color: var(--text-mention-grey);
-  text-decoration: underline dotted;
-  text-underline-offset: 2px;
-}
-
-.score-count.indicator--green {
-  background-color: rgb(184, 254, 201);
-}
-
-.score-count.indicator--yellow {
-  background-color: rgb(254, 240, 184);
-}
-
-.score-count.indicator--orange {
-  background-color: rgb(254, 224, 184);
-}
-
-.score-count.indicator--red {
-  background-color: rgb(254, 201, 201);
 }
 
 @media (max-width: 767px) {

--- a/src/custom/simplifions/components/integration-indicator.css
+++ b/src/custom/simplifions/components/integration-indicator.css
@@ -1,0 +1,33 @@
+.integration-indicator {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  background-color: var(--background-alt-grey);
+  border-radius: 4px;
+}
+
+.integration-indicator > * {
+  margin: 0 !important;
+}
+
+.integration-indicator__label {
+  color: var(--text-mention-grey);
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
+}
+
+.integration-indicator__count.indicator--green {
+  background-color: rgb(184, 254, 201);
+}
+
+.integration-indicator__count.indicator--yellow {
+  background-color: rgb(254, 240, 184);
+}
+
+.integration-indicator__count.indicator--orange {
+  background-color: rgb(254, 224, 184);
+}
+
+.integration-indicator__count.indicator--red {
+  background-color: rgb(254, 201, 201);
+}

--- a/src/custom/simplifions/model/grist.ts
+++ b/src/custom/simplifions/model/grist.ts
@@ -45,6 +45,7 @@ export type Recommandation = {
   Solutions_integratrices_categorie_logiciel_metier: number[]
   Solutions_integratrices_categorie_briques_techniques: number[]
   Solutions_integratrices_categorie_portail_de_consultation: number[]
+  Type_de_recommandation: string | null
 }
 export type RecommandationRecord = GristRecord & {
   fields: Recommandation


### PR DESCRIPTION
Fix https://linear.app/pole-api/issue/API-6464/ajouter-le-nombre-dapi-integrees-par-les-solutions-dans-la-fiche-cas

<img width="1149" height="538" alt="Capture d’écran 2026-05-19 à 17 00 13" src="https://github.com/user-attachments/assets/f641a4e0-4f60-4d85-9772-16595e5c62a4" />

```mermaid
flowchart TD
      CU[Cas_d_usages]
      R["Recommandations\n───────────────\nSolution_recommandee\nAPI_et_datasets_utiles_fourni
  s\nType_de_recommandation\nSolutions_integratrices_categorie_*"]
      SF["Solutions fournisseur\n─────────────────\nNom"]
      SI["Solutions intégratrices\n─────────────────\nAPI_ou_datasets_integres"]

      CU -->|Recommandations| R
      R -->|Solution_recommandee| SF
      R -->|Solutions_integratrices_categorie_*| SI

      R -->|API_et_datasets_utiles_fournis| SCORE
      SI -->|API_ou_datasets_integres| SCORE
      SF -->|Nom| SCORE

      SCORE["Score\n─────────────────────────────────────────\nY =
  API_et_datasets_utiles_fournis.length\nX = API_ou_datasets_integres\n        .filter(id ∈
  API_et_datasets_utiles_fournis)\n        .length\ncolorClass = f(X/Y)\ntypeLabel =
  Type_de_recommandation"]

      SCORE --> UI["integration-indicator\nX/Y · typeLabel · Nom"]
```