### PR TITLE
feat(seo): refactor meta handling

### DIFF
--- a/cypress/e2e/custom/ecospheres/topics/meta.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/meta.cy.ts
@@ -54,7 +54,7 @@ describe('Topic meta tags', () => {
       cy.get('head meta[property="og:title"]').should(
         'have.attr',
         'content',
-        `Test Topic Name | ${siteTitle}`
+        `Collection - Test Topic Name | ${siteTitle}`
       )
       cy.get('head meta[property="og:description"]').should(
         'have.attr',

--- a/src/custom/culture/views/DemarcheView.vue
+++ b/src/custom/culture/views/DemarcheView.vue
@@ -1,24 +1,14 @@
 <script setup lang="ts">
-import { useHead } from '@unhead/vue'
 import { computed, onMounted, ref } from 'vue'
 
 import { fromMarkdown } from '@/utils'
+import { useMeta } from '@/utils/seo'
 
-useHead({
-  meta: [
-    { property: 'og:title', content: 'Démarche - culture.data.gouv.fr' },
-    {
-      name: 'description',
-      content:
-        "Découvrez la démarche et la vision du ministère de la Culture pour l'ouverture des données culturelles."
-    },
-    {
-      property: 'og:description',
-      content:
-        "Découvrez la démarche et la vision du ministère de la Culture pour l'ouverture des données culturelles."
-    }
-  ],
-  link: [{ rel: 'canonical', href: window.location.origin + '/demarche' }]
+useMeta({
+  title: () => 'Démarche',
+  description: () =>
+    "Découvrez la démarche et la vision du ministère de la Culture pour l'ouverture des données culturelles.",
+  canonicalUrl: () => `${window.location.origin}/demarche`
 })
 
 interface DemarcheContent {

--- a/src/custom/culture/views/DepsView.vue
+++ b/src/custom/culture/views/DepsView.vue
@@ -1,27 +1,16 @@
 <script setup lang="ts">
-import { useHead } from '@unhead/vue'
 import { onMounted, ref } from 'vue'
 
 import SearchComponent from '@/components/SearchComponent.vue'
 import config from '@/config'
 import CultureDatasetCard from '@/custom/culture/components/CultureDatasetCard.vue'
 import { fromMarkdown } from '@/utils'
+import { useMeta } from '@/utils/seo'
 
-useHead({
-  meta: [
-    { property: 'og:title', content: config.website.title },
-    {
-      name: 'description',
-      content:
-        'culture.data.gouv.fr référence et centralise les données du domaine de la culture.'
-    },
-    {
-      property: 'og:description',
-      content:
-        'culture.data.gouv.fr référence et centralise les données du domaine de la culture.'
-    }
-  ],
-  link: [{ rel: 'canonical', href: window.location.origin + '/deps' }]
+useMeta({
+  title: () => undefined,
+  description: () => config.website.homepage.meta_description,
+  canonicalUrl: () => `${window.location.origin}/deps`
 })
 
 interface Section {

--- a/src/custom/culture/views/HomeView.vue
+++ b/src/custom/culture/views/HomeView.vue
@@ -1,27 +1,16 @@
 <script setup lang="ts">
-import { useHead } from '@unhead/vue'
 import { onMounted, ref } from 'vue'
 
 import SearchComponent from '@/components/SearchComponent.vue'
 import config from '@/config'
 import CultureDatasetCard from '@/custom/culture/components/CultureDatasetCard.vue'
 import { fromMarkdown } from '@/utils'
+import { useMeta } from '@/utils/seo'
 
-useHead({
-  meta: [
-    { property: 'og:title', content: config.website.title },
-    {
-      name: 'description',
-      content:
-        'culture.data.gouv.fr référence et centralise les données du domaine de la culture.'
-    },
-    {
-      property: 'og:description',
-      content:
-        'culture.data.gouv.fr référence et centralise les données du domaine de la culture.'
-    }
-  ],
-  link: [{ rel: 'canonical', href: window.location.origin }]
+useMeta({
+  title: () => undefined,
+  description: () => config.website.homepage.meta_description,
+  canonicalUrl: () => window.location.origin
 })
 
 interface Section {

--- a/src/custom/culture/views/PublierView.vue
+++ b/src/custom/culture/views/PublierView.vue
@@ -2,26 +2,16 @@
 import '@gouvfr/dsfr-chart/BarChart'
 import '@gouvfr/dsfr-chart/BarChart/css'
 
-import { useHead } from '@unhead/vue'
+import { useMeta } from '@/utils/seo'
 import { computed, onMounted, ref } from 'vue'
 
 import { fromMarkdown } from '@/utils'
 
-useHead({
-  meta: [
-    { property: 'og:title', content: 'Publier - culture.data.gouv.fr' },
-    {
-      name: 'description',
-      content:
-        'Découvrez comment ajouter vos jeux de données au sein de la transversale des données de la culture'
-    },
-    {
-      property: 'og:description',
-      content:
-        'Découvrez comment ajouter vos jeux de données au sein de la transversale des données de la culture'
-    }
-  ],
-  link: [{ rel: 'canonical', href: window.location.origin + '/publier' }]
+useMeta({
+  title: () => 'Publier',
+  description: () =>
+    'Découvrez comment ajouter vos jeux de données au sein de la transversale des données de la culture',
+  canonicalUrl: () => `${window.location.origin}/publier`
 })
 
 interface PublierContent {

--- a/src/custom/ecospheres/views/HomeView.vue
+++ b/src/custom/ecospheres/views/HomeView.vue
@@ -1,22 +1,15 @@
 <script setup lang="ts">
-import { useHead } from '@unhead/vue'
-
 import config from '@/config'
 import HomeAboutNews from '@/custom/ecospheres/components/home/HomeAboutNews.vue'
 import HomeCollections from '@/custom/ecospheres/components/home/HomeCollections.vue'
 import HomeContributors from '@/custom/ecospheres/components/home/HomeContributors.vue'
 import HomeHero from '@/custom/ecospheres/components/home/HomeHero.vue'
+import { useMeta } from '@/utils/seo'
 
-useHead({
-  meta: [
-    { property: 'og:title', content: config.website.title },
-    { name: 'description', content: config.website.homepage.meta_description },
-    {
-      property: 'og:description',
-      content: config.website.homepage.meta_description
-    }
-  ],
-  link: [{ rel: 'canonical', href: window.location.origin }]
+useMeta({
+  title: () => undefined,
+  description: () => config.website.homepage.meta_description,
+  canonicalUrl: () => window.location.origin
 })
 </script>
 

--- a/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
+++ b/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useCanonicalUrl, useMeta } from '@/utils/seo'
 import { ReadMore } from '@datagouv/components-next'
-import { computed, inject, onMounted, ref } from 'vue'
+import { capitalize, computed, inject, onMounted, ref } from 'vue'
 
 import DiscussionsList from '@/components/DiscussionsList.vue'
 import GenericContainer from '@/components/GenericContainer.vue'
@@ -39,6 +39,8 @@ const indicator = computed(() => datasetStore.get(indicatorId) as Indicator)
 const tabularApiUrl = config.datagouvfr?.tabular_api_url
 
 const showAddToTopicModal = ref(false)
+const indicatorConf = usePageConf('indicators')
+const labels = useLabels(indicatorConf.labels)
 const topicConf = usePageConf('bouquets')
 const topicsLabels = useLabels(topicConf.labels)
 
@@ -92,7 +94,9 @@ const activeTab = ref(0)
 const description = computed(() => descriptionFromMarkdown(indicator))
 
 useMeta({
-  title: () => indicator.value?.title,
+  title: () =>
+    indicator.value?.title &&
+    `${capitalize(labels.singular)} - ${indicator.value.title}`,
   description: () => indicator.value?.description,
   canonicalUrl: useCanonicalUrl(() => {
     const slug = indicator.value?.slug

--- a/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
+++ b/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import { useMeta } from '@/utils/seo'
 import { ReadMore } from '@datagouv/components-next'
-import { useHead } from '@unhead/vue'
 import { computed, inject, onMounted, ref } from 'vue'
 
 import DiscussionsList from '@/components/DiscussionsList.vue'
@@ -23,7 +23,6 @@ import { useUserStore } from '@/store/UserStore'
 import { descriptionFromMarkdown } from '@/utils'
 import { usePageConf } from '@/utils/config'
 import { useLabels } from '@/utils/labels'
-import { toMetaDescription, useCanonical } from '@/utils/seo'
 import IndicatorInformationPanel from '../../components/indicators/IndicatorInformationPanel.vue'
 import IndicatorSourcesList from '../../components/indicators/IndicatorSourcesList.vue'
 import type { Indicator } from '../../model/indicator'
@@ -92,33 +91,18 @@ const activeTab = ref(0)
 
 const description = computed(() => descriptionFromMarkdown(indicator))
 
-const metaDescription = (): string => {
-  return toMetaDescription(indicator.value?.description)
-}
-
-const metaTitle = computed(() => {
-  return indicator.value?.title
-})
-
-useHead({
-  meta: [
-    {
-      property: 'og:title',
-      content: () => `${metaTitle.value} | ${config.website.title}`
-    },
-    { name: 'description', content: metaDescription },
-    { property: 'og:description', content: metaDescription }
-  ]
-})
-
-useCanonical(() => {
-  const slug = indicator.value?.slug
-  if (!slug) return null
-  const resolved = router.resolve({
-    name: 'indicators_detail',
-    params: { item_id: slug }
-  })
-  return `${window.location.origin}${resolved.href}`
+useMeta({
+  title: () => indicator.value?.title,
+  description: () => indicator.value?.description,
+  canonicalUrl: () => {
+    const slug = indicator.value?.slug
+    if (!slug) return null
+    const resolved = router.resolve({
+      name: 'indicators_detail',
+      params: { item_id: slug }
+    })
+    return `${window.location.origin}${resolved.href}`
+  }
 })
 
 onMounted(() => {

--- a/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
+++ b/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useMeta } from '@/utils/seo'
+import { useCanonicalUrl, useMeta } from '@/utils/seo'
 import { ReadMore } from '@datagouv/components-next'
 import { computed, inject, onMounted, ref } from 'vue'
 
@@ -94,15 +94,11 @@ const description = computed(() => descriptionFromMarkdown(indicator))
 useMeta({
   title: () => indicator.value?.title,
   description: () => indicator.value?.description,
-  canonicalUrl: () => {
+  canonicalUrl: useCanonicalUrl(() => {
     const slug = indicator.value?.slug
     if (!slug) return null
-    const resolved = router.resolve({
-      name: 'indicators_detail',
-      params: { item_id: slug }
-    })
-    return `${window.location.origin}${resolved.href}`
-  }
+    return { name: 'indicators_detail', params: { item_id: slug } }
+  })
 })
 
 onMounted(() => {

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,8 +1,11 @@
 import { useHead } from '@unhead/vue'
-import type { MaybeRefOrGetter } from 'vue'
+import type { Ref } from 'vue'
 import { toValue } from 'vue'
 
+import config from '@/config'
 import { stripFromMarkdown } from '@/utils'
+
+type ReactiveInput<T> = Ref<T> | (() => T)
 
 // Google displays ~160 chars; 155 gives a safe margin before it truncates
 const META_DESCRIPTION_MAX_LENGTH = 155
@@ -14,13 +17,47 @@ export function toMetaDescription(value: string | null | undefined): string {
   return plain.slice(0, META_DESCRIPTION_MAX_LENGTH).trimEnd() + '…'
 }
 
-export function useCanonical(
-  href: MaybeRefOrGetter<string | undefined | null>
-) {
-  useHead({
+function toMetaKeywords(keywords: string[] | undefined): string | undefined {
+  return keywords?.length ? keywords.join(', ') : undefined
+}
+
+export function useMeta({
+  title,
+  description,
+  keywords,
+  canonicalUrl,
+  noIndex
+}: {
+  title: ReactiveInput<string | undefined>
+  description: ReactiveInput<string | undefined>
+  keywords?: ReactiveInput<string[] | undefined>
+  canonicalUrl: ReactiveInput<string | undefined | null>
+  noIndex?: ReactiveInput<boolean | undefined>
+}) {
+  const args = {
+    meta: () => {
+      const t = toValue(title)
+      const metaDescription = toMetaDescription(toValue(description))
+      const metaKeywords = toMetaKeywords(toValue(keywords))
+      return [
+        {
+          property: 'og:title',
+          content: t ? `${t} | ${config.website.title}` : config.website.title
+        },
+        { name: 'description', content: metaDescription },
+        { property: 'og:description', content: metaDescription },
+        ...(metaKeywords != null
+          ? [{ name: 'keywords', content: metaKeywords }]
+          : []),
+        ...(toValue(noIndex)
+          ? [{ name: 'robots', content: 'noindex, nofollow' }]
+          : [])
+      ]
+    },
     link: () => {
-      const url = toValue(href)
+      const url = toValue(canonicalUrl)
       return url ? [{ rel: 'canonical', href: url }] : []
     }
-  })
+  }
+  useHead(args)
 }

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,6 +1,8 @@
 import { useHead } from '@unhead/vue'
 import type { Ref } from 'vue'
 import { toValue } from 'vue'
+import type { RouteLocationRaw } from 'vue-router'
+import { useRouter } from 'vue-router'
 
 import config from '@/config'
 import { stripFromMarkdown } from '@/utils'
@@ -19,6 +21,17 @@ export function toMetaDescription(value: string | null | undefined): string {
 
 function toMetaKeywords(keywords: string[] | undefined): string | undefined {
   return keywords?.length ? keywords.join(', ') : undefined
+}
+
+export function useCanonicalUrl(
+  getRoute: () => RouteLocationRaw | null | undefined
+): () => string | null {
+  const router = useRouter()
+  return () => {
+    const route = getRoute()
+    if (!route) return null
+    return `${window.location.origin}${router.resolve(route).href}`
+  }
 }
 
 export function useMeta({

--- a/src/views/dataservices/DataserviceDetailView.vue
+++ b/src/views/dataservices/DataserviceDetailView.vue
@@ -21,7 +21,7 @@ import { useCurrentPageConf, useRouteParamsAsString } from '@/router/utils'
 import { useDataserviceStore } from '@/store/DataserviceStore'
 import { descriptionFromMarkdown, formatDate } from '@/utils'
 import { useAsyncComponent } from '@/utils/component'
-import { useCanonical } from '@/utils/seo'
+import { useMeta } from '@/utils/seo'
 import { OpenApiViewer } from '@datagouv/components-next'
 
 const route = useRouteParamsAsString()
@@ -108,7 +108,11 @@ const getDatasetPage = (id: string) => {
   return { name: 'datasets_detail', params: { item_id: id } }
 }
 
-useCanonical(() => dataservice.value?.self_web_url)
+useMeta({
+  title: () => dataservice.value?.title,
+  description: () => dataservice.value?.description,
+  canonicalUrl: () => dataservice.value?.self_web_url
+})
 
 onMounted(() => {
   dataserviceStore

--- a/src/views/dataservices/DataserviceDetailView.vue
+++ b/src/views/dataservices/DataserviceDetailView.vue
@@ -6,6 +6,7 @@ import {
   ReadMore,
   SimpleBanner
 } from '@datagouv/components-next'
+import { capitalize } from 'vue'
 
 import ContactPoints from '@/components/datasets/ContactPoints.vue'
 import DiscussionsList from '@/components/DiscussionsList.vue'
@@ -21,6 +22,7 @@ import { useCurrentPageConf, useRouteParamsAsString } from '@/router/utils'
 import { useDataserviceStore } from '@/store/DataserviceStore'
 import { descriptionFromMarkdown, formatDate } from '@/utils'
 import { useAsyncComponent } from '@/utils/component'
+import { useLabels } from '@/utils/labels'
 import { useMeta } from '@/utils/seo'
 import { OpenApiViewer } from '@datagouv/components-next'
 
@@ -37,6 +39,7 @@ const total = computed(
 )
 
 const { pageKey, meta, pageConf } = useCurrentPageConf()
+const labels = useLabels(pageConf.labels)
 
 const CardComponent = useAsyncComponent(() => meta?.datasetCardComponent, {
   fallback: DatasetCard
@@ -109,7 +112,9 @@ const getDatasetPage = (id: string) => {
 }
 
 useMeta({
-  title: () => dataservice.value?.title,
+  title: () =>
+    dataservice.value?.title &&
+    `${capitalize(labels.singular)} - ${dataservice.value.title}`,
   description: () => dataservice.value?.description,
   canonicalUrl: () => dataservice.value?.self_web_url
 })

--- a/src/views/datasets/DatasetDetailView.vue
+++ b/src/views/datasets/DatasetDetailView.vue
@@ -26,7 +26,7 @@ import { useLabels } from '@/utils/labels'
 import type { OgcLayerInfo } from '@/utils/ogcServices'
 import { fetchAllOgcResources } from '@/utils/ogcServices'
 import { openInQgis } from '@/utils/qgis'
-import { useCanonical } from '@/utils/seo'
+import { useMeta } from '@/utils/seo'
 
 const route = useRouteParamsAsString()
 const datasetIdOrSlug = route.params.item_id
@@ -135,7 +135,12 @@ const exploreUrl = computed(() => {
   )
 })
 
-useCanonical(() => dataset.value?.page)
+useMeta({
+  // TODO: inject 'Jeu de données - {title}' if it makes sense
+  title: () => dataset.value?.title,
+  description: () => dataset.value?.description,
+  canonicalUrl: () => dataset.value?.page
+})
 
 onMounted(() => {
   datasetStore

--- a/src/views/datasets/DatasetDetailView.vue
+++ b/src/views/datasets/DatasetDetailView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ReadMore, SimpleBanner } from '@datagouv/components-next'
-import { computed, inject, onMounted, ref } from 'vue'
+import { capitalize, computed, inject, onMounted, ref } from 'vue'
 
 import DiscussionsList from '@/components/DiscussionsList.vue'
 import GenericContainer from '@/components/GenericContainer.vue'
@@ -63,6 +63,7 @@ const showDiscussions = pageConf.resources_tabs.discussions.display
 const datasetsConf = useDatasetsConf()
 const topicPageKey = datasetsConf.add_to_topic?.page
 const topicPageConf = topicPageKey ? usePageConf(topicPageKey) : null
+const labels = useLabels(pageConf.labels)
 const topicLabels = topicPageConf ? useLabels(topicPageConf.labels) : null
 
 const canEdit = computed(() => {
@@ -136,8 +137,9 @@ const exploreUrl = computed(() => {
 })
 
 useMeta({
-  // TODO: inject 'Jeu de données - {title}' if it makes sense
-  title: () => dataset.value?.title,
+  title: () =>
+    dataset.value?.title &&
+    `${capitalize(labels.singular)} - ${dataset.value.title}`,
   description: () => dataset.value?.description,
   canonicalUrl: () => dataset.value?.page
 })

--- a/src/views/organizations/OrganizationDetailView.vue
+++ b/src/views/organizations/OrganizationDetailView.vue
@@ -15,7 +15,7 @@ import { useRouteParamsAsString } from '@/router/utils'
 import { useDatasetStore } from '@/store/OrganizationDatasetStore'
 import { useOrganizationStore } from '@/store/OrganizationStore'
 import { descriptionFromMarkdown } from '@/utils'
-import { useCanonical } from '@/utils/seo'
+import { useMeta } from '@/utils/seo'
 
 const route = useRouteParamsAsString()
 const organizationId = route.params.oid
@@ -42,7 +42,11 @@ const setAccessibilityProperties = inject(
   AccessibilityPropertiesKey
 ) as AccessibilityPropertiesType
 
-useCanonical(() => org.value?.page)
+useMeta({
+  title: () => org.value?.name,
+  description: () => org.value?.description,
+  canonicalUrl: () => org.value?.page
+})
 
 onMounted(() => {
   orgStore

--- a/src/views/organizations/OrganizationDetailView.vue
+++ b/src/views/organizations/OrganizationDetailView.vue
@@ -43,7 +43,7 @@ const setAccessibilityProperties = inject(
 ) as AccessibilityPropertiesType
 
 useMeta({
-  title: () => org.value?.name,
+  title: () => org.value?.name && `Organisation - ${org.value.name}`,
   description: () => org.value?.description,
   canonicalUrl: () => org.value?.page
 })

--- a/src/views/topics/TopicDetailView.vue
+++ b/src/views/topics/TopicDetailView.vue
@@ -193,13 +193,6 @@ const togglePublish = () => {
     .finally(() => loader.hide())
 }
 
-const metaKeywords = computed(() => {
-  const tags = topic.value?.tags
-  if (!tags?.length) return undefined
-  const prefix = pageConf.filter_prefix
-  return prefix ? tags.filter((t) => !t.startsWith(prefix)) : tags
-})
-
 const metaTitle = computed(() => {
   return topic.value?.name
 })
@@ -214,7 +207,12 @@ const handleNavigateToFactor = (elementId: string) => {
 useMeta({
   title: metaTitle,
   description: () => topic.value?.description,
-  keywords: metaKeywords,
+  keywords: () => {
+    const tags = topic.value?.tags
+    if (!tags?.length) return undefined
+    const prefix = pageConf.filter_prefix
+    return prefix ? tags.filter((t) => !t.startsWith(prefix)) : tags
+  },
   canonicalUrl: useCanonicalUrl(() => {
     const slug = topic.value?.slug
     if (!slug) return null

--- a/src/views/topics/TopicDetailView.vue
+++ b/src/views/topics/TopicDetailView.vue
@@ -36,7 +36,7 @@ import { descriptionFromMarkdown, formatDate } from '@/utils'
 import { getOwnerAvatar } from '@/utils/avatar'
 import { useAsyncComponent } from '@/utils/component'
 import { useLabels } from '@/utils/labels'
-import { useMeta } from '@/utils/seo'
+import { useCanonicalUrl, useMeta } from '@/utils/seo'
 import { useSpatialCoverage } from '@/utils/spatial'
 import { useTagsByRef } from '@/utils/tags'
 import { useExtras, useTopicFactors } from '@/utils/topic'
@@ -215,15 +215,11 @@ useMeta({
   title: metaTitle,
   description: () => topic.value?.description,
   keywords: metaKeywords,
-  canonicalUrl: () => {
+  canonicalUrl: useCanonicalUrl(() => {
     const slug = topic.value?.slug
     if (!slug) return null
-    const resolved = router.resolve({
-      name: `${pageKey}_detail`,
-      params: { item_id: slug }
-    })
-    return `${window.location.origin}${resolved.href}`
-  },
+    return { name: `${pageKey}_detail`, params: { item_id: slug } }
+  }),
   noIndex: () => topic.value?.private
 })
 

--- a/src/views/topics/TopicDetailView.vue
+++ b/src/views/topics/TopicDetailView.vue
@@ -5,7 +5,15 @@ import {
 } from '@datagouv/components-next'
 import { storeToRefs } from 'pinia'
 import type { Ref } from 'vue'
-import { computed, inject, nextTick, ref, watch, watchEffect } from 'vue'
+import {
+  capitalize,
+  computed,
+  inject,
+  nextTick,
+  ref,
+  watch,
+  watchEffect
+} from 'vue'
 import { useLoading } from 'vue-loading-overlay'
 import { useRouter } from 'vue-router'
 
@@ -205,7 +213,8 @@ const handleNavigateToFactor = (elementId: string) => {
 }
 
 useMeta({
-  title: metaTitle,
+  title: () =>
+    metaTitle.value && `${capitalize(labels.singular)} - ${metaTitle.value}`,
   description: () => topic.value?.description,
   keywords: () => {
     const tags = topic.value?.tags

--- a/src/views/topics/TopicDetailView.vue
+++ b/src/views/topics/TopicDetailView.vue
@@ -3,7 +3,6 @@ import {
   OrganizationNameWithCertificate,
   ReadMore
 } from '@datagouv/components-next'
-import { useHead } from '@unhead/vue'
 import { storeToRefs } from 'pinia'
 import type { Ref } from 'vue'
 import { computed, inject, nextTick, ref, watch, watchEffect } from 'vue'
@@ -37,7 +36,7 @@ import { descriptionFromMarkdown, formatDate } from '@/utils'
 import { getOwnerAvatar } from '@/utils/avatar'
 import { useAsyncComponent } from '@/utils/component'
 import { useLabels } from '@/utils/labels'
-import { toMetaDescription, useCanonical } from '@/utils/seo'
+import { useMeta } from '@/utils/seo'
 import { useSpatialCoverage } from '@/utils/spatial'
 import { useTagsByRef } from '@/utils/tags'
 import { useExtras, useTopicFactors } from '@/utils/topic'
@@ -194,16 +193,11 @@ const togglePublish = () => {
     .finally(() => loader.hide())
 }
 
-const metaDescription = (): string => {
-  return toMetaDescription(topic.value?.description)
-}
-
 const metaKeywords = computed(() => {
   const tags = topic.value?.tags
   if (!tags?.length) return undefined
   const prefix = pageConf.filter_prefix
-  const keywords = prefix ? tags.filter((t) => !t.startsWith(prefix)) : tags
-  return keywords.length ? keywords.join(', ') : undefined
+  return prefix ? tags.filter((t) => !t.startsWith(prefix)) : tags
 })
 
 const metaTitle = computed(() => {
@@ -217,31 +211,20 @@ const handleNavigateToFactor = (elementId: string) => {
   })
 }
 
-useHead({
-  meta: () => [
-    {
-      property: 'og:title',
-      content: `${metaTitle.value} | ${config.website.title}`
-    },
-    { name: 'description', content: metaDescription() },
-    { property: 'og:description', content: metaDescription() },
-    ...(metaKeywords.value != null
-      ? [{ name: 'keywords', content: metaKeywords.value }]
-      : []),
-    ...(topic.value?.private
-      ? [{ name: 'robots', content: 'noindex, nofollow' }]
-      : [])
-  ]
-})
-
-useCanonical(() => {
-  const slug = topic.value?.slug
-  if (!slug) return null
-  const resolved = router.resolve({
-    name: `${pageKey}_detail`,
-    params: { item_id: slug }
-  })
-  return `${window.location.origin}${resolved.href}`
+useMeta({
+  title: metaTitle,
+  description: () => topic.value?.description,
+  keywords: metaKeywords,
+  canonicalUrl: () => {
+    const slug = topic.value?.slug
+    if (!slug) return null
+    const resolved = router.resolve({
+      name: `${pageKey}_detail`,
+      params: { item_id: slug }
+    })
+    return `${window.location.origin}${resolved.href}`
+  },
+  noIndex: () => topic.value?.private
 })
 
 // Handle factor deeplinks: #factor-{id} switches to Données tab and scrolls to factor


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1106
Fix https://github.com/ecolabdata/ecospheres/issues/1107

Introduce a `useMeta` composable that rationalises the way meta tags are computed and injected.

Bonus re SEO recos / existing issues: dataservice detail view is handled the same way as dataset.

NB: follow-up PR incoming with title management.