### PR TITLE
feat(infra): add CSP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,4 @@ RUN echo "$(date)" && \
 FROM nginx:alpine-slim
 
 COPY --from=builder /app/dist /usr/share/nginx/html
-
-RUN echo 'server { \
-    listen 80; \
-    location / { \
-        root /usr/share/nginx/html; \
-        try_files $uri $uri/ /index.html; \
-        add_header Cache-Control "public,max-age=0,must-revalidate"; \
-    } \
-}' > /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,78 @@
+server {
+    listen 80;
+
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+
+        # Revalidate on every request; assets are content-hashed by Vite so
+        # stale HTML is the only real risk.
+        add_header Cache-Control "public,max-age=0,must-revalidate" always;
+
+        # ------------------------------------------------------------------ #
+        # Content Security Policy
+        # ------------------------------------------------------------------ #
+        # script-src: only self-hosted bundles + Matomo (vue-matomo injects a
+        #   <script> tag pointing to stats.data.gouv.fr/matomo.js at runtime).
+        #   No unsafe-inline / unsafe-eval — Vite produces no inline scripts.
+        #
+        # connect-src: all fetch/XHR targets.
+        #   *.data.gouv.fr covers www, tabular-api, metric-api, meteo-api,
+        #   object, static, schema, stats (Matomo beacons), errors (Sentry).
+        #   raw.githubusercontent.com: organisation JSON fetched at runtime.
+        #   tile.openstreetmap.org: MapLibre/Leaflet tile requests.
+        #   grist.numerique.gouv.fr: Grist document API.
+        #   validata.fr: passed as schemaValidataUrl to @datagouv/components-next.
+        #
+        # img-src: data: and blob: are required by mapping libraries (canvas
+        #   exports, marker icons). *.data.gouv.fr serves dataset thumbnails and
+        #   organisation logos. raw.githubusercontent.com serves org images.
+        #   tile.openstreetmap.org for Leaflet raster tiles (loaded as <img>).
+        #
+        # style-src: unsafe-inline cannot be avoided — DSFR and Vue component
+        #   libraries inject inline styles at runtime.
+        #
+        # font-src: DSFR fonts are bundled and served from self.
+        #
+        # frame-src: only Grist forms are embedded as iframes.
+        #
+        # worker-src: MapLibre GL instantiates web workers from blob: URLs.
+        #
+        # object-src / base-uri: locked down; no plugins, no base-tag hijacking.
+        #
+        # form-action: external form links (Tally, Typeform…) are plain <a>
+        #   hrefs — CSP does not restrict navigation, only submissions.
+        #
+        # frame-ancestors: prevents this app from being embedded elsewhere.
+        # ------------------------------------------------------------------ #
+        add_header Content-Security-Policy "
+            default-src 'self';
+            script-src  'self' stats.data.gouv.fr;
+            connect-src 'self' *.data.gouv.fr grist.numerique.gouv.fr tile.openstreetmap.org raw.githubusercontent.com validata.fr;
+            img-src     'self' data: blob: *.data.gouv.fr raw.githubusercontent.com tile.openstreetmap.org;
+            style-src   'self' 'unsafe-inline';
+            font-src    'self';
+            frame-src   grist.numerique.gouv.fr;
+            worker-src  'self' blob:;
+            object-src  'none';
+            base-uri    'self';
+            form-action 'self';
+            frame-ancestors 'none';
+        " always;
+
+        # Prevent MIME-type sniffing (e.g. serving a JS file as text/html).
+        add_header X-Content-Type-Options "nosniff" always;
+
+        # Disallow embedding this app in any frame on an external origin.
+        # Redundant with frame-ancestors in the CSP above, but keeps older
+        # browsers (pre-CSP3) covered.
+        add_header X-Frame-Options "DENY" always;
+
+        # Send only origin (no path/query) in the Referer header when crossing
+        # origins, nothing at all when downgrading to HTTP.
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+        # Opt out of FLoC / Privacy Sandbox APIs that are off by default anyway.
+        add_header Permissions-Policy "interest-cohort=()" always;
+    }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -27,8 +27,9 @@ server {
         #   data: and blob: must be listed explicitly as https: does not cover
         #   non-http schemes (required by mapping libraries).
         #
-        # style-src: unsafe-inline cannot be avoided — DSFR and Vue component
-        #   libraries inject inline styles at runtime.
+        # style-src: 'self' only — Vite extracts all styles into bundled .css files.
+        #   If a library injects a <style> element at runtime (e.g. MapLibre GL),
+        #   a CSP violation will appear in the console identifying the culprit.
         #
         # font-src: DSFR fonts are bundled and served from self.
         #
@@ -41,7 +42,7 @@ server {
         #
         # frame-ancestors: prevents this app from being embedded elsewhere.
         # ------------------------------------------------------------------ #
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' stats.data.gouv.fr; connect-src 'self' https:; img-src https: data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' stats.data.gouv.fr; connect-src 'self' https:; img-src https: data: blob:; style-src 'self'; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
 
         # Prevent MIME-type sniffing (e.g. serving a JS file as text/html).
         add_header X-Content-Type-Options "nosniff" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,8 +5,6 @@ server {
         root /usr/share/nginx/html;
         try_files $uri $uri/ /index.html;
 
-        # Revalidate on every request; assets are content-hashed by Vite so
-        # stale HTML is the only real risk.
         add_header Cache-Control "public,max-age=0,must-revalidate" always;
 
         # ------------------------------------------------------------------ #

--- a/nginx.conf
+++ b/nginx.conf
@@ -27,6 +27,7 @@ server {
         #   exports, marker icons). *.data.gouv.fr serves dataset thumbnails and
         #   organisation logos. raw.githubusercontent.com serves org images.
         #   tile.openstreetmap.org for Leaflet raster tiles (loaded as <img>).
+        #   gist.github.com: Gist-hosted images used by some sites.
         #   *.s3.{rbx,gra,sbg}.io.cloud.ovh.net: user avatars/uploads on OVH S3
         #   (French regions: Roubaix, Gravelines, Strasbourg); bucket names and
         #   URLs are dynamic, sourced from API responses. FIXME: should probably 
@@ -46,7 +47,7 @@ server {
         #
         # frame-ancestors: prevents this app from being embedded elsewhere.
         # ------------------------------------------------------------------ #
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' stats.data.gouv.fr; connect-src 'self' *.data.gouv.fr grist.numerique.gouv.fr tile.openstreetmap.org raw.githubusercontent.com; img-src 'self' data: blob: *.data.gouv.fr raw.githubusercontent.com tile.openstreetmap.org *.s3.rbx.io.cloud.ovh.net *.s3.gra.io.cloud.ovh.net *.s3.sbg.io.cloud.ovh.net; style-src 'self' 'unsafe-inline'; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' stats.data.gouv.fr; connect-src 'self' *.data.gouv.fr grist.numerique.gouv.fr tile.openstreetmap.org raw.githubusercontent.com; img-src 'self' data: blob: *.data.gouv.fr raw.githubusercontent.com gist.github.com tile.openstreetmap.org *.s3.rbx.io.cloud.ovh.net *.s3.gra.io.cloud.ovh.net *.s3.sbg.io.cloud.ovh.net; style-src 'self' 'unsafe-inline'; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
 
         # Prevent MIME-type sniffing (e.g. serving a JS file as text/html).
         add_header X-Content-Type-Options "nosniff" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,12 +14,11 @@ server {
         #   <script> tag pointing to stats.data.gouv.fr/matomo.js at runtime).
         #   No unsafe-inline / unsafe-eval — Vite produces no inline scripts.
         #
-        # connect-src: all fetch/XHR targets.
-        #   *.data.gouv.fr covers www, demo, tabular-api, metric-api, meteo-api,
-        #   object, static, schema, stats (Matomo beacons), errors (Sentry).
-        #   raw.githubusercontent.com: organisation JSON fetched at runtime.
-        #   tile.openstreetmap.org: MapLibre/Leaflet tile requests.
-        #   grist.numerique.gouv.fr: Grist document API.
+        # connect-src: https: allows all HTTPS origins. WMS layer URLs are
+        #   user-configured and sourced from API responses — they can point to
+        #   arbitrary external services (e.g. services.data.shom.fr) that cannot
+        #   be enumerated at build time. script-src remains the effective XSS
+        #   barrier; connect-src cannot be meaningfully tightened here.
         #
         # img-src: data: and blob: are required by mapping libraries (canvas
         #   exports, marker icons). *.data.gouv.fr serves dataset thumbnails and
@@ -45,7 +44,7 @@ server {
         #
         # frame-ancestors: prevents this app from being embedded elsewhere.
         # ------------------------------------------------------------------ #
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' stats.data.gouv.fr; connect-src 'self' *.data.gouv.fr grist.numerique.gouv.fr tile.openstreetmap.org raw.githubusercontent.com; img-src 'self' data: blob: *.data.gouv.fr raw.githubusercontent.com gist.github.com tile.openstreetmap.org *.s3.rbx.io.cloud.ovh.net *.s3.gra.io.cloud.ovh.net *.s3.sbg.io.cloud.ovh.net; style-src 'self' 'unsafe-inline'; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' stats.data.gouv.fr; connect-src 'self' https:; img-src 'self' data: blob: *.data.gouv.fr raw.githubusercontent.com gist.github.com tile.openstreetmap.org *.s3.rbx.io.cloud.ovh.net *.s3.gra.io.cloud.ovh.net *.s3.sbg.io.cloud.ovh.net; style-src 'self' 'unsafe-inline'; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
 
         # Prevent MIME-type sniffing (e.g. serving a JS file as text/html).
         add_header X-Content-Type-Options "nosniff" always;
@@ -55,9 +54,7 @@ server {
         # browsers (pre-CSP3) covered.
         add_header X-Frame-Options "DENY" always;
 
-        # Send only origin (no path/query) in the Referer header when crossing
-        # origins, nothing at all when downgrading to HTTP.
+        # Send only origin (no path/query) in the Referer header when crossing origins
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,35 +17,36 @@ server {
         #   No unsafe-inline / unsafe-eval — Vite produces no inline scripts.
         #
         # connect-src: all fetch/XHR targets.
-        #   *.data.gouv.fr covers www, tabular-api, metric-api, meteo-api,
+        #   *.data.gouv.fr covers www, demo, tabular-api, metric-api, meteo-api,
         #   object, static, schema, stats (Matomo beacons), errors (Sentry).
         #   raw.githubusercontent.com: organisation JSON fetched at runtime.
         #   tile.openstreetmap.org: MapLibre/Leaflet tile requests.
         #   grist.numerique.gouv.fr: Grist document API.
-        #   validata.fr: passed as schemaValidataUrl to @datagouv/components-next.
         #
         # img-src: data: and blob: are required by mapping libraries (canvas
         #   exports, marker icons). *.data.gouv.fr serves dataset thumbnails and
         #   organisation logos. raw.githubusercontent.com serves org images.
         #   tile.openstreetmap.org for Leaflet raster tiles (loaded as <img>).
+        #   *.s3.{rbx,gra,sbg}.io.cloud.ovh.net: user avatars/uploads on OVH S3
+        #   (French regions: Roubaix, Gravelines, Strasbourg); bucket names and
+        #   URLs are dynamic, sourced from API responses. FIXME: should probably 
+        #   list all the buckets X env.
         #
         # style-src: unsafe-inline cannot be avoided — DSFR and Vue component
         #   libraries inject inline styles at runtime.
         #
         # font-src: DSFR fonts are bundled and served from self.
         #
-        # frame-src: only Grist forms are embedded as iframes.
-        #
         # worker-src: MapLibre GL instantiates web workers from blob: URLs.
         #
         # object-src / base-uri: locked down; no plugins, no base-tag hijacking.
         #
-        # form-action: external form links (Tally, Typeform…) are plain <a>
+        # form-action: external form links (Tally...) are plain <a>
         #   hrefs — CSP does not restrict navigation, only submissions.
         #
         # frame-ancestors: prevents this app from being embedded elsewhere.
         # ------------------------------------------------------------------ #
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' stats.data.gouv.fr; connect-src 'self' *.data.gouv.fr grist.numerique.gouv.fr tile.openstreetmap.org raw.githubusercontent.com validata.fr; img-src 'self' data: blob: *.data.gouv.fr raw.githubusercontent.com tile.openstreetmap.org; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src grist.numerique.gouv.fr; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' stats.data.gouv.fr; connect-src 'self' *.data.gouv.fr grist.numerique.gouv.fr tile.openstreetmap.org raw.githubusercontent.com; img-src 'self' data: blob: *.data.gouv.fr raw.githubusercontent.com tile.openstreetmap.org *.s3.rbx.io.cloud.ovh.net *.s3.gra.io.cloud.ovh.net *.s3.sbg.io.cloud.ovh.net; style-src 'self' 'unsafe-inline'; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
 
         # Prevent MIME-type sniffing (e.g. serving a JS file as text/html).
         add_header X-Content-Type-Options "nosniff" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -20,15 +20,12 @@ server {
         #   be enumerated at build time. script-src remains the effective XSS
         #   barrier; connect-src cannot be meaningfully tightened here.
         #
-        # img-src: data: and blob: are required by mapping libraries (canvas
-        #   exports, marker icons). *.data.gouv.fr serves dataset thumbnails and
-        #   organisation logos. raw.githubusercontent.com serves org images.
-        #   tile.openstreetmap.org for Leaflet raster tiles (loaded as <img>).
-        #   gist.github.com: Gist-hosted images used by some sites.
-        #   *.s3.{rbx,gra,sbg}.io.cloud.ovh.net: user avatars/uploads on OVH S3
-        #   (French regions: Roubaix, Gravelines, Strasbourg); bucket names and
-        #   URLs are dynamic, sourced from API responses. FIXME: should probably 
-        #   list all the buckets X env.
+        # img-src: https: allows images from any HTTPS origin. Dataset thumbnails,
+        #   avatars, WMS map images, markdown included images and org logos come 
+        #   from API responses and can point to arbitrary external hosts. HTTP is 
+        #   intentionally excluded.
+        #   data: and blob: must be listed explicitly as https: does not cover
+        #   non-http schemes (required by mapping libraries).
         #
         # style-src: unsafe-inline cannot be avoided — DSFR and Vue component
         #   libraries inject inline styles at runtime.
@@ -44,7 +41,7 @@ server {
         #
         # frame-ancestors: prevents this app from being embedded elsewhere.
         # ------------------------------------------------------------------ #
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' stats.data.gouv.fr; connect-src 'self' https:; img-src 'self' data: blob: *.data.gouv.fr raw.githubusercontent.com gist.github.com tile.openstreetmap.org *.s3.rbx.io.cloud.ovh.net *.s3.gra.io.cloud.ovh.net *.s3.sbg.io.cloud.ovh.net; style-src 'self' 'unsafe-inline'; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' stats.data.gouv.fr; connect-src 'self' https:; img-src https: data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
 
         # Prevent MIME-type sniffing (e.g. serving a JS file as text/html).
         add_header X-Content-Type-Options "nosniff" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -28,8 +28,8 @@ server {
         #   non-http schemes (required by mapping libraries).
         #
         # style-src: 'self' only — Vite extracts all styles into bundled .css files.
-        #   If a library injects a <style> element at runtime (e.g. MapLibre GL),
-        #   a CSP violation will appear in the console identifying the culprit.
+        #   Vue :style bindings use JS property access (not setAttribute) so they
+        #   don't require unsafe-inline. Verified working including maps and modals.
         #
         # font-src: DSFR fonts are bundled and served from self.
         #

--- a/nginx.conf
+++ b/nginx.conf
@@ -45,20 +45,7 @@ server {
         #
         # frame-ancestors: prevents this app from being embedded elsewhere.
         # ------------------------------------------------------------------ #
-        add_header Content-Security-Policy "
-            default-src 'self';
-            script-src  'self' stats.data.gouv.fr;
-            connect-src 'self' *.data.gouv.fr grist.numerique.gouv.fr tile.openstreetmap.org raw.githubusercontent.com validata.fr;
-            img-src     'self' data: blob: *.data.gouv.fr raw.githubusercontent.com tile.openstreetmap.org;
-            style-src   'self' 'unsafe-inline';
-            font-src    'self';
-            frame-src   grist.numerique.gouv.fr;
-            worker-src  'self' blob:;
-            object-src  'none';
-            base-uri    'self';
-            form-action 'self';
-            frame-ancestors 'none';
-        " always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' stats.data.gouv.fr; connect-src 'self' *.data.gouv.fr grist.numerique.gouv.fr tile.openstreetmap.org raw.githubusercontent.com validata.fr; img-src 'self' data: blob: *.data.gouv.fr raw.githubusercontent.com tile.openstreetmap.org; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src grist.numerique.gouv.fr; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
 
         # Prevent MIME-type sniffing (e.g. serving a JS file as text/html).
         add_header X-Content-Type-Options "nosniff" always;

--- a/nginx.conf
+++ b/nginx.conf
@@ -60,7 +60,5 @@ server {
         # origins, nothing at all when downgrading to HTTP.
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
-        # Opt out of FLoC / Privacy Sandbox APIs that are off by default anyway.
-        add_header Permissions-Policy "interest-cohort=()" always;
     }
 }

--- a/src/components/sections/SubSectionCards.vue
+++ b/src/components/sections/SubSectionCards.vue
@@ -10,7 +10,7 @@ defineProps({
 <template>
   <div>
     <h3 v-if="subsection.title">{{ subsection.title }}</h3>
-    <div style="display: flex; flex-wrap: wrap">
+    <div class="cards-row">
       <div v-for="(item, index) in subsection.cards" :key="index">
         <DsfrCard
           class="subsection-card"
@@ -31,5 +31,9 @@ defineProps({
   width: 350px;
   margin-right: 30px;
   margin-bottom: 30px;
+}
+.cards-row {
+  display: flex;
+  flex-wrap: wrap;
 }
 </style>

--- a/src/custom/simplifions/components/SimplifionsRecoSolutions.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutions.vue
@@ -157,7 +157,7 @@
                 v-if="integratingSolutionsLogicielsMetiers?.length"
                 panel-id="tab-content-logiciel-metier"
                 tab-id="tab-logiciel-metier"
-                style="background-color: white"
+                class="tab-bg-white"
               >
                 <p>
                   <strong>Liste des logiciels métier, sur étagère</strong>
@@ -191,7 +191,7 @@
                 v-if="integratingSolutionsBriquesTechniques?.length"
                 panel-id="tab-content-brique-technique"
                 tab-id="tab-brique-technique"
-                style="background-color: white"
+                class="tab-bg-white"
               >
                 <p>
                   <strong>Briques techniques logicielles</strong> destinées à
@@ -226,7 +226,7 @@
                 v-if="integratingSolutionsPortailsConsultation?.length"
                 panel-id="tab-content-portail-consultation"
                 tab-id="tab-portail-consultation"
-                style="background-color: white"
+                class="tab-bg-white"
               >
                 <p>
                   <b
@@ -516,6 +516,9 @@ const hasIntegratingSolutions = computed(() => tabTitles.value.length > 0)
 
 .reco-section {
   display: flex;
+}
+.tab-bg-white {
+  background-color: white;
 }
 
 :deep(.fr-accordion__btn[aria-expanded='true']) {

--- a/src/custom/simplifions/views/ApisFranceConnectees.vue
+++ b/src/custom/simplifions/views/ApisFranceConnectees.vue
@@ -4,161 +4,258 @@
 
     <div class="fr-grid-row fr-grid-row--gutters">
       <div class="fr-col-12 fr-col-lg-8">
-      <p class="fr-text--lead">Les API FranceConnectées donnent accès à diverses données administratives des particuliers en proposant FranceConnect comme modalité d'appel.</p>
-      <p class="fr-mb-4w fr-text--lg">Elles permettent de simplifier les démarches d'un particulier utilisant FranceConnect en récupérant automatiquement d'autres informations administratives le concernant.
-      </p>
+        <p class="fr-text--lead">
+          Les API FranceConnectées donnent accès à diverses données
+          administratives des particuliers en proposant FranceConnect comme
+          modalité d'appel.
+        </p>
+        <p class="fr-mb-4w fr-text--lg">
+          Elles permettent de simplifier les démarches d'un particulier
+          utilisant FranceConnect en récupérant automatiquement d'autres
+          informations administratives le concernant.
+        </p>
       </div>
 
       <div class="fr-col-12 fr-col-lg-4">
-      <nav class="fr-summary" role="navigation" aria-labelledby="fr-summary-title">
-        <ol>
-           <li>
-                <a id="summary-link-2" class="fr-summary__link"  href="#definition">Définition</a>
+        <nav
+          class="fr-summary"
+          role="navigation"
+          aria-labelledby="fr-summary-title"
+        >
+          <ol>
+            <li>
+              <a id="summary-link-2" class="fr-summary__link" href="#definition"
+                >Définition</a
+              >
             </li>
             <li>
-                <a id="summary-link-2" class="fr-summary__link"  href="#acteurs">Acteurs</a>
+              <a id="summary-link-2" class="fr-summary__link" href="#acteurs"
+                >Acteurs</a
+              >
             </li>
             <li>
-                <a id="summary-link-2" class="fr-summary__link" href="#possibilite-de-simplification">Possibilités de simplification</a>
+              <a
+                id="summary-link-2"
+                class="fr-summary__link"
+                href="#possibilite-de-simplification"
+                >Possibilités de simplification</a
+              >
             </li>
             <li>
-                <a id="summary-link-2" class="fr-summary__link" href="#liste-des-api-franceconnectees">Liste des API FranceConnectées</a>
+              <a
+                id="summary-link-2"
+                class="fr-summary__link"
+                href="#liste-des-api-franceconnectees"
+                >Liste des API FranceConnectées</a
+              >
             </li>
-        </ol>
-      </nav>
+          </ol>
+        </nav>
       </div>
     </div>
 
- 
-      <h2 id="definition" class="fr-h2 fr-my-0w fr-mt-4w" style="color: black; background-color: rgb(167, 212, 205); padding: 2px 4px; display: inline-block;">Définition</h2>
+    <h2 id="definition" class="fr-h2 fr-my-0w fr-mt-4w section-heading-teal">
+      Définition
+    </h2>
 
-      <p class="fr-text--lead" style="text-align: center">
-      Dans l'administration, on parle d'<i>«&nbsp;API FranceConnectée&nbsp;»</i> : 
-      </p>
-    
-    <div class="fr-grid-row fr-grid-row--gutters fr-ml-8w fr-mr-8w fr-mb-4w fr-grid-row--top">
-    
+    <p class="fr-text--lead text-center">
+      Dans l'administration, on parle d'<i>«&nbsp;API FranceConnectée&nbsp;»</i>
+      :
+    </p>
+
+    <div
+      class="fr-grid-row fr-grid-row--gutters fr-ml-8w fr-mr-8w fr-mb-4w fr-grid-row--top"
+    >
       <div class="fr-col-12 fr-col-md-6">
-        <p class="fr-text--lead fr-text--bold" style="text-align: center">
-      Lorsqu'une API est interrogée via le bouton FranceConnect ...
+        <p class="fr-text--lead fr-text--bold text-center">
+          Lorsqu'une API est interrogée via le bouton FranceConnect ...
         </p>
         <figure role="group" class="fr-content-media fr-content-media--sm">
           <div class="fr-content-media__img">
             <img
-              class="fr-responsive-img "
+              class="fr-responsive-img img-auto-height"
               src="/static/simplifions/assets/api-franceconnectees-bouton-france-connect.png"
               alt=""
-              style="width: auto; height: 100%"
-            />
-          </div>
-        </figure>
-         <p class="fr-text--lg">Les API FranceConnectées permettent d'<b>utiliser l'identité pivot fournie par <a target="_blank" href="https://franceconnect.gouv.fr/partenaires">FranceConnect</a> comme modalité d'appel.</b>
-         </p>
-      </div>
-      <div
-        class="fr-col-12 fr-col-md-6">
-         <p class="fr-text--lead  fr-text--bold" style="text-align: center">
-         ... et lorsqu'elle délivre des données administratives des particuliers.
-        </p>
-        <figure role="group" class="fr-content-media fr-content-media--sm ">
-          <div class="fr-content-media__img ">
-            <img
-              class="fr-responsive-img"
-              src="/static/simplifions/assets/api-franceconnectees-donnees-personnelles.png"
-              alt=""
-              style="width: auto; height: 100%"
             />
           </div>
         </figure>
         <p class="fr-text--lg">
-           Elles permettent de <b>transmettre des données administratives personnelles du citoyen</b>. 
+          Les API FranceConnectées permettent d'<b
+            >utiliser l'identité pivot fournie par
+            <a target="_blank" href="https://franceconnect.gouv.fr/partenaires"
+              >FranceConnect</a
+            >
+            comme modalité d'appel.</b
+          >
+        </p>
+      </div>
+      <div class="fr-col-12 fr-col-md-6">
+        <p class="fr-text--lead fr-text--bold text-center">
+          ... et lorsqu'elle délivre des données administratives des
+          particuliers.
+        </p>
+        <figure role="group" class="fr-content-media fr-content-media--sm">
+          <div class="fr-content-media__img">
+            <img
+              class="fr-responsive-img img-auto-height"
+              src="/static/simplifions/assets/api-franceconnectees-donnees-personnelles.png"
+              alt=""
+            />
+          </div>
+        </figure>
+        <p class="fr-text--lg">
+          Elles permettent de
+          <b>transmettre des données administratives personnelles du citoyen</b
+          >.
         </p>
       </div>
 
       <div class="fr-col-12">
-          <p class="fr-text--lg">Selon le cadre d'utilisation, elles proposent également de <b>récupérer l'identité pivot utilisée et fournie par FranceConnect</b>.</p>
+        <p class="fr-text--lg">
+          Selon le cadre d'utilisation, elles proposent également de
+          <b>récupérer l'identité pivot utilisée et fournie par FranceConnect</b
+          >.
+        </p>
       </div>
     </div>
 
-
-    <h2 id="acteurs" class="fr-h2 fr-my-0w fr-mt-4w" style="color: black; background-color: rgb(167, 212, 205); padding: 2px 4px; display: inline-block;">Les acteurs des API FranceConnectées</h2>
+    <h2 id="acteurs" class="fr-h2 fr-my-0w fr-mt-4w section-heading-teal">
+      Les acteurs des API FranceConnectées
+    </h2>
 
     <h3 class="fr-h4">FranceConnect et les fournisseurs d'identité :</h3>
 
     <p>
-    Lors de l'intégration d'une API FranceConnectée dans votre service, il est pré-requis d'intégrer la <a href="/solutions/franceconnect-2">solution FranceConnect</a> car le bouton "FranceConnect" sera la modalité d'appel utilisée par l'API pour renvoyer les données à l'usager.
+      Lors de l'intégration d'une API FranceConnectée dans votre service, il est
+      pré-requis d'intégrer la
+      <a href="/solutions/franceconnect-2">solution FranceConnect</a> car le
+      bouton "FranceConnect" sera la modalité d'appel utilisée par l'API pour
+      renvoyer les données à l'usager.
     </p>
 
     <p>
-      En proposant le bouton FranceConnect sur votre service, vous permettez à vos usagers d'utiliser le <i>fournisseur d'identité</i> qu'il souhaitent pour s'authentifier (impots.gouv.fr, ameli.fr, l'Identité Numérique La Poste, etc.).
+      En proposant le bouton FranceConnect sur votre service, vous permettez à
+      vos usagers d'utiliser le <i>fournisseur d'identité</i> qu'il souhaitent
+      pour s'authentifier (impots.gouv.fr, ameli.fr, l'Identité Numérique La
+      Poste, etc.).
     </p>
 
     <blockquote class="fr-highlight">
-      <p>💬 <strong>Rôle de FranceConnect :</strong><br>
-         FranceConnect est votre interlocuteur pour intégrer le bouton FranceConnect, de l'habilitation à l'homologation, en passant par l'intégration. Par contre FranceConnect n'est pas en mesure de répondre à vos questions sur les données distribuées via les API FranceConnectées.
-         <br/><br/>
-         💬 <strong>Rôle des fournisseurs d'identité :</strong><br>
-      Les fournisseurs d'identité ne seront jamais vos interlocuteurs. En intégrant FranceConnect, tous les fournisseurs d'identité seront proposés à vos usagers quand ils cliqueront sur le bouton FranceConnect. 
+      <p>
+        💬 <strong>Rôle de FranceConnect :</strong><br />
+        FranceConnect est votre interlocuteur pour intégrer le bouton
+        FranceConnect, de l'habilitation à l'homologation, en passant par
+        l'intégration. Par contre FranceConnect n'est pas en mesure de répondre
+        à vos questions sur les données distribuées via les API
+        FranceConnectées.
+        <br /><br />
+        💬 <strong>Rôle des fournisseurs d'identité :</strong><br />
+        Les fournisseurs d'identité ne seront jamais vos interlocuteurs. En
+        intégrant FranceConnect, tous les fournisseurs d'identité seront
+        proposés à vos usagers quand ils cliqueront sur le bouton FranceConnect.
       </p>
     </blockquote>
 
-     <h3 class="fr-h4">Les fournisseurs de données :</h3>
+    <h3 class="fr-h4">Les fournisseurs de données :</h3>
     <p>
-      Différentes administrations mettent à disposition, après habilitation et via des API FranceConnectées, les données administratives des particuliers dont elles ont la charge. Dans l'univers des API FranceConnectées, ces administrations sont nommées <i>fournisseurs de données</i>.
+      Différentes administrations mettent à disposition, après habilitation et
+      via des API FranceConnectées, les données administratives des particuliers
+      dont elles ont la charge. Dans l'univers des API FranceConnectées, ces
+      administrations sont nommées <i>fournisseurs de données</i>.
     </p>
-      
+
     <p>
-      <b>En voici la liste :</b> Caisse nationale des allocations familiales (CNAF), Direction de la Sécurité sociale, Direction générale des finances publiques (DGFIP), France Travail, Ministère de l'Enseignement supérieur et de la Recherche, Ministère de l'Éducation nationale et Cnous.
+      <b>En voici la liste :</b> Caisse nationale des allocations familiales
+      (CNAF), Direction de la Sécurité sociale, Direction générale des finances
+      publiques (DGFIP), France Travail, Ministère de l'Enseignement supérieur
+      et de la Recherche, Ministère de l'Éducation nationale et Cnous.
     </p>
 
     <blockquote class="fr-highlight">
-      <p>💬 <strong>Rôle des fournisseurs d'identité :</strong><br>
-        Les fournisseurs de données sont vos interlocuteurs concernant la délivrance des accès, l'intégration et la maintenance des API FranceConnectées. C'est eux qui sont en mesure de répondre à vos questions concernant les données distribuées et le fonctionnement des API qu'ils opèrent.
-        <br/>
-        <i>Si vous utilisez l'API Particulier</i>, ce service sera votre interlocuteur unique.
+      <p>
+        💬 <strong>Rôle des fournisseurs d'identité :</strong><br />
+        Les fournisseurs de données sont vos interlocuteurs concernant la
+        délivrance des accès, l'intégration et la maintenance des API
+        FranceConnectées. C'est eux qui sont en mesure de répondre à vos
+        questions concernant les données distribuées et le fonctionnement des
+        API qu'ils opèrent.
+        <br />
+        <i>Si vous utilisez l'API Particulier</i>, ce service sera votre
+        interlocuteur unique.
       </p>
     </blockquote>
 
-
     <p>
-      <b>Afin de simplifier l'intégration des API FranceConnectées</b>, la <a href="/solutions/bouquet-api-particulier">solution API Particulier</a> regroupe dans un même bouquet d'API une grande partie des API FranceConnectées.
+      <b>Afin de simplifier l'intégration des API FranceConnectées</b>, la
+      <a href="/solutions/bouquet-api-particulier">solution API Particulier</a>
+      regroupe dans un même bouquet d'API une grande partie des API
+      FranceConnectées.
     </p>
 
     <blockquote class="fr-highlight">
-      <p>💬 <strong>Rôle de l'API Particulier :</strong><br>
-       Si vous accédez aux API FranceConnectées via ce bouquet d'API, API Particulier est votre interlocuteur unique pour l'habilitation, l'intégration et la maintenance des API FranceConnectées du bouquet. API Particulier est en mesure de répondre à vos questions concernant les données distribuées et le fonctionnement des API qu'il propose. En cas de difficulté, API Particulier se charge des échanges avec les fournisseurs de données.
+      <p>
+        💬 <strong>Rôle de l'API Particulier :</strong><br />
+        Si vous accédez aux API FranceConnectées via ce bouquet d'API, API
+        Particulier est votre interlocuteur unique pour l'habilitation,
+        l'intégration et la maintenance des API FranceConnectées du bouquet. API
+        Particulier est en mesure de répondre à vos questions concernant les
+        données distribuées et le fonctionnement des API qu'il propose. En cas
+        de difficulté, API Particulier se charge des échanges avec les
+        fournisseurs de données.
       </p>
     </blockquote>
 
-    
-    <h2 id="possibilite-de-simplification" class="fr-h2 fr-my-0w fr-mt-4w" style="color: black; background-color: rgb(167, 212, 205); padding: 2px 4px; display: inline-block;">Possibilités de simplification</h2>
+    <h2
+      id="possibilite-de-simplification"
+      class="fr-h2 fr-my-0w fr-mt-4w section-heading-teal"
+    >
+      Possibilités de simplification
+    </h2>
 
-
-    <p class="fr-text--lead">Voici un comparatif entre une API appelée via une modalité d'appel classique <i>identifiant ou état civil</i> et une API appelée en mode "FranceConnectée", c'est-à-dire via l'identité pivot FranceConnect :</p>
+    <p class="fr-text--lead">
+      Voici un comparatif entre une API appelée via une modalité d'appel
+      classique <i>identifiant ou état civil</i> et une API appelée en mode
+      "FranceConnectée", c'est-à-dire via l'identité pivot FranceConnect :
+    </p>
 
     <table class="fr-table">
       <thead>
         <tr>
           <th></th>
-          <th style="width:40%">Modalité d'appel<br/>Identité pivot ou Identifiant</th>
-          <th style="width:40%">Modalité d'appel<br/>FranceConnect</th>
+          <th class="col-40">
+            Modalité d'appel<br />Identité pivot ou Identifiant
+          </th>
+          <th class="col-40">Modalité d'appel<br />FranceConnect</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td><strong>Étapes du parcours de l'usager</strong></td>
-          <td>  
+          <td>
             <ol>
-              <li>L'usager se connecte via son compte personnel authentifié ou via FranceConnect ;</li>
-              <li>Au cours de sa démarche, il recherche les informations nécessaires pour permettre l'appel aux API ne proposant pas la modalité d'appel FranConnect ; comme par exemple son numéro fiscal, son état civil ou son identifiant FranceTravail ;</li>
+              <li>
+                L'usager se connecte via son compte personnel authentifié ou via
+                FranceConnect ;
+              </li>
+              <li>
+                Au cours de sa démarche, il recherche les informations
+                nécessaires pour permettre l'appel aux API ne proposant pas la
+                modalité d'appel FranConnect ; comme par exemple son numéro
+                fiscal, son état civil ou son identifiant FranceTravail ;
+              </li>
               <li>Il saisit ces informations ;</li>
-              <li>Sa démarche est complétée des données récupérées via les API.</li>
+              <li>
+                Sa démarche est complétée des données récupérées via les API.
+              </li>
             </ol>
           </td>
           <td>
             <ol>
               <li>L'usager se connecte via FranceConnect ;</li>
-              <li>La démarche est déjà pré-remplie des informations récupérées via les API.</li>
+              <li>
+                La démarche est déjà pré-remplie des informations récupérées via
+                les API.
+              </li>
             </ol>
           </td>
         </tr>
@@ -168,14 +265,33 @@
           <td>✅ Comprise avec la connexion</td>
         </tr>
         <tr>
-          <td><strong>Délivrance instantanée de données administratives complémentaires issues des API FranceConnectées</strong></td>
-          <td>❌ Uniquement après vérification de l'identité de l'internaute par vos agents</td>
+          <td>
+            <strong
+              >Délivrance instantanée de données administratives complémentaires
+              issues des API FranceConnectées</strong
+            >
+          </td>
+          <td>
+            ❌ Uniquement après vérification de l'identité de l'internaute par
+            vos agents
+          </td>
           <td>✅ Oui</td>
         </tr>
         <tr>
-          <td><strong>Moins de données personnelles dans votre système d'information</strong></td>
-          <td>❌ Les données personnelles renseignées par l'usager pour appeler l'API transitent par votre système d'information</td>
-          <td>✅ Il est possible de choisir que l'identité pivot ne transite pas par votre système d'information</td>
+          <td>
+            <strong
+              >Moins de données personnelles dans votre système
+              d'information</strong
+            >
+          </td>
+          <td>
+            ❌ Les données personnelles renseignées par l'usager pour appeler
+            l'API transitent par votre système d'information
+          </td>
+          <td>
+            ✅ Il est possible de choisir que l'identité pivot ne transite pas
+            par votre système d'information
+          </td>
         </tr>
         <tr>
           <td><strong>Périmètre des usagers couverts</strong></td>
@@ -185,10 +301,16 @@
       </tbody>
     </table>
 
-  
-    <h2 id="liste-des-api-franceconnectees" class="fr-h2 fr-my-0w fr-mt-4w" style="color: black; background-color: rgb(167, 212, 205); padding: 2px 4px; display: inline-block;">Liste des API FranceConnectées</h2>
+    <h2
+      id="liste-des-api-franceconnectees"
+      class="fr-h2 fr-my-0w fr-mt-4w section-heading-teal"
+    >
+      Liste des API FranceConnectées
+    </h2>
 
-    <p class="fr-text--lead">Voici la liste des API pouvant être requêtées via un token FranceConnect :</p>
+    <p class="fr-text--lead">
+      Voici la liste des API pouvant être requêtées via un token FranceConnect :
+    </p>
 
     <div v-if="apisLoading" class="fr-mt-4w">
       <p>Chargement des APIs en cours...</p>
@@ -240,5 +362,18 @@ grist
   list-style: none;
   padding: 0;
   margin: 0;
+}
+.section-heading-teal {
+  color: black;
+  background-color: rgb(167, 212, 205);
+  padding: 2px 4px;
+  display: inline-block;
+}
+.img-auto-height {
+  width: auto;
+  height: 100%;
+}
+.col-40 {
+  width: 40%;
 }
 </style>

--- a/src/custom/simplifions/views/HomeView.vue
+++ b/src/custom/simplifions/views/HomeView.vue
@@ -90,23 +90,16 @@ const niveauxDeSimplification = [
         Acteurs publics, utilisez la donnée pour simplifier vos services !
       </h1>
       <div class="fr-mt-5w">
-        <div class="subtitle fr-text--alt fr-mb-10w">
+        <div class="subtitle fr-mb-10w">
           <div class="fr-grid-row fr-grid-row--gutters">
             <div class="fr-content-media__img fr-col-lg-2 fr-col-4">
               <img
-                class="fr-responsive-img"
+                class="fr-responsive-img img-block"
                 src="/static/simplifions/assets/accueil-picto-ecosystem.png"
                 alt=""
-                style="display: block; width: 100%; height: auto"
               />
             </div>
-            <div
-              class="fr-col-lg-8 fr-col-12"
-              style="
-                font-family: Marianne, arial, sans-serif !important;
-                font-style: normal;
-              "
-            >
+            <div class="fr-col-lg-8 fr-col-12">
               <p class="fr-text--lead">
                 Simplifiez les démarches et services des citoyens, entreprises
                 et associations en récupérant pour eux leurs informations
@@ -127,14 +120,11 @@ const niveauxDeSimplification = [
   </div>
 
   <div class="fr-container hero-text">
-    <h2
-      class="fr-h1 fr-mt-15w fr-mb-5w"
-      style="color: black; text-align: center"
-    >
+    <h2 class="fr-h1 fr-mt-15w fr-mb-5w section-heading">
       Améliorer les services à destination :
     </h2>
 
-    <p class="fr-text--lg" style="text-align: center">
+    <p class="fr-text--lg text-center">
       Le portail <i>simplifions.data.gouv.fr</i> vous accompagne pour
       simplifier, avec de la donnée, les démarches des citoyens.<br />Retrouvez
       tous les cas d'usages selon le public concerné :
@@ -177,14 +167,11 @@ const niveauxDeSimplification = [
   </div>
 
   <div class="fr-container hero-text">
-    <h2
-      class="fr-h1 fr-mt-15w fr-mb-5w"
-      style="color: black; text-align: center"
-    >
+    <h2 class="fr-h1 fr-mt-15w fr-mb-5w section-heading">
       Quelles que soient vos ressources, il existe des solutions !
     </h2>
 
-    <p class="fr-text--lg" style="text-align: center">
+    <p class="fr-text--lg text-center">
       Ce portail s'adresse à l'ensemble des acteurs publics, qu'ils disposent ou
       non de ressources informatiques.
       <br />
@@ -198,7 +185,7 @@ const niveauxDeSimplification = [
         :key="categorie_solution.title"
         class="fr-col-12 fr-col-lg-4"
       >
-        <div class="fr-card" style="background-color: #fafafa">
+        <div class="fr-card card-light">
           <div class="fr-card__body">
             <div class="fr-card__content">
               <ul class="fr-tags-group">
@@ -238,21 +225,11 @@ const niveauxDeSimplification = [
             </div>
           </div>
           <div class="fr-card__header">
-            <div
-              style="
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                height: 100px;
-                overflow: hidden;
-                margin-top: 10px;
-              "
-            >
+            <div class="card-image-container">
               <img
-                class="fr-responsive-img"
+                class="fr-responsive-img card-image"
                 :src="categorie_solution.imageSrc"
                 alt=""
-                style="max-height: 100%; width: auto"
               />
             </div>
           </div>
@@ -262,14 +239,11 @@ const niveauxDeSimplification = [
   </div>
 
   <div class="fr-container hero-text">
-    <h2
-      class="fr-h1 fr-mt-15w fr-mb-5w"
-      style="color: black; text-align: center"
-    >
+    <h2 class="fr-h1 fr-mt-15w fr-mb-5w section-heading">
       Pourquoi simplifier vos démarches avec la donnée ?
     </h2>
 
-    <p class="fr-text--lg" style="text-align: center">
+    <p class="fr-text--lg text-center">
       Administrations et collectivités, en intégrant des API ou des données dans
       vos démarches et/ou votre système d'information, de nombreux avantages
       s'offrent à vous et vos usagers :
@@ -313,14 +287,11 @@ const niveauxDeSimplification = [
   </div>
 
   <div class="fr-container hero-text">
-    <h2
-      class="fr-h1 fr-mt-15w fr-mb-5w"
-      style="color: black; text-align: center"
-    >
+    <h2 class="fr-h1 fr-mt-15w fr-mb-5w section-heading">
       La simplification en 3 niveaux
     </h2>
 
-    <p class="fr-text--lg" style="text-align: center">
+    <p class="fr-text--lg text-center">
       Il y a
       <router-link to="/niveaux-simplification"
         >plusieurs niveaux de simplification</router-link
@@ -336,7 +307,7 @@ const niveauxDeSimplification = [
         :key="niveau.title"
         class="fr-col-12 fr-col-md-4"
       >
-        <div class="fr-card" style="background-color: #fafafa">
+        <div class="fr-card card-light">
           <div class="fr-card__body">
             <div class="fr-card__content">
               <h3 class="fr-card__title">
@@ -368,16 +339,7 @@ const niveauxDeSimplification = [
             </div>
           </div>
           <div class="fr-card__header">
-            <div
-              style="
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                height: 10px;
-                overflow: hidden;
-                margin-top: 0px;
-              "
-            ></div>
+            <div class="card-header-spacer"></div>
           </div>
         </div>
       </div>
@@ -393,15 +355,8 @@ const niveauxDeSimplification = [
       </router-link>
     </div>
   </div>
-  <div
-    class="fr-container hero-text fr-mt-8w fr-py-8w"
-    style="background-color: rgb(243, 243, 251)"
-  >
-    <h2
-      id="redaction-contenu"
-      class="fr-h1 fr-mb-5w"
-      style="color: black; text-align: center"
-    >
+  <div class="fr-container hero-text fr-mt-8w fr-py-8w section-bg-light">
+    <h2 id="redaction-contenu" class="fr-h1 fr-mb-5w section-heading">
       Comment est rédigé le contenu sur <i>Simplifions.data</i> ?
     </h2>
 
@@ -412,16 +367,13 @@ const niveauxDeSimplification = [
         <figure role="group" class="fr-content-media fr-content-media--sm">
           <div class="fr-content-media__img fr-col-4">
             <img
-              class="fr-responsive-img"
+              class="fr-responsive-img img-auto-height"
               src="/static/simplifions/assets/accueil-picto-contenu-ligne-editoriale.png"
               alt=""
-              style="width: auto; height: 100%"
             />
           </div>
         </figure>
-        <h3 style="text-align: center">
-          Ligne éditoriale <i>DLNUF/proactivité</i>
-        </h3>
+        <h3 class="text-center">Ligne éditoriale <i>DLNUF/proactivité</i></h3>
         <p class="fr-text--lg fr-text--bold">
           Un contenu rédigé au sein du Pôle Data de la DINUM pour tenir une
           ligne éditoriale :
@@ -440,14 +392,13 @@ const niveauxDeSimplification = [
         <figure role="group" class="fr-content-media fr-content-media--sm">
           <div class="fr-content-media__img fr-col-3">
             <img
-              class="fr-responsive-img"
+              class="fr-responsive-img img-auto-height"
               src="/static/simplifions/assets/accueil-picto-contenu-contributif.png"
               alt=""
-              style="width: auto; height: 100%"
             />
           </div>
         </figure>
-        <h3 style="text-align: center">Contenu collaboratif</h3>
+        <h3 class="text-center">Contenu collaboratif</h3>
         <p class="fr-text--lg fr-text--bold">
           De nombreux espaces sont disponibles sur le site pour permettre aux
           usagers de proposer des modifications dans l'objectif de construire
@@ -461,10 +412,7 @@ const niveauxDeSimplification = [
       </div>
     </div>
 
-    <p
-      class="fr-text--xl fr-text--bold fr-mx-2w fr-mt-4w"
-      style="text-align: center"
-    >
+    <p class="fr-text--xl fr-text--bold fr-mx-2w fr-mt-4w text-center">
       📝 Proposez une modification, un cas d'usage ou une solution :
     </p>
 
@@ -479,10 +427,7 @@ const niveauxDeSimplification = [
         Formulaire pour proposer un contenu
       </a>
     </div>
-    <p
-      class="fr-text--xl fr-text--bold fr-mx-2w fr-mt-2w"
-      style="text-align: center"
-    >
+    <p class="fr-text--xl fr-text--bold fr-mx-2w fr-mt-2w text-center">
       Consultez les règles utilisées par le pôle Data <br />pour identifier les
       contenus qui sont référencés dans <i>Simplifions.data</i> :
     </p>
@@ -527,7 +472,6 @@ const niveauxDeSimplification = [
 }
 .subtitle {
   text-align: left;
-  font-style: italic;
   font-size: 20px;
   line-height: 28px;
 }
@@ -535,9 +479,42 @@ const niveauxDeSimplification = [
   margin-top: 30px;
   text-align: left;
 }
-
 .button-link {
   text-decoration: none;
   background: none;
+}
+.img-block {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.section-heading {
+  color: black;
+  text-align: center;
+}
+.card-light {
+  background-color: #fafafa;
+}
+.card-image-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100px;
+  overflow: hidden;
+  margin-top: 10px;
+}
+.card-image {
+  max-height: 100%;
+  width: auto;
+}
+.card-header-spacer {
+  height: 10px;
+}
+.section-bg-light {
+  background-color: rgb(243, 243, 251);
+}
+.img-auto-height {
+  width: auto;
+  height: 100%;
 }
 </style>


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1121

Add a basic CSP and add a few security headers to Dockerfile (should be used by data.gouv.fr infra too). 

The main point is to protect `script-src` (which is probably the most critical). `connect-src` and `img-src` have to be open due to the nature of our content and features (cf comments below).

`style-src` now forbids the usage of inline styles 💅, which warranted some fixes in templates.

The Dockerfile is used by dokku, so the deploy previews act as test envs.