### PR TITLE
feat(indicators): refactor tabs

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -267,7 +267,6 @@ definitions: &definitions
 #         api_param: {string?}        # API query parameter name to use (optional, defaults to "tag")
 #         default_option: {string?}   # default option for the filter (optional)
 #         default_value: {string?}    # default value for the filter (optional)
-#         hide_on_list: {bool?}       # do not display filter on list page (optional, defaults to false)
 #         advanced: {bool?}           # show in the advanced (collapsed) section of GlobalSearch; omit for basic (always visible)
 #                                     # ⚠️ only applicable to data.gouv.fr native filters (eg badge)
 #         values:                     # list of values for this filter
@@ -429,32 +428,6 @@ pages:
       - id: last_update_range
         name: Date de mise à jour
         type: last_update_range
-      - id: theme
-        name: Thématique
-        default_option: Toutes les thématiques
-        type: select
-        color: green-menthe
-        use_filter_prefix: true
-        hide_on_list: true
-        values: *fnv_themes
-      - id: enjeu
-        name: Enjeu
-        default_option: Tous les enjeux
-        type: select
-        color: blue-ecume
-        use_filter_prefix: true
-        hide_on_list: true
-        values:
-          - id: adaptation-climat
-            name: Adaptation climat
-          - id: attenuation-climat
-            name: Atténuation climat
-          - id: biodiversite
-            name: Biodiversité
-          - id: ressources
-            name: Ressources
-          - id: sante
-            name: Santé
       - id: secteur
         name: Secteur
         default_option: Tous les secteurs

