### PR TITLE
feat(orgs): custom routes

### DIFF
--- a/configs/accessibilite/config.yaml
+++ b/configs/accessibilite/config.yaml
@@ -86,9 +86,6 @@ website:
     - text: À propos
       to: /about
   router:
-    disable:
-      - organizations_routes
-      - topics
     static_pages:
       - title: 'À propos'
         id: 'about'

--- a/configs/culture/config.yaml
+++ b/configs/culture/config.yaml
@@ -107,9 +107,6 @@ website:
     - text: 'La démarche'
       to: /demarche
   router:
-    disable:
-      - organizations_routes
-      - topics
     # ⚠️ When updating this list, also update the sitemap below if needed
     static_pages:
       - title: 'Accessibilité'

--- a/configs/defis/config.yaml
+++ b/configs/defis/config.yaml
@@ -247,8 +247,6 @@ website:
     - text: Guides
       to: https://guides.data.gouv.fr/
   router:
-    disable:
-      - organizations_routes
     static_pages:
       - title: 'Open Data University'
         id: 'opendatauniversity'

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -199,7 +199,7 @@ organizations:
   datasets: https://raw.githubusercontent.com/opendatateam/udata-front-kit-universe/refs/heads/artifacts/dist/ecospheres-demo/organizations-datasets.json
   dataservices: https://raw.githubusercontent.com/opendatateam/udata-front-kit-universe/refs/heads/artifacts/dist/ecospheres-demo/organizations-dataservices.json
   bouquets: https://raw.githubusercontent.com/opendatateam/udata-front-kit-universe/refs/heads/artifacts/dist/ecospheres-demo/organizations-bouquets.json
-  list:
+  page: # organizations.page is a special case of config.pages
     breadcrumb_title: Contributeurs
     labels:
       singular: contributeur

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -123,8 +123,6 @@ website:
     - text: À propos
       to: /about
   router:
-    disable:
-      - topics
     # ⚠️ When updating this list, also update the sitemap below if needed
     static_pages:
       - title: 'À propos'
@@ -203,6 +201,8 @@ organizations:
   bouquets: https://raw.githubusercontent.com/opendatateam/udata-front-kit-universe/refs/heads/artifacts/dist/ecospheres-demo/organizations-bouquets.json
   list:
     breadcrumb_title: Contributeurs
+    labels:
+      singular: contributeur
     meta:
       title: Liste des contributeurs
       description: Recherchez une organisation qui a partagé un jeu de données ou une réutilisation sur la transition écologique

--- a/configs/hackathon/config.yaml
+++ b/configs/hackathon/config.yaml
@@ -79,9 +79,6 @@ website:
     - text: Guide du prochain hackathon
       to: 'https://guides.data.gouv.fr/guide-du-participant-au-hackathon-le-climat-en-donnees/'
   router:
-    disable:
-      - organizations_routes
-      - topics
     static_pages:
       - title: 'Accessibilité'
         id: 'accessibility'

--- a/configs/logistique/config.yaml
+++ b/configs/logistique/config.yaml
@@ -98,9 +98,6 @@ website:
     - text: A propos
       to: /about
   router:
-    disable:
-      - organizations_routes
-      - topics
     static_pages:
       - title: 'A propos'
         id: 'about'

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -107,9 +107,6 @@ website:
     - text: A propos
       to: /about
   router:
-    disable:
-      - organizations_routes
-      - topic_routes
     static_pages:
       - title: 'A propos'
         id: 'about'

--- a/configs/simplifions/config.yaml
+++ b/configs/simplifions/config.yaml
@@ -103,8 +103,6 @@ website:
     - text: À propos
       to: /about
   router:
-    disable:
-      - topics
     static_pages:
       - title: 'À propos'
         id: 'about'

--- a/src/custom/ecospheres/routes.ts
+++ b/src/custom/ecospheres/routes.ts
@@ -1,5 +1,6 @@
 import {
   useGlobalSearchPageRoutes,
+  useOrganizationsRoutes,
   useTopicAdminPagesRoutes
 } from '@/router/utils'
 import type { RouteRecordRaw } from 'vue-router'
