### PR TITLE
[Simplifions] Fix problème de non-scroll depuis un lien externe vers une ancre

### DIFF
--- a/src/custom/simplifions/components/SimplifionsCasDusageDescription.vue
+++ b/src/custom/simplifions/components/SimplifionsCasDusageDescription.vue
@@ -166,6 +166,7 @@ import ContentPlaceholder from '@/components/ContentPlaceholder.vue'
 import { formatDate, fromMarkdown } from '@/utils'
 import { OrganizationNameWithCertificate } from '@datagouv/components-next'
 import { grist } from '../grist.ts'
+import { useHashScroll } from '../useHashScroll'
 import type { CasUsage, Recommandation } from '../model/grist'
 import type { TopicCasUsage } from '../model/topics'
 import DraftTag from './DraftTag.vue'
@@ -183,6 +184,11 @@ const casUsageId = props.topic.extras['simplifions-v2-cas-d-usages'].id
 
 const casUsage = ref<CasUsage | undefined>(undefined)
 const recommandations = ref<Recommandation[] | undefined>(undefined)
+
+useHashScroll({
+  ready: () => !!casUsage.value,
+  containerSelector: '.test_cas-d-usage-description'
+})
 
 grist.getRecord('Cas_d_usages', casUsageId).then((data) => {
   casUsage.value = data.fields as CasUsage

--- a/src/custom/simplifions/components/SimplifionsCasDusageDescription.vue
+++ b/src/custom/simplifions/components/SimplifionsCasDusageDescription.vue
@@ -166,9 +166,9 @@ import ContentPlaceholder from '@/components/ContentPlaceholder.vue'
 import { formatDate, fromMarkdown } from '@/utils'
 import { OrganizationNameWithCertificate } from '@datagouv/components-next'
 import { grist } from '../grist.ts'
-import { useHashScroll } from '../useHashScroll'
 import type { CasUsage, Recommandation } from '../model/grist'
 import type { TopicCasUsage } from '../model/topics'
+import { useHashScroll } from '../useHashScroll'
 import DraftTag from './DraftTag.vue'
 import SimplifionsRecoDataApi from './SimplifionsRecoDataApi.vue'
 import SimplifionsRecoSolutions from './SimplifionsRecoSolutions.vue'
@@ -186,8 +186,7 @@ const casUsage = ref<CasUsage | undefined>(undefined)
 const recommandations = ref<Recommandation[] | undefined>(undefined)
 
 useHashScroll({
-  ready: () => !!casUsage.value,
-  containerSelector: '.test_cas-d-usage-description'
+  ready: () => !!casUsage.value
 })
 
 grist.getRecord('Cas_d_usages', casUsageId).then((data) => {

--- a/src/custom/simplifions/components/SimplifionsSolutionDescription.vue
+++ b/src/custom/simplifions/components/SimplifionsSolutionDescription.vue
@@ -335,7 +335,6 @@ import ContentPlaceholder from '@/components/ContentPlaceholder.vue'
 import { formatDate, fromMarkdown } from '@/utils'
 import { OrganizationNameWithCertificate } from '@datagouv/components-next'
 import { grist } from '../grist'
-import { useHashScroll } from '../useHashScroll'
 import type {
   ApiEtDatasetsIntegresRecord,
   ApiOrDataset,
@@ -345,6 +344,7 @@ import type {
   SolutionRecord
 } from '../model/grist'
 import type { TopicSolution } from '../model/topics'
+import { useHashScroll } from '../useHashScroll'
 import DraftTag from './DraftTag.vue'
 import HumanReadableList from './HumanReadableList.vue'
 import SimplifionsCasDusageRelatedCard from './SimplifionsCasDusageRelatedCard.vue'
@@ -554,7 +554,6 @@ const onFiltersUpdate = (filters: IntegrateursFilters) => {
 
 useHashScroll({
   ready: () => !!solution.value,
-  containerSelector: '.solution-description',
   hashConditions: {
     '#solutions-integratices': () => solutionsIntegratices.value.length > 0
   }

--- a/src/custom/simplifions/components/SimplifionsSolutionDescription.vue
+++ b/src/custom/simplifions/components/SimplifionsSolutionDescription.vue
@@ -335,6 +335,7 @@ import ContentPlaceholder from '@/components/ContentPlaceholder.vue'
 import { formatDate, fromMarkdown } from '@/utils'
 import { OrganizationNameWithCertificate } from '@datagouv/components-next'
 import { grist } from '../grist'
+import { useHashScroll } from '../useHashScroll'
 import type {
   ApiEtDatasetsIntegresRecord,
   ApiOrDataset,
@@ -550,6 +551,14 @@ const filteredAndSortedSolutions = computed(() => {
 const onFiltersUpdate = (filters: IntegrateursFilters) => {
   integrateursFilters.value = filters
 }
+
+useHashScroll({
+  ready: () => !!solution.value,
+  containerSelector: '.solution-description',
+  hashConditions: {
+    '#solutions-integratices': () => solutionsIntegratices.value.length > 0
+  }
+})
 </script>
 
 <style scoped>

--- a/src/custom/simplifions/useHashScroll.ts
+++ b/src/custom/simplifions/useHashScroll.ts
@@ -1,0 +1,62 @@
+import { nextTick, watchEffect } from 'vue'
+import { useRoute } from 'vue-router'
+
+interface UseHashScrollOptions {
+  // base condition: is the page's primary data loaded?
+  ready: () => boolean
+  // CSS selector of the container to observe for layout stability
+  containerSelector: string
+  // per-hash extra conditions (for sections with conditional rendering)
+  hashConditions?: Record<string, () => boolean>
+  debounceMs?: number
+}
+
+export function useHashScroll({
+  ready,
+  containerSelector,
+  hashConditions,
+  debounceMs = 150
+}: UseHashScrollOptions): void {
+  const route = useRoute()
+  let scrollHandled = false
+
+  watchEffect(async () => {
+    const hash = route.hash
+
+    if (scrollHandled || !hash || !ready()) return
+
+    const extraCondition = hashConditions?.[hash]
+    if (extraCondition && !extraCondition()) return
+
+    scrollHandled = true
+    await nextTick()
+    scrollToStable(hash, containerSelector, debounceMs)
+  })
+}
+
+// Waits for the container to stop resizing (debounced) before scrolling.
+// This handles async child components that expand after the initial render.
+function scrollToStable(
+  hash: string,
+  containerSelector: string,
+  debounceMs: number
+) {
+  const el = document.querySelector(hash)
+  if (!el) return
+
+  let timer: ReturnType<typeof setTimeout>
+  const scheduleScroll = () => {
+    clearTimeout(timer)
+    timer = setTimeout(() => {
+      observer.disconnect()
+      el.scrollIntoView({ behavior: 'smooth' })
+    }, debounceMs)
+  }
+
+  const observer = new ResizeObserver(scheduleScroll)
+  const container = document.querySelector(containerSelector)
+  if (container) observer.observe(container)
+
+  scheduleScroll()
+  setTimeout(() => observer.disconnect(), 3000)
+}

--- a/src/custom/simplifions/useHashScroll.ts
+++ b/src/custom/simplifions/useHashScroll.ts
@@ -1,54 +1,58 @@
-import { nextTick, onUnmounted, watchEffect } from 'vue'
+import { onUnmounted, watchEffect } from 'vue'
 import { useRoute } from 'vue-router'
-import { useDebounceFn } from '@vueuse/core'
 
 interface UseHashScrollOptions {
   ready: () => boolean
-  containerSelector: string
   hashConditions?: Record<string, () => boolean>
   debounceMs?: number
 }
 
 export function useHashScroll({
   ready,
-  containerSelector,
   hashConditions,
   debounceMs = 150
 }: UseHashScrollOptions): void {
   const route = useRoute()
-  let scrollHandled = false
-  let observer: ResizeObserver | null = null
+  let scrollHandledFor: string | null = null
+  let observer: MutationObserver | null = null
+  let scrollTimeout: ReturnType<typeof setTimeout> | null = null
 
-  const scrollToElement = useDebounceFn((el: Element) => {
-    if (!el.isConnected) return
+  const cleanup = () => {
     observer?.disconnect()
     observer = null
-    el.scrollIntoView({ behavior: 'smooth' })
-  }, debounceMs)
+    if (scrollTimeout !== null) {
+      clearTimeout(scrollTimeout)
+      scrollTimeout = null
+    }
+  }
 
-  onUnmounted(() => {
-    observer?.disconnect()
-    observer = null
-  })
+  onUnmounted(cleanup)
 
-  watchEffect(async () => {
+  watchEffect(() => {
     const hash = route.hash
-    if (scrollHandled || !hash || !ready()) return
+    if (scrollHandledFor === hash || !hash || !ready()) return
     const extraCondition = hashConditions?.[hash]
     if (extraCondition && !extraCondition()) return
 
-    // Element already in DOM: scrollBehavior handles it, no need to intervene
+    cleanup()
+
+    // Element already in DOM: scrollBehavior handles it
     if (document.querySelector(hash)) return
 
-    scrollHandled = true
-    await nextTick()
-
-    const el = document.querySelector(hash)
-    if (!el) return
-
-    observer = new ResizeObserver(() => scrollToElement(el))
-    const container = document.querySelector(containerSelector)
-    if (container) observer.observe(container)
-    scrollToElement(el)
+    observer = new MutationObserver(() => {
+      const el = document.querySelector(hash)
+      if (!el) return
+      // Debounce: wait for DOM mutations to settle before scrolling,
+      // so content above the target (async sections) has finished rendering.
+      if (scrollTimeout !== null) clearTimeout(scrollTimeout)
+      scrollTimeout = setTimeout(() => {
+        scrollTimeout = null
+        if (!el.isConnected) return
+        el.scrollIntoView({ behavior: 'smooth' })
+        scrollHandledFor = hash
+        cleanup()
+      }, debounceMs)
+    })
+    observer.observe(document.body, { childList: true, subtree: true })
   })
 }

--- a/src/custom/simplifions/useHashScroll.ts
+++ b/src/custom/simplifions/useHashScroll.ts
@@ -1,12 +1,10 @@
-import { nextTick, watchEffect } from 'vue'
+import { nextTick, onUnmounted, watchEffect } from 'vue'
 import { useRoute } from 'vue-router'
+import { useDebounceFn } from '@vueuse/core'
 
 interface UseHashScrollOptions {
-  // base condition: is the page's primary data loaded?
   ready: () => boolean
-  // CSS selector of the container to observe for layout stability
   containerSelector: string
-  // per-hash extra conditions (for sections with conditional rendering)
   hashConditions?: Record<string, () => boolean>
   debounceMs?: number
 }
@@ -19,44 +17,38 @@ export function useHashScroll({
 }: UseHashScrollOptions): void {
   const route = useRoute()
   let scrollHandled = false
+  let observer: ResizeObserver | null = null
+
+  const scrollToElement = useDebounceFn((el: Element) => {
+    if (!el.isConnected) return
+    observer?.disconnect()
+    observer = null
+    el.scrollIntoView({ behavior: 'smooth' })
+  }, debounceMs)
+
+  onUnmounted(() => {
+    observer?.disconnect()
+    observer = null
+  })
 
   watchEffect(async () => {
     const hash = route.hash
-
     if (scrollHandled || !hash || !ready()) return
-
     const extraCondition = hashConditions?.[hash]
     if (extraCondition && !extraCondition()) return
 
+    // Element already in DOM: scrollBehavior handles it, no need to intervene
+    if (document.querySelector(hash)) return
+
     scrollHandled = true
     await nextTick()
-    scrollToStable(hash, containerSelector, debounceMs)
+
+    const el = document.querySelector(hash)
+    if (!el) return
+
+    observer = new ResizeObserver(() => scrollToElement(el))
+    const container = document.querySelector(containerSelector)
+    if (container) observer.observe(container)
+    scrollToElement(el)
   })
-}
-
-// Waits for the container to stop resizing (debounced) before scrolling.
-// This handles async child components that expand after the initial render.
-function scrollToStable(
-  hash: string,
-  containerSelector: string,
-  debounceMs: number
-) {
-  const el = document.querySelector(hash)
-  if (!el) return
-
-  let timer: ReturnType<typeof setTimeout>
-  const scheduleScroll = () => {
-    clearTimeout(timer)
-    timer = setTimeout(() => {
-      observer.disconnect()
-      el.scrollIntoView({ behavior: 'smooth' })
-    }, debounceMs)
-  }
-
-  const observer = new ResizeObserver(scheduleScroll)
-  const container = document.querySelector(containerSelector)
-  if (container) observer.observe(container)
-
-  scheduleScroll()
-  setTimeout(() => observer.disconnect(), 3000)
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -112,9 +112,12 @@ const routerPromise = siteRoutesPromise.then((siteRoutes) => {
         return false
       }
       if (to.hash !== '') {
-        return {
-          el: to.hash
+        // Only scroll if the element is already in the DOM. If it isn't (async content),
+        // useHashScroll in the target component can take over if wired.
+        if (document.querySelector(to.hash)) {
+          return { el: to.hash }
         }
+        return false
       }
       // Preserve scroll when switching between search list pages (e.g. datasets ↔ indicators)
       if (to.meta.searchConfig && from.meta.searchConfig) {


### PR DESCRIPTION
En tant que utilisateur, si je clique sur une URL de type `/solutions/bouquet-api-entreprise#solutions-integratices`, la page ne me mène pas vers l'ancre, elle reste en haut de la page. Pour arriver sur l'ancre, il est requis de reloader.

Cette PR vise à réparer ce problème.