### PR TITLE
feat(collection): refactor Factor Form

### DIFF
--- a/cypress/e2e/custom/ecospheres/topics/elements/addition.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/elements/addition.cy.ts
@@ -1,4 +1,5 @@
 import type { Topic } from '@/model/topic'
+import { datasetFactory } from 'cypress/support/factories/datasets_factory'
 import { factorFactory, setupEmptyTopic, visitTopic } from '../support'
 
 describe('Topic Elements - Factor Addition', () => {
@@ -103,6 +104,97 @@ describe('Topic Elements - Factor Addition', () => {
       // Verify the updated factor appears in the DOM
       cy.contains(updatedFactor.title).should('be.visible')
       cy.contains(testFactor.title).should('not.exist')
+    })
+
+    it('should allow submission without description', () => {
+      const testFactor = factorFactory.one()
+      const remoteFactor = { ...testFactor, id: 'server-generated-id-456' }
+
+      cy.intercept('POST', `**/topics/${testTopic.id}/elements/`, {
+        statusCode: 201,
+        body: [remoteFactor]
+      }).as('createElement')
+
+      cy.get('.test__add_dataset_btn').click()
+
+      cy.get('#input-title').type(testFactor.title)
+
+      cy.get(`input[name="source"][value="missing"]`).then(($input) => {
+        const labelId = $input.attr('id')
+        cy.get(`label[for="${labelId}"]`).click()
+      })
+
+      // Submit without filling description
+      cy.get('.test__submit_modal_btn').click()
+
+      cy.wait('@createElement').then((interception) => {
+        expect(interception.request.body[0]).to.include({
+          title: testFactor.title
+        })
+      })
+
+      cy.contains(testFactor.title).should('be.visible')
+    })
+
+    it('should pre-fill the title when a dataset is selected and the title is empty', () => {
+      const searchDataset = datasetFactory.one({
+        overrides: { title: 'Pre-filled Dataset Title' }
+      })
+
+      cy.intercept('GET', /.*data\.gouv\.fr\/api\/\d\/datasets\/search.*/, {
+        statusCode: 200,
+        body: {
+          data: [searchDataset],
+          total: 1,
+          page: 1,
+          page_size: 10,
+          next_page: null,
+          previous_page: null
+        }
+      }).as('searchDatasets')
+
+      cy.get('.test__add_dataset_btn').click()
+
+      // Type in the dataset search input (min 3 chars to trigger search)
+      cy.get('#input-dataset').type('Pre-filled')
+      cy.wait('@searchDatasets')
+
+      // Select the first result
+      cy.get('.multiselect-option').first().click()
+
+      // Title should be pre-filled with the dataset title
+      cy.get('#input-title').should('have.value', searchDataset.title)
+    })
+
+    it('should not pre-fill the title when a dataset is selected but the title is already set', () => {
+      const searchDataset = datasetFactory.one({
+        overrides: { title: 'Dataset Title From Search' }
+      })
+
+      cy.intercept('GET', /.*data\.gouv\.fr\/api\/\d\/datasets\/search.*/, {
+        statusCode: 200,
+        body: {
+          data: [searchDataset],
+          total: 1,
+          page: 1,
+          page_size: 10,
+          next_page: null,
+          previous_page: null
+        }
+      }).as('searchDatasets')
+
+      cy.get('.test__add_dataset_btn').click()
+
+      // Set the title first
+      cy.get('#input-title').type('My custom title')
+
+      // Select a dataset
+      cy.get('#input-dataset').type('Dataset')
+      cy.wait('@searchDatasets')
+      cy.get('.multiselect-option').first().click()
+
+      // Title should remain unchanged
+      cy.get('#input-title').should('have.value', 'My custom title')
     })
   })
 })

--- a/cypress/e2e/custom/ecospheres/topics/elements/addition.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/elements/addition.cy.ts
@@ -141,28 +141,15 @@ describe('Topic Elements - Factor Addition', () => {
         overrides: { title: 'Pre-filled Dataset Title' }
       })
 
-      cy.intercept('GET', /.*data\.gouv\.fr\/api\/\d\/datasets\/search.*/, {
-        statusCode: 200,
-        body: {
-          data: [searchDataset],
-          total: 1,
-          page: 1,
-          page_size: 10,
-          next_page: null,
-          previous_page: null
-        }
-      }).as('searchDatasets')
+      cy.mockSearch('datasets', [searchDataset])
 
       cy.get('.test__add_dataset_btn').click()
 
-      // Type in the dataset search input (min 3 chars to trigger search)
       cy.get('#input-dataset').type('Pre-filled')