@@ -54,5 +55,6 @@ export const routes: RouteRecordRaw[] = [
   ...useTopicAdminPagesRoutes({
     pageKey: 'bouquets',
     topicConf
-  })
+  }),
+  useOrganizationsRoutes()
 ]

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -160,8 +160,11 @@ export type OrganizationsConfig = {
   datasets?: string
   dataservices?: string
   bouquets?: string
-  list?: {
+  page?: {
     breadcrumb_title?: string
+    labels?: {
+      singular?: string
+    }
     meta?: {
       title?: string
       description?: string

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,8 +5,6 @@ import type { StaticPageConfig } from '@/model/config'
 import NotFoundView from '@/views/NotFoundView.vue'
 import StaticPageView from '@/views/StaticPageView.vue'
 
-const disableRoutes: string[] = config.website.router.disable ?? []
-
 // common/default routes
 const defaultRoutes: RouteRecordRaw[] = [
   // home
@@ -18,28 +16,6 @@ const defaultRoutes: RouteRecordRaw[] = [
     },
     component: async () => await import('@/views/HomeView.vue')
   },
-  // organizations
-  {
-    path: '/organizations',
-    name: 'organizations_routes',
-    children: [
-      {
-        path: '',
-        name: 'organizations',
-        meta: {
-          title: config.organizations?.list?.meta?.title ?? 'Organisations'
-        },
-        component: async () =>
-          await import('@/views/organizations/OrganizationsListView.vue')
-      },
-      {
-        path: ':oid',
-        name: 'organization_detail',
-        component: async () =>
-          await import('@/views/organizations/OrganizationDetailView.vue')
-      }
-    ]
-  },
   // technical pages
   {
     path: '/404',
@@ -49,10 +25,7 @@ const defaultRoutes: RouteRecordRaw[] = [
     },
     component: NotFoundView
   }
-].filter((route) => {
-  if (route.name === undefined) return true
-  return !disableRoutes.includes(route.name)
-})
+]
 
 // static pages
 const pages = (config.website.router.static_pages ?? []).map(

--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -327,6 +327,27 @@ export const useTopicAdminPagesRoutes = ({
   ]
 }
 
+export const useOrganizationsRoutes = (): RouteRecordRaw => {
+  return {
+    path: '/organizations',
+    name: 'organizations_routes',
+    children: [
+      {
+        path: '',
+        name: 'organizations',
+        component: async () =>
+          await import('@/views/organizations/OrganizationsListView.vue')
+      },
+      {
+        path: ':oid',
+        name: 'organization_detail',
+        component: async () =>
+          await import('@/views/organizations/OrganizationDetailView.vue')
+      }
+    ]
+  }
+}
+
 export const useRouteMeta = () => {
   return useRoute().meta
 }

--- a/src/views/organizations/OrganizationDetailView.vue
+++ b/src/views/organizations/OrganizationDetailView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { DatasetV2 } from '@datagouv/components-next'
 import { DatasetCard } from '@datagouv/components-next'
-import { computed, onMounted, ref, watch, type Ref } from 'vue'
+import { capitalize, computed, onMounted, ref, watch, type Ref } from 'vue'
 import { useLoading } from 'vue-loading-overlay'
 
 import GenericContainer from '@/components/GenericContainer.vue'
@@ -34,12 +34,6 @@ const pages: Ref<{ label: string; href: string; title: string }[]> = ref([])
 const datasets: Ref<DatasetV2[] | undefined> = ref(undefined)
 const selectedSort: Ref<string | undefined> = ref(undefined)
 
-useMeta({
-  title: () => org.value?.name && `Organisation - ${org.value.name}`,
-  description: () => org.value?.description,
-  canonicalUrl: () => org.value?.page
-})
-
 onMounted(() => {
   orgStore.load(organizationId, -1, { toasted: false, redirectNotFound: true })
 })
@@ -66,6 +60,18 @@ watch(
   },
   { immediate: true }
 )
+
+const metaTitle = () => {
+  if (!org.value?.name) return
+  const title = `${config.organizations?.list?.labels?.singular || 'Organisation'} - ${org.value.name}`
+  return capitalize(title)
+}
+
+useMeta({
+  title: () => metaTitle(),
+  description: () => org.value?.description,
+  canonicalUrl: () => org.value?.page
+})
 
 // we need the technical id to fetch the datasets and thus pagination
 watchEffect(() => {

--- a/src/views/organizations/OrganizationDetailView.vue
+++ b/src/views/organizations/OrganizationDetailView.vue
@@ -7,6 +7,7 @@ import { useLoading } from 'vue-loading-overlay'
 import GenericContainer from '@/components/GenericContainer.vue'
 import config from '@/config'
 import type { BreadcrumbItem } from '@/model/breadcrumb'
+import type { OrganizationsConfig } from '@/model/config'
 import { useRouteParamsAsString } from '@/router/utils'
 import { useDatasetStore } from '@/store/OrganizationDatasetStore'
 import { useOrganizationStore } from '@/store/OrganizationStore'
@@ -20,12 +21,13 @@ const orgStore = useOrganizationStore()
 const datasetStore = useDatasetStore()
 
 const org = computed(() => orgStore.get(organizationId))
+const organizationsConfig = config.organizations as OrganizationsConfig
 
 const breadcrumbLinks: Ref<BreadcrumbItem[]> = ref([
   { to: '/', text: 'Accueil' },
   {
     to: '/organizations',
-    text: config.organizations?.list?.breadcrumb_title || 'Organisations'
+    text: organizationsConfig.page?.breadcrumb_title || 'Organisations'
   }
 ])
 
@@ -63,7 +65,7 @@ watch(
 
 const metaTitle = () => {
   if (!org.value?.name) return
-  const title = `${config.organizations?.list?.labels?.singular || 'Organisation'} - ${org.value.name}`
+  const title = `${organizationsConfig.page?.labels?.singular || 'Organisation'} - ${org.value.name}`
   return capitalize(title)
 }
 

--- a/src/views/organizations/OrganizationsListView.vue
+++ b/src/views/organizations/OrganizationsListView.vue
@@ -34,6 +34,7 @@ async function onUpdatePage(page: number) {
 }
 
 useMeta({
+  title: () => organizationsConfig.list?.meta?.title ?? 'Organisations',
   description: () => organizationsConfig.list?.meta?.description,
   canonicalUrl: useCanonicalUrl()
 })

--- a/src/views/organizations/OrganizationsListView.vue
+++ b/src/views/organizations/OrganizationsListView.vue
@@ -19,7 +19,7 @@ const { pagination } = storeToRefs(store)
 const organizations: Ref<Organization[]> = ref([])
 
 const organizationsConfig = config.organizations as OrganizationsConfig
-const title = organizationsConfig.list?.breadcrumb_title || 'Organisations'
+const title = organizationsConfig.page?.breadcrumb_title || 'Organisations'
 const links = computed(() => [{ to: '/', text: 'Accueil' }, { text: title }])
 
 async function onUpdatePage(page: number) {
@@ -34,8 +34,8 @@ async function onUpdatePage(page: number) {
 }
 
 useMeta({
-  title: () => organizationsConfig.list?.meta?.title ?? 'Organisations',
-  description: () => organizationsConfig.list?.meta?.description,
+  title: () => organizationsConfig.page?.meta?.title ?? 'Organisations',
+  description: () => organizationsConfig.page?.meta?.description,
   canonicalUrl: useCanonicalUrl()
 })
 


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1117

`useOrganizationsRoutes` in `src/custom/ecospheres/routes.ts` instead of default routes that need to be disabled for all sites except ecologie.

`config.router.disable[]` is now useless (`topics` is dead code, artifact from pre pages migration).

While we're at, organization detail meta title is now more precise (Contributeur) and config structure is refactored a bit.

Doc is done in https://github.com/opendatateam/udata-front-kit/pull/1212