### PR TITLE
fix(dataset): harvest modified no fallback

### DIFF
--- a/src/components/datasets/DatasetTemporalitySection.vue
+++ b/src/components/datasets/DatasetTemporalitySection.vue
@@ -38,10 +38,10 @@ const harvestModifiedAt = harvest?.modified_at
           formatDate(harvestIssuedAt)
         }}</DescriptionListDetails>
       </div>
-      <div>
+      <div v-if="harvestModifiedAt">
         <DescriptionListTerm>Dernière révision</DescriptionListTerm>
         <DescriptionListDetails>{{
-          formatDate(harvestModifiedAt ?? dataset.last_update)
+          formatDate(harvestModifiedAt)
         }}</DescriptionListDetails>
       </div>
       <div v-if="dataset.frequency">


### PR DESCRIPTION
Do not fallback on `dataset.last_update` when there's no `harvest.modified_at`.