-      cy.wait('@searchDatasets')
+      cy.wait('@search_datasets')
 
-      // Select the first result
       cy.get('.multiselect-option').first().click()
 
-      // Title should be pre-filled with the dataset title
       cy.get('#input-title').should('have.value', searchDataset.title)
     })
 
@@ -171,29 +158,16 @@ describe('Topic Elements - Factor Addition', () => {
         overrides: { title: 'Dataset Title From Search' }
       })
 
-      cy.intercept('GET', /.*data\.gouv\.fr\/api\/\d\/datasets\/search.*/, {
-        statusCode: 200,
-        body: {
-          data: [searchDataset],
-          total: 1,
-          page: 1,
-          page_size: 10,
-          next_page: null,
-          previous_page: null
-        }
-      }).as('searchDatasets')
+      cy.mockSearch('datasets', [searchDataset])
 
       cy.get('.test__add_dataset_btn').click()
 
-      // Set the title first
       cy.get('#input-title').type('My custom title')
 
-      // Select a dataset
       cy.get('#input-dataset').type('Dataset')
-      cy.wait('@searchDatasets')
+      cy.wait('@search_datasets')
       cy.get('.multiselect-option').first().click()
 
-      // Title should remain unchanged
       cy.get('#input-title').should('have.value', 'My custom title')
     })
   })

--- a/cypress/support/datagouv_mocks.ts
+++ b/cypress/support/datagouv_mocks.ts
@@ -263,6 +263,13 @@ Cypress.Commands.add('mockDataserviceMetricsApi', (dataserviceId) => {
   ).as(`get_metrics_total_${dataserviceId}`)
 })
 
