### PR TITLE
chore: lock pnpm@11 on upgrade workflow

### DIFF
--- a/.github/workflows/update-pnpm.yml
+++ b/.github/workflows/update-pnpm.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Update pnpm via corepack
         run: |
           corepack enable
-          corepack use pnpm@latest
+          corepack use pnpm@11
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
@@ -26,4 +26,4 @@ jobs:
           commit-message: 'chore: update pnpm'
           title: 'chore: update pnpm'
           branch: chore/update-pnpm
-          body: Automated pnpm version bump via `corepack use pnpm@latest`.
+          body: Automated pnpm version bump via `corepack use pnpm@11`.


### PR DESCRIPTION
This locks the upgrade path for pnpm in the weekly workflow to major v11.

pnpm has a big rewrite in the works for v12, it will be worth waiting a bit for things to stabilise I think. 

pnpm still releases fixes to the last major branch, so even if v12 is released, we should still keep getting upgrades on v11.

I'm also a bit worried about the LLM-fed activity and release frenzy on the repo this last few months, but I'm not sure what can be done about that except not upgrading to major too fast. The development is still led by the historic maintainer AFAIK. I can't find any GitHub discussion about the new development pace.