--- a/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
@@ -10,6 +10,7 @@ describe('Indicator Detail View', () => {
   beforeEach(() => {
     cy.mockMatomo()
     cy.mockStaticDatagouv()
+    cy.mockSpatialLevels()
 
     indicator = createIndicator({}, { enable_visualization: false })
     cy.mockDatasetAndRelatedObjects(indicator)
@@ -27,49 +28,43 @@ describe('Indicator Detail View', () => {
     })
   })
 
-  describe('Custom Metadata In Informations Tab', () => {
-    it('should display the thématique', () => {
+  describe('Tags display', () => {
+    it('should display the secteur tag', () => {
       cy.visit(`/indicators/${indicator.id}`)
-      cy.contains('Thématique').should('be.visible')
-      cy.contains('Mieux consommer').should('be.visible')
-    })
-
-    it('should display the enjeu', () => {
-      cy.visit(`/indicators/${indicator.id}`)
-      cy.contains('Enjeu').should('be.visible')
-      cy.contains('Biodiversité').should('be.visible')
-    })
-
-    it('should display the secteur', () => {
-      cy.visit(`/indicators/${indicator.id}`)
-      cy.contains('Secteur').should('be.visible')
       cy.contains('Energie').should('be.visible')
     })
 
-    it('should display the levier', () => {
+    it('should display the levier tag', () => {
       cy.visit(`/indicators/${indicator.id}`)
-      cy.contains('Levier').should('be.visible')
       cy.contains('Biogaz').should('be.visible')
-    })
-
-    it('should display the unité', () => {
-      cy.visit(`/indicators/${indicator.id}`)
-      cy.contains('Unité').should('be.visible')
-      cy.contains('kg CO2').should('be.visible')
     })
   })
 
-  describe('Custom Metadata In Technical Details Tab', () => {
+  describe('Informations Tab', () => {
     beforeEach(() => {
       cy.visit(`/indicators/${indicator.id}`)
-      cy.contains('Détails technique').click()
+      cy.contains('Informations').click()
     })
 
-    it('should display the granularité de la couverture territoriale', () => {
-      cy.contains('Granularité de la couverture territoriale').should(
-        'be.visible'
-      )
+    it('should display all metadata', () => {
+      cy.contains('Couverture géographique').should('be.visible')
+      cy.contains('Île-de-France').should('be.visible')
+      cy.contains('Couverture temporelle').should('be.visible')
+      cy.contains('Unité').should('be.visible')
+      cy.contains('kg CO2').should('be.visible')
+      cy.contains('Mailles').should('be.visible')
       cy.contains('Région française').should('be.visible')
+      cy.contains('Date de création').should('be.visible')
+      cy.contains('Date de mise à jour').should('be.visible')
+      cy.contains('Identifiant').should('be.visible')
+      cy.contains(indicator.id).should('be.visible')
+      cy.contains('Licence').should('be.visible')
+      cy.contains('Fréquence de mise à jour').should('be.visible')
+      cy.contains('Annuelle').should('be.visible')
+      cy.contains('Prochaine mise à jour attendue').should('be.visible')
+      cy.contains('T3 2025').should('be.visible')
+      cy.contains('Voir les mots-clés').should('be.visible')
+      cy.contains('Voir les extras').should('be.visible')
     })
   })
 

--- a/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
@@ -54,6 +54,7 @@ describe('Indicator Detail View', () => {
 
         // Couverture temporelle
         cy.contains('Couverture temporelle').should('be.visible')
+        cy.contains('2020 à 2022').should('be.visible')
 
         // Unité
         cy.contains('Unité').should('be.visible')
@@ -64,10 +65,10 @@ describe('Indicator Detail View', () => {
         cy.contains('Région française').should('be.visible')
 
         // Date de création
-        cy.contains('Date de création').should('be.visible')
+        cy.contains('h3', 'Date de création').parent().contains('2025')
 
         // Date de mise à jour
-        cy.contains('Date de mise à jour').should('be.visible')
+        cy.contains('h3', 'Date de mise à jour').parent().contains('2025')
 
         // Identifiant
         cy.contains('Identifiant').should('be.visible')
@@ -75,6 +76,7 @@ describe('Indicator Detail View', () => {
 
         // Licence
         cy.contains('Licence').should('be.visible')
+        cy.contains('Licence Ouverte / Open Licence').should('be.visible')
 
         // Fréquence de mise à jour
         cy.contains('Fréquence de mise à jour').should('be.visible')

--- a/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
@@ -65,10 +65,10 @@ describe('Indicator Detail View', () => {
         cy.contains('Région française').should('be.visible')
 
         // Date de création
-        cy.contains('h3', 'Date de création').parent().contains('2025')
+        cy.contains('dt', 'Date de création').parent().contains('2025')
 
         // Date de mise à jour
-        cy.contains('h3', 'Date de mise à jour').parent().contains('2025')
+        cy.contains('dt', 'Date de mise à jour').parent().contains('2025')
 
         // Identifiant
         cy.contains('Identifiant').should('be.visible')

--- a/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
@@ -47,45 +47,47 @@ describe('Indicator Detail View', () => {
     })
 
     it('should display all metadata', () => {
-      // Couverture géographique
-      cy.contains('Couverture géographique').should('be.visible')
-      cy.contains('Île-de-France').should('be.visible')
+      cy.get('#tab-content-infos').within(() => {
+        // Couverture géographique
+        cy.contains('Couverture géographique').should('be.visible')
+        cy.contains('Île-de-France').should('be.visible')
 
-      // Couverture temporelle
-      cy.contains('Couverture temporelle').should('be.visible')
+        // Couverture temporelle
+        cy.contains('Couverture temporelle').should('be.visible')
 
-      // Unité
-      cy.contains('Unité').should('be.visible')
-      cy.contains('kg CO2').should('be.visible')
+        // Unité
+        cy.contains('Unité').should('be.visible')
+        cy.contains('kg CO2').should('be.visible')
 
-      // Mailles
-      cy.contains('Mailles').should('be.visible')
-      cy.contains('Région française').should('be.visible')
+        // Mailles
+        cy.contains('Mailles').should('be.visible')
+        cy.contains('Région française').should('be.visible')
 
-      // Date de création
-      cy.contains('Date de création').should('be.visible')
+        // Date de création
+        cy.contains('Date de création').should('be.visible')
 
-      // Date de mise à jour
-      cy.contains('Date de mise à jour').should('be.visible')
+        // Date de mise à jour
+        cy.contains('Date de mise à jour').should('be.visible')
 
-      // Identifiant
-      cy.contains('Identifiant').should('be.visible')
-      cy.contains(indicator.id).should('be.visible')
+        // Identifiant
+        cy.contains('Identifiant').should('be.visible')
+        cy.contains(indicator.id).should('be.visible')
 
-      // Licence
-      cy.contains('Licence').should('be.visible')
+        // Licence
+        cy.contains('Licence').should('be.visible')
 
-      // Fréquence de mise à jour
-      cy.contains('Fréquence de mise à jour').should('be.visible')
-      cy.contains('Annuelle').should('be.visible')
+        // Fréquence de mise à jour
+        cy.contains('Fréquence de mise à jour').should('be.visible')
+        cy.contains('Annuelle').should('be.visible')
 
-      // Prochaine mise à jour attendue (Q → T replacement)
-      cy.contains('Prochaine mise à jour attendue').should('be.visible')
-      cy.contains('T3 2025').should('be.visible')
+        // Prochaine mise à jour attendue (Q → T replacement)
+        cy.contains('Prochaine mise à jour attendue').should('be.visible')
+        cy.contains('T3 2025').should('be.visible')
 
-      // Mots-clés et extras
-      cy.contains('Voir les mots-clés').should('be.visible')
-      cy.contains('Voir les extras').should('be.visible')
+        // Mots-clés et extras
+        cy.contains('Voir les mots-clés').should('be.visible')
+        cy.contains('Voir les extras').should('be.visible')
+      })
     })
   })
 

--- a/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
@@ -47,22 +47,43 @@ describe('Indicator Detail View', () => {
     })
 
     it('should display all metadata', () => {
+      // Couverture géographique
       cy.contains('Couverture géographique').should('be.visible')
       cy.contains('Île-de-France').should('be.visible')
+
+      // Couverture temporelle
       cy.contains('Couverture temporelle').should('be.visible')
+
+      // Unité
       cy.contains('Unité').should('be.visible')
       cy.contains('kg CO2').should('be.visible')
+
+      // Mailles
       cy.contains('Mailles').should('be.visible')
       cy.contains('Région française').should('be.visible')
+
+      // Date de création
       cy.contains('Date de création').should('be.visible')
+
+      // Date de mise à jour
       cy.contains('Date de mise à jour').should('be.visible')
+
+      // Identifiant
       cy.contains('Identifiant').should('be.visible')
       cy.contains(indicator.id).should('be.visible')
+
+      // Licence
       cy.contains('Licence').should('be.visible')
+
+      // Fréquence de mise à jour
       cy.contains('Fréquence de mise à jour').should('be.visible')
       cy.contains('Annuelle').should('be.visible')
+
+      // Prochaine mise à jour attendue (Q → T replacement)
       cy.contains('Prochaine mise à jour attendue').should('be.visible')
       cy.contains('T3 2025').should('be.visible')
+
+      // Mots-clés et extras
       cy.contains('Voir les mots-clés').should('be.visible')
       cy.contains('Voir les extras').should('be.visible')
     })

--- a/cypress/e2e/custom/ecospheres/indicators/support.ts
+++ b/cypress/e2e/custom/ecospheres/indicators/support.ts
@@ -50,16 +50,37 @@ export function createIndicator(
           }
         }
       ],
+      next_expected_update_quarter: 'Q3 2025',
       ...extraOverrides
     }
   }
 
-  // DatasetV2WithFullObject replaces license/frequency/spatial with richer objects; license/frequency default to null.
+  // DatasetV2WithFullObject replaces license/frequency/spatial with richer objects.
   return {
     ...dataset,
-    license: null,
-    frequency: null,
-    spatial: { granularity: { id: 'fr:region', name: 'Région' }, zones: [] },
+    temporal_coverage: { start: '2020-01-01', end: '2022-12-31' },
+    license: {
+      id: 'fr-lo',
+      title: 'Licence Ouverte / Open Licence',
+      alternate_titles: [],
+      alternate_urls: [],
+      flags: [],
+      maintainer: 'Etalab',
+      url: 'https://www.etalab.gouv.fr/licence-ouverte-open-licence'
+    },
+    frequency: { id: 'annual', label: 'Annuelle' },
+    spatial: {
+      granularity: { id: 'fr:region', name: 'Région française' },
+      zones: [
+        {
+          code: '11',
+          id: 'fr:region:11',
+          level: 'fr:region',
+          name: 'Île-de-France',
+          uri: ''
+        }
+      ]
+    },
     extras
   }
 }

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -169,7 +169,6 @@ Le filtre `organization_custom` ne déclare pas de `values` : la liste des organ
 | `default_value`    | Valeur par défaut                                                                                          |
 | `advanced`         | Place le filtre dans la section "Filtres avancés" de `GlobalSearch`                                        |
 | `applies_to_pages` | Indique les pages pour lesquelles le filtre est partagé (valeur de filtre conservée au changement de page) |
-| `hide_on_list`     | Masque le filtre sur la page de liste                                                                      |
 
 ### Exemple détaillé
 

--- a/src/custom/ecospheres/components/indicators/IndicatorInformationPanel.vue
+++ b/src/custom/ecospheres/components/indicators/IndicatorInformationPanel.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
 import { formatDate } from '@/utils'
-import { DateRangeDetails } from '@datagouv/components-next'
+import {
+  CopyButton,
+  DateRangeDetails,
+  ExtraAccordion,
+  LicenseBadge
+} from '@datagouv/components-next'
 import { computed, toRef } from 'vue'
 import type { Indicator } from '../../model/indicator'
 import { UNFILLED_LABEL, useIndicatorExtras } from '../../utils/indicator'
-import IndicatorTags from './IndicatorTags.vue'
 import InformationPanelItem from './informations/InformationPanelItem.vue'
 import InformationPanelSection from './informations/InformationPanelSection.vue'
 
@@ -24,47 +28,87 @@ const { unite, mailles } = useIndicatorExtras(indicator)
 
 <template>
   <div class="divide-y">
-    <!-- Catégorisation -->
-    <InformationPanelSection title="Catégorisation">
-      <InformationPanelItem title="Enjeux">
-        <IndicatorTags :indicator="indicator" type="enjeu" />
-      </InformationPanelItem>
-      <InformationPanelItem title="Thématique">
-        <IndicatorTags :indicator="indicator" type="theme" />
-      </InformationPanelItem>
-      <InformationPanelItem title="Secteur">
-        <IndicatorTags :indicator="indicator" type="secteur" />
-      </InformationPanelItem>
-      <InformationPanelItem title="Levier">
-        <IndicatorTags :indicator="indicator" type="levier" />
-      </InformationPanelItem>
-    </InformationPanelSection>
-
-    <!-- Métadonnées -->
-    <InformationPanelSection title="Métadonnées">
-      <InformationPanelItem title="Unité" :value="unite" />
-      <InformationPanelItem
-        title="Mailles"
-        :value="mailles.length ? mailles.join(', ') : UNFILLED_LABEL"
-      />
-    </InformationPanelSection>
-
     <!-- Couverture -->
     <InformationPanelSection title="Couverture">
+      <InformationPanelItem
+        title="Couverture géographique"
+        :value="spatialCoverage"
+      />
       <InformationPanelItem
         v-if="indicator.temporal_coverage"
         title="Couverture temporelle"
       >
         <DateRangeDetails :range="indicator.temporal_coverage" />
       </InformationPanelItem>
+    </InformationPanelSection>
+
+    <!-- Détails techniques -->
+    <InformationPanelSection title="Détails techniques">
+      <InformationPanelItem title="Unité" :value="unite" />
+      <InformationPanelItem
+        title="Mailles"
+        :value="mailles.length ? mailles.join(', ') : UNFILLED_LABEL"
+      />
+      <InformationPanelItem
+        title="Date de création"
+        :value="formatDate(indicator.created_at)"
+      />
       <InformationPanelItem
         title="Date de mise à jour"
         :value="formatDate(indicator.last_update)"
       />
+      <InformationPanelItem title="Identifiant">
+        {{ indicator.id }}
+        <CopyButton
+          class="!-mt-0.5"
+          label="Copier l'identifiant"
+          copied-label="Identifiant copié"
+          :text="indicator.id"
+          :hide-label="true"
+        />
+      </InformationPanelItem>
+      <InformationPanelItem v-if="indicator.license" title="Licence">
+        <LicenseBadge :license="indicator.license" />
+      </InformationPanelItem>
       <InformationPanelItem
-        title="Couverture géographique"
-        :value="spatialCoverage"
+        v-if="indicator.frequency"
+        title="Fréquence de mise à jour"
+        :value="indicator.frequency.label"
+      />
+      <InformationPanelItem
+        v-if="
+          indicator.extras['ecospheres-indicateurs']
+            .next_expected_update_quarter
+        "
+        title="Prochaine mise à jour attendue"
+        :value="
+          indicator.extras[
+            'ecospheres-indicateurs'
+          ].next_expected_update_quarter.replace('Q', 'T')
+        "
       />
     </InformationPanelSection>
+
+    <!-- Tags -->
+    <div class="pt-6">
+      <ExtraAccordion
+        v-if="indicator.tags?.length"
+        button-text="Voir les mots-clés"
+        title-text="Mots-clés"
+        :extra="
+          Object.fromEntries(indicator.tags.map((item, idx) => [idx, item]))
+        "
+        title-level="h3"
+      />
+
+      <!-- Extras -->
+      <ExtraAccordion
+        v-if="indicator.extras && Object.keys(indicator.extras).length"
+        button-text="Voir les extras"
+        title-text="Extras"
+        :extra="indicator.extras"
+        title-level="h3"
+      />
+    </div>
   </div>
 </template>

--- a/src/custom/ecospheres/components/indicators/IndicatorInformationPanel.vue
+++ b/src/custom/ecospheres/components/indicators/IndicatorInformationPanel.vue
@@ -3,8 +3,10 @@ import { formatDate } from '@/utils'
 import {
   CopyButton,
   DateRangeDetails,
+  DescriptionListDetails,
   ExtraAccordion,
-  LicenseBadge
+  LicenseBadge,
+  Tag
 } from '@datagouv/components-next'
 import { computed, toRef } from 'vue'
 import type { Indicator } from '../../model/indicator'
@@ -86,6 +88,17 @@ const { unite, mailles } = useIndicatorExtras(indicator)
       </InformationPanelItem>
       <InformationPanelItem v-if="indicator.license" title="Licence">
         <LicenseBadge :license="indicator.license" />
+      </InformationPanelItem>
+      <InformationPanelItem
+        v-if="indicator.tags && indicator.tags.length"
+        title="Mots-clés"
+        is-row
+      >
+        <DescriptionListDetails class="flex flex-wrap gap-2 items-start">
+          <Tag v-for="tag in indicator.tags" :key="tag" type="secondary">
+            {{ tag }}
+          </Tag>
+        </DescriptionListDetails>
       </InformationPanelItem>
     </InformationPanelSection>
 

--- a/src/custom/ecospheres/components/indicators/IndicatorInformationPanel.vue
+++ b/src/custom/ecospheres/components/indicators/IndicatorInformationPanel.vue
@@ -57,19 +57,6 @@ const { unite, mailles } = useIndicatorExtras(indicator)
         title="Date de mise à jour"
         :value="formatDate(indicator.last_update)"
       />
-      <InformationPanelItem title="Identifiant">
-        {{ indicator.id }}
-        <CopyButton
-          class="!-mt-0.5"
-          label="Copier l'identifiant"
-          copied-label="Identifiant copié"
-          :text="indicator.id"
-          :hide-label="true"
-        />
-      </InformationPanelItem>
-      <InformationPanelItem v-if="indicator.license" title="Licence">
-        <LicenseBadge :license="indicator.license" />
-      </InformationPanelItem>
       <InformationPanelItem
         v-if="indicator.frequency"
         title="Fréquence de mise à jour"
@@ -87,6 +74,19 @@ const { unite, mailles } = useIndicatorExtras(indicator)
           ].next_expected_update_quarter.replace('Q', 'T')
         "
       />
+      <InformationPanelItem title="Identifiant">
+        {{ indicator.id }}
+        <CopyButton
+          class="!-mt-0.5"
+          label="Copier l'identifiant"
+          copied-label="Identifiant copié"
+          :text="indicator.id"
+          :hide-label="true"
+        />
+      </InformationPanelItem>
+      <InformationPanelItem v-if="indicator.license" title="Licence">
+        <LicenseBadge :license="indicator.license" />
+      </InformationPanelItem>
     </InformationPanelSection>
 
     <!-- Tags -->

--- a/src/custom/ecospheres/model/indicator.ts
+++ b/src/custom/ecospheres/model/indicator.ts
@@ -33,6 +33,7 @@ export interface IndicatorExtrasData {
   y_start_at_zero?: boolean
   ignore_format_big_number?: boolean
   enable_visualization?: boolean
+  next_expected_update_quarter?: string
 }
 
 export type IndicatorExtras = DatasetV2WithFullObject['extras'] & {

--- a/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
+++ b/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
@@ -7,7 +7,6 @@ import DiscussionsList from '@/components/DiscussionsList.vue'
 import GenericContainer from '@/components/GenericContainer.vue'
 import DatasetAddToTopicModal from '@/components/datasets/DatasetAddToTopicModal.vue'
 import DatasetDataservicesList from '@/components/datasets/DatasetDataservicesList.vue'
-import DatasetInformationPanel from '@/components/datasets/DatasetInformationPanel.vue'
 import DatasetReusesList from '@/components/datasets/DatasetReusesList.vue'
 import DatasetSidebar from '@/components/datasets/DatasetSidebar.vue'
 import ResourcesList from '@/components/datasets/ResourcesList.vue'
@@ -21,6 +20,7 @@ import { usePageConf } from '@/utils/config'
 import { useLabels } from '@/utils/labels'
 import IndicatorInformationPanel from '../../components/indicators/IndicatorInformationPanel.vue'
 import IndicatorSourcesList from '../../components/indicators/IndicatorSourcesList.vue'
+import IndicatorTags from '../../components/indicators/IndicatorTags.vue'
 import type { Indicator } from '../../model/indicator'
 
 const route = useRouteParamsAsString()
@@ -47,12 +47,6 @@ const links = computed(() => [
 ])
 
 const tabTitles = computed(() => [
-  { title: 'Informations', tabId: 'tab-info', panelId: 'tab-content-info' },
-  {
-    title: 'Fichiers',
-    tabId: 'tab-files',
-    panelId: 'tab-content-files'
-  },
   // only display the visualization tab if the indicator has visualization enabled
   ...(indicator.value?.extras['ecospheres-indicateurs'].enable_visualization
     ? [
@@ -63,6 +57,11 @@ const tabTitles = computed(() => [
         }
       ]
     : []),
+  {
+    title: 'Fichiers',
+    tabId: 'tab-files',
+    panelId: 'tab-content-files'
+  },
   { title: 'Sources', tabId: 'tab-sources', panelId: 'tab-content-sources' },
   {
     title: 'Réutilisations et API',
@@ -75,9 +74,9 @@ const tabTitles = computed(() => [
     panelId: 'tab-content-discussions'
   },
   {
-    title: 'Détails techniques',
-    tabId: 'tab-details',
-    panelId: 'tab-content-details'
+    title: 'Informations',
+    tabId: 'tab-infos',
+    panelId: 'tab-content-infos'
   }
 ])
 
@@ -138,7 +137,10 @@ onMounted(() => {
   <GenericContainer v-if="indicator">
     <div class="fr-grid-row fr-grid-row--gutters fr-mt-1w">
       <div class="fr-col-12 fr-col-md-8">
-        <h1 class="fr-mb-2v">{{ indicator.title }}</h1>
+        <div class="fr-mb-4v">
+          <h1 class="fr-mb-1v fr-mr-2v">{{ indicator.title }}</h1>
+          <IndicatorTags :indicator="indicator" />
+        </div>
         <ReadMore max-height="600">
           <!-- eslint-disable-next-line vue/no-v-html -->
           <div v-html="description"></div>
@@ -153,11 +155,6 @@ onMounted(() => {
       tab-list-name="Groupes d'attributs du jeu de données"
       :tab-titles="tabTitles"
     >
-      <!-- Informations -->
-      <DsfrTabContent panel-id="tab-content-info" tab-id="tab-info">
-        <IndicatorInformationPanel :indicator="indicator" />
-      </DsfrTabContent>
-
       <!-- Fichiers -->
       <DsfrTabContent panel-id="tab-content-files" tab-id="tab-files">
         <ResourcesList
@@ -204,9 +201,9 @@ onMounted(() => {
         <IndicatorSourcesList :indicator="indicator" />
       </DsfrTabContent>
 
-      <!-- Détails techniques -->
-      <DsfrTabContent panel-id="tab-content-details" tab-id="tab-details">
-        <DatasetInformationPanel :dataset="indicator" />
+      <!-- Informations -->
+      <DsfrTabContent panel-id="tab-content-infos" tab-id="tab-infos">
+        <IndicatorInformationPanel :indicator="indicator" />
       </DsfrTabContent>
     </DsfrTabs>
   </GenericContainer>

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -56,7 +56,6 @@ export interface PageFilterConf {
   use_filter_prefix: boolean | null
   api_param: string | null
   form: PageFilterFormConf | null
-  hide_on_list: boolean | null
   values: PageFilterValueConf[]
 }
 

--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -190,11 +190,7 @@ export function buildGlobalSearchConfig(pageKey: string): {
 
   // Build customFilters for the primary page (rendered via SearchSelectFilter/SearchOrganizationFilter in #custom-filters slot).
   const customFilters: CustomFilterConfig[] = pageConf.filters
-    .filter(
-      (f) =>
-        !f.hide_on_list &&
-        CUSTOM_FILTER_TYPE_SET.has(f.type as CustomFilterType)
-    )
+    .filter((f) => CUSTOM_FILTER_TYPE_SET.has(f.type as CustomFilterType))
     .flatMap((f): CustomFilterConfig[] => {
       if (f.type === 'organization_custom') {
         return [


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1139
Related https://github.com/ecolabdata/ecospheres/issues/915

I also added `next_expected_update_quarter` support in informations tab, it provides a nice balance with frequency. We'll see in https://github.com/ecolabdata/ecospheres/issues/915 if moving/copying it to the sidebar is still warranted.

NB: the tags accordion is done with minimal effort (reuse extras even though the structure is different). YMMV, I don't think it matters a lot (power user feature).

<img width="1083" height="842" alt="Capture d’écran 2026-06-08 à 12 01 49" src="https://github.com/user-attachments/assets/336f4c9b-df7b-43af-b9a4-3d2beda7385d" />
<img width="1241" height="966" alt="Capture d’écran 2026-06-08 à 12 17 44" src="https://github.com/user-attachments/assets/4d4cb60c-9980-4e7e-b311-70ec92ec4bdd" />