+Cypress.Commands.add('mockSearch', (type, data = []) => {
+  cy.intercept('GET', datagouvUrlRegex(`${type}/search`), {
+    statusCode: 200,
+    body: datagouvResponseBuilder(data)
+  }).as(`search_${type}`)
+})
+
 Cypress.Commands.add(
   'mockDatasetAndRelatedObjects',
   (

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -29,6 +29,7 @@ declare global {
       mockMetricsApi(datasetId: string): Chainable<void>
       mockResources(datasetId: string, data?: object[]): Chainable<void>
       mockResourceTypes(): Chainable<void>
+      mockSearch(type: string, data?: object[]): Chainable<void>
       mockSpatialGranularities(): Chainable<void>
       mockSpatialLevels(): Chainable<void>
       mockSpatialZone(): Chainable<void>

--- a/src/assets/multiselect.css
+++ b/src/assets/multiselect.css
@@ -3,8 +3,8 @@
   --ms-bg: var(--background-contrast-grey);
   --ms-spinner-color: var(--text-active-blue-france);
   --ms-option-bg-selected: var(--background-action-high-blue-france);
-  --ms-option-bg-pointed: var(--background-action-high-blue-france);
-  --ms-option-color-pointed: var(--background-contrast-grey);
+  --ms-option-bg-pointed: var(--background-contrast-blue-france);
+  --ms-option-color-pointed: var(--text-default-grey);
   --ms-option-bg-selected-pointed: var(
     --background-action-high-blue-france-hover
   );

--- a/src/components/forms/dataset/DatasetCardForSelect.vue
+++ b/src/components/forms/dataset/DatasetCardForSelect.vue
@@ -89,7 +89,7 @@ const badgeClasse = computed(() => {
         <p
           class="fr-mt-1w fr-mb-1w fr-hidden fr-unhidden-sm overflow-wrap-anywhere fr-text--sm description-clamp"
         >
-          {{ stripFromMarkdown(dataset.description) }}
+          {{ stripFromMarkdown(dataset.description, 250) }}
         </p>
       </div>
     </div>

--- a/src/components/forms/dataset/DatasetCardForSelect.vue
+++ b/src/components/forms/dataset/DatasetCardForSelect.vue
@@ -87,13 +87,9 @@ const badgeClasse = computed(() => {
           <template v-else>{{ ownerName }}</template>
         </p>
         <p
-          class="fr-mt-1w fr-mb-1w fr-hidden fr-unhidden-sm overflow-wrap-anywhere fr-text--sm"
+          class="fr-mt-1w fr-mb-1w fr-hidden fr-unhidden-sm overflow-wrap-anywhere fr-text--sm description-clamp"
         >
-          <text-clamp
-            :auto-resize="true"
-            :text="stripFromMarkdown(dataset.description)"
-            :max-lines="2"
-          />
+          {{ stripFromMarkdown(dataset.description) }}
         </p>
       </div>
     </div>
@@ -103,5 +99,11 @@ const badgeClasse = computed(() => {
 <style scoped>
 h4 {
   font-size: 1rem;
+}
+.description-clamp {
+  display: -webkit-box !important;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 </style>

--- a/src/components/forms/dataset/FactorEditModal.vue
+++ b/src/components/forms/dataset/FactorEditModal.vue
@@ -60,9 +60,6 @@ const validateFields = () => {
   if (!modalFactor?.title.trim()) {
     formErrors.value.push('title')
   }
-  if (!modalFactor?.description?.trim()) {
-    formErrors.value.push('purpose')
-  }
   if (
     !modalFactor?.siteExtras.uri &&
     modalFactor?.siteExtras.availability === Availability.LOCAL_AVAILABLE

--- a/src/components/forms/dataset/FactorEditModal.vue
+++ b/src/components/forms/dataset/FactorEditModal.vue
@@ -61,8 +61,9 @@ const validateFields = () => {
     formErrors.value.push('title')
   }
   if (
-    !modalFactor?.siteExtras.uri &&
-    modalFactor?.siteExtras.availability === Availability.LOCAL_AVAILABLE
+    modalFactor?.siteExtras.availability === Availability.NOT_AVAILABLE ||
+    (!modalFactor?.siteExtras.uri &&
+      modalFactor?.siteExtras.availability === Availability.LOCAL_AVAILABLE)
   ) {
     formErrors.value.push('availability')
   }

--- a/src/components/forms/dataset/FactorEditModal.vue
+++ b/src/components/forms/dataset/FactorEditModal.vue
@@ -61,6 +61,7 @@ const validateFields = () => {
     formErrors.value.push('title')
   }
   if (
+    // NOT_AVAILABLE is not allowed anymore in edit/creation
     modalFactor?.siteExtras.availability === Availability.NOT_AVAILABLE ||
     (!modalFactor?.siteExtras.uri &&
       modalFactor?.siteExtras.availability === Availability.LOCAL_AVAILABLE)

--- a/src/components/forms/dataset/FactorFields.vue
+++ b/src/components/forms/dataset/FactorFields.vue
@@ -189,12 +189,6 @@ onMounted(() => {
           :value="Availability.MISSING"
           label="Je n'ai pas trouvé la donnée"
         />
-        <DsfrRadioButton
-          v-model="factor.siteExtras.availability"
-          name="source"
-          :value="Availability.NOT_AVAILABLE"
-          label="Je n'ai pas cherché la donnée"
-        />
       </fieldset>
     </div>
     <ErrorMessage

--- a/src/components/forms/dataset/FactorFields.vue
+++ b/src/components/forms/dataset/FactorFields.vue
@@ -130,11 +130,6 @@ onMounted(() => {
 </script>
 
 <template>
-  <FactorTextFields
-    v-model:factor-model="factor"
-    :error-title="getErrorMessage('title')"
-    :error-purpose="getErrorMessage('purpose')"
-  />
   <div id="input-availability" tabindex="-1">
     <div class="fr-mt-1w fr-mb-4w">
       <SelectDataset
@@ -205,6 +200,11 @@ onMounted(() => {
       input-name="availability"
     />
   </div>
+  <FactorTextFields
+    v-model:factor-model="factor"
+    :error-title="getErrorMessage('title')"
+    :error-purpose="getErrorMessage('purpose')"
+  />
   <div class="fr-input-group">
     <SelectTopicFactorGroup
       v-model:factor-model="factor"

--- a/src/components/forms/dataset/FactorFields.vue
+++ b/src/components/forms/dataset/FactorFields.vue
@@ -49,7 +49,6 @@ const selectedDataset: Ref<DatasetV2 | undefined> = ref(undefined)
 const hasEditorialization = computed(() => {
   return (
     !!factor.value.title.trim() &&
-    !!factor.value.description?.trim() &&
     (factor.value.siteExtras.group
       ? factor.value.siteExtras.group.trim().length < 100
       : true)

--- a/src/components/forms/dataset/FactorFields.vue
+++ b/src/components/forms/dataset/FactorFields.vue
@@ -86,6 +86,9 @@ const onSelectDataset = (value: DatasetV2 | undefined) => {
     factor.value.siteExtras.uri = null
     factor.value.element = null
   } else {
+    if (!factor.value.title.trim()) {
+      factor.value.title = value.title
+    }
     factor.value.siteExtras.availability = Availability.LOCAL_AVAILABLE
     factor.value.element = {
       id: value.id,

--- a/src/components/forms/dataset/FactorTextFields.vue
+++ b/src/components/forms/dataset/FactorTextFields.vue
@@ -46,7 +46,7 @@ const labels = computed(() => props.labels ?? useLabels(pageConf.labels))
   <div class="fr-input-group">
     <label class="fr-label" for="input-purpose"
       >Raison d'utilisation dans {{ labels.articles.ce }}
-      {{ labels.singular }} (obligatoire)</label
+      {{ labels.singular }} (facultatif)</label
     >
     <p id="purpose-description" class="fr-mt-1v fr-mb-2v fr-text--sm">
       Renseignez les motifs métier ou techniques motivant la sélection de ce jeu

--- a/src/model/topic.ts
+++ b/src/model/topic.ts
@@ -8,6 +8,7 @@ export type SiteId = 'siteId'
 
 export enum Availability {
   MISSING = 'missing',
+  // kept for backward compatibility with existing data — no longer offered in the UI
   NOT_AVAILABLE = 'not available',
   LOCAL_AVAILABLE = 'available',
   URL_AVAILABLE = 'url available',

--- a/src/utils/form.ts
+++ b/src/utils/form.ts
@@ -15,8 +15,12 @@ const errorMessages = (topicName: string) =>
       message: `Veuillez sélectionner un ${topicName}.`
     },
     {
-      inputName: 'group',
-      message: 'Le nom du regroupement est limité à 100 caractères.'
+      inputName: 'availability',
+      message: 'Un jeu de données ou une disponibilité doit être sélectionné.'
+    },
+    {
+      inputName: 'availabilityUrl',
+      message: 'Une URL doit être renseignée.'
     },
     { inputName: 'title', message: 'Le libellé doit être renseigné.' },
     {
@@ -24,12 +28,8 @@ const errorMessages = (topicName: string) =>
       message: "La raison d'utilisation ne doit pas être vide."
     },
     {
-      inputName: 'availability',
-      message: 'Un jeu de données ou une disponibilité doit être sélectionné.'
-    },
-    {
-      inputName: 'availabilityUrl',
-      message: 'Une URL doit être renseignée.'
+      inputName: 'group',
+      message: 'Le nom du regroupement est limité à 100 caractères.'
     }
   ] as const
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -34,10 +34,12 @@ export const fromMarkdown = (value: string | null, inline: boolean = false) => {
 /**
  * Strip HTML tags from markdown
  */
-export const stripFromMarkdown = (value: string) => {
+export const stripFromMarkdown = (value: string, maxSize?: number) => {
   const html = marked.parse(value, markedOptions)
   // type cast to string because we don't use async mode of marked
-  return stripHtml(html as string).result
+  const text = stripHtml(html as string).result
+  if (maxSize === undefined || text.length <= maxSize) return text
+  return text.slice(0, maxSize).replace(/\S+$/, '').trimEnd() + '…'
 }
 
 /**

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -21,9 +21,7 @@ const META_DESCRIPTION_MAX_LENGTH = 155
 
 export function toMetaDescription(value: string | null | undefined): string {
   if (!value) return ''
-  const plain = stripFromMarkdown(value)
-  if (plain.length <= META_DESCRIPTION_MAX_LENGTH) return plain
-  return plain.slice(0, META_DESCRIPTION_MAX_LENGTH).trimEnd() + '…'
+  return stripFromMarkdown(value, META_DESCRIPTION_MAX_LENGTH)
 }
 
 function toMetaKeywords(keywords: string[] | undefined): string | undefined {

--- a/src/utils/topic.ts
+++ b/src/utils/topic.ts
@@ -36,7 +36,7 @@ export const cloneTopic = async (
     if (!keepDatasets) {
       factor.element = null
       factor.extras[topicsExtrasKey].uri = null
-      factor.extras[topicsExtrasKey].availability = Availability.NOT_AVAILABLE
+      factor.extras[topicsExtrasKey].availability = Availability.MISSING
     }
     return factor
   })


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1122
Fix https://github.com/ecolabdata/ecospheres/issues/1123
Fix https://github.com/ecolabdata/ecospheres/issues/1128
Fix https://github.com/ecolabdata/ecospheres/issues/1127

- change the fields order
- description is not required anymore 
- "je n'ai pas trouvé la donnée" option is removed; legacy values stay as is, editing a factor forces the user to choose a new value
- selecting a dataset will prefill the factor title with the dataset's one, unless a factor title is already set
- bonus: change the background value for hover on dataset search/select list
- bonus: fix a performance issue with text clamping on `<DatasetCardForSelect>`

<img width="833" height="731" alt="Capture d’écran 2026-05-28 à 17 54 03" src="https://github.com/user-attachments/assets/bcacf0a3-2423-4de9-b578-5f572dbff1cc" />
