### PR TITLE
chore(tests): ignore domain for dictionnary updates

### DIFF
--- a/cypress/support/generic_mocks.ts
+++ b/cypress/support/generic_mocks.ts
@@ -9,7 +9,8 @@ const allowedDomains = [
   'www.google.com',
   'android.clients.google.com',
   'safebrowsing.googleapis.com',
-  'accounts.google.com'
+  'accounts.google.com',
+  'gvt1.com'
 ]
 
 Cypress.Commands.add('catchUnmockedRequests', () => {


### PR DESCRIPTION
Avoid transient errors in tests like:

```
    1) Home Page
         "before each" hook for "should load the home page successfully":
       Error: Unmocked external API call detected: GET
  https://r3---sn-2imern7r.gvt1.com/edgedl/chrome/dict/en-us-10-1.bdic?cms_redirect=yes&met=1
  781505898,&mh=7g&mip=20.169.53.40&mm=28&mn=sn-2imern7r&ms=nvh&mt=1781505610&mv=m&mvi=3&pl=1
  5&rmhost=r2---sn-2imern7r.gvt1.com&rms=nvh,nvh&shardbypass=sd
```