### PR TITLE
fix(accessibilite): use dsfr icon on hp

### DIFF
--- a/src/custom/accessibilite/components/home/HomeAbout.vue
+++ b/src/custom/accessibilite/components/home/HomeAbout.vue
@@ -30,7 +30,7 @@ import { DsfrButton } from '@gouvminint/vue-dsfr'
           </p>
           <DsfrButton
             label="Contactez-nous"
-            icon="ri:arrow-right-line"
+            icon="fr-icon-arrow-right-line"
             :icon-right="true"
           />
         </div>


### PR DESCRIPTION
Avoids making a call to a CDN for an icon that is included in dsfr.

(This made some tests fail eg https://github.com/opendatateam/udata-front-kit/actions/runs/27283310184/job/80583513399?pr=1233)