### PR TITLE
feat(useHashScroll): use MutationObserver

### DIFF
--- a/src/custom/simplifions/components/SimplifionsCasDusageDescription.vue
+++ b/src/custom/simplifions/components/SimplifionsCasDusageDescription.vue
@@ -166,9 +166,9 @@ import ContentPlaceholder from '@/components/ContentPlaceholder.vue'
 import { formatDate, fromMarkdown } from '@/utils'
 import { OrganizationNameWithCertificate } from '@datagouv/components-next'
 import { grist } from '../grist.ts'
-import { useHashScroll } from '../useHashScroll'
 import type { CasUsage, Recommandation } from '../model/grist'
 import type { TopicCasUsage } from '../model/topics'
+import { useHashScroll } from '../useHashScroll'
 import DraftTag from './DraftTag.vue'
 import SimplifionsRecoDataApi from './SimplifionsRecoDataApi.vue'
 import SimplifionsRecoSolutions from './SimplifionsRecoSolutions.vue'
@@ -186,8 +186,7 @@ const casUsage = ref<CasUsage | undefined>(undefined)
 const recommandations = ref<Recommandation[] | undefined>(undefined)
 
 useHashScroll({
-  ready: () => !!casUsage.value,
-  containerSelector: '.test_cas-d-usage-description'
+  ready: () => !!casUsage.value
 })
 
 grist.getRecord('Cas_d_usages', casUsageId).then((data) => {

--- a/src/custom/simplifions/components/SimplifionsSolutionDescription.vue
+++ b/src/custom/simplifions/components/SimplifionsSolutionDescription.vue
@@ -335,7 +335,6 @@ import ContentPlaceholder from '@/components/ContentPlaceholder.vue'
 import { formatDate, fromMarkdown } from '@/utils'
 import { OrganizationNameWithCertificate } from '@datagouv/components-next'
 import { grist } from '../grist'
-import { useHashScroll } from '../useHashScroll'
 import type {
   ApiEtDatasetsIntegresRecord,
   ApiOrDataset,
@@ -345,6 +344,7 @@ import type {
   SolutionRecord
 } from '../model/grist'
 import type { TopicSolution } from '../model/topics'
+import { useHashScroll } from '../useHashScroll'
 import DraftTag from './DraftTag.vue'
 import HumanReadableList from './HumanReadableList.vue'
 import SimplifionsCasDusageRelatedCard from './SimplifionsCasDusageRelatedCard.vue'
@@ -554,7 +554,6 @@ const onFiltersUpdate = (filters: IntegrateursFilters) => {
 
 useHashScroll({
   ready: () => !!solution.value,
-  containerSelector: '.solution-description',
   hashConditions: {
     '#solutions-integratices': () => solutionsIntegratices.value.length > 0
   }

--- a/src/custom/simplifions/useHashScroll.ts
+++ b/src/custom/simplifions/useHashScroll.ts
@@ -1,54 +1,61 @@
-import { nextTick, onUnmounted, watchEffect } from 'vue'
+import { onUnmounted, watchEffect } from 'vue'
 import { useRoute } from 'vue-router'
-import { useDebounceFn } from '@vueuse/core'
 
 interface UseHashScrollOptions {
   ready: () => boolean
-  containerSelector: string
   hashConditions?: Record<string, () => boolean>
   debounceMs?: number
 }
 
 export function useHashScroll({
   ready,
-  containerSelector,
   hashConditions,
   debounceMs = 150
 }: UseHashScrollOptions): void {
   const route = useRoute()
-  let scrollHandled = false
-  let observer: ResizeObserver | null = null
+  let scrollHandledFor: string | null = null
+  let observer: MutationObserver | null = null
+  let scrollTimeout: ReturnType<typeof setTimeout> | null = null
 
-  const scrollToElement = useDebounceFn((el: Element) => {
-    if (!el.isConnected) return
+  const cleanup = () => {
     observer?.disconnect()
     observer = null
-    el.scrollIntoView({ behavior: 'smooth' })
-  }, debounceMs)
+    if (scrollTimeout !== null) {
+      clearTimeout(scrollTimeout)
+      scrollTimeout = null
+    }
+  }
 
-  onUnmounted(() => {
-    observer?.disconnect()
-    observer = null
-  })
+  onUnmounted(cleanup)
 
-  watchEffect(async () => {
+  watchEffect(() => {
     const hash = route.hash
-    if (scrollHandled || !hash || !ready()) return
+    if (scrollHandledFor === hash || !hash || !ready()) return
     const extraCondition = hashConditions?.[hash]
     if (extraCondition && !extraCondition()) return
 
-    // Element already in DOM: scrollBehavior handles it, no need to intervene
-    if (document.querySelector(hash)) return
+    // Element already in DOM: scrollBehavior handles it
+    if (document.querySelector(hash)) {
+      cleanup()
+      return
+    }
 
-    scrollHandled = true
-    await nextTick()
+    cleanup()
 
-    const el = document.querySelector(hash)
-    if (!el) return
-
-    observer = new ResizeObserver(() => scrollToElement(el))
-    const container = document.querySelector(containerSelector)
-    if (container) observer.observe(container)
-    scrollToElement(el)
+    observer = new MutationObserver(() => {
+      const el = document.querySelector(hash)
+      if (!el) return
+      // Debounce: wait for DOM mutations to settle before scrolling,
+      // so content above the target (async sections) has finished rendering.
+      if (scrollTimeout !== null) clearTimeout(scrollTimeout)
+      scrollTimeout = setTimeout(() => {
+        scrollTimeout = null
+        if (!el.isConnected) return
+        el.scrollIntoView({ behavior: 'smooth' })
+        scrollHandledFor = hash
+        cleanup()
+      }, debounceMs)
+    })
+    observer.observe(document.body, { childList: true, subtree: true })
   })
 }

--- a/src/custom/simplifions/useHashScroll.ts
+++ b/src/custom/simplifions/useHashScroll.ts
@@ -34,13 +34,10 @@ export function useHashScroll({
     const extraCondition = hashConditions?.[hash]
     if (extraCondition && !extraCondition()) return
 
-    // Element already in DOM: scrollBehavior handles it
-    if (document.querySelector(hash)) {
-      cleanup()
-      return
-    }
-
     cleanup()
+
+    // Element already in DOM: scrollBehavior handles it
+    if (document.querySelector(hash)) return
 
     observer = new MutationObserver(() => {
       const el = document.querySelector(hash)

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -112,6 +112,8 @@ const routerPromise = siteRoutesPromise.then((siteRoutes) => {
         return false
       }
       if (to.hash !== '') {
+        // Only scroll if the element is already in the DOM. If it isn't (async content),
+        // useHashScroll in the target component can take over if wired.
         if (document.querySelector(to.hash)) {
           return { el: to.hash }
         }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -112,9 +112,10 @@ const routerPromise = siteRoutesPromise.then((siteRoutes) => {
         return false
       }
       if (to.hash !== '') {
-        return {
-          el: to.hash
+        if (document.querySelector(to.hash)) {
+          return { el: to.hash }
         }
+        return false
       }
       // Preserve scroll when switching between search list pages (e.g. datasets ↔ indicators)
       if (to.meta.searchConfig && from.meta.searchConfig) {


### PR DESCRIPTION
Replaces the `useHashScroll` implementation introduced in #1257 with a better observer strategy:

**`useHashScroll.ts`:**
- Drops `ResizeObserver` + `containerSelector` approach → uses `MutationObserver` on `document.body` instead. This is more robust: ResizeObserver on a container only fires when that container resizes, but MutationObserver on the body catches any DOM insertion.
- Drops `nextTick` + `@vueuse/core` `useDebounceFn` → manual `setTimeout` debounce. The debounce now waits for mutations to settle rather than just debouncing scroll calls.
- Tracks `scrollHandledFor` (the hash string) instead of a boolean `scrollHandled`, so hash changes re-trigger correctly.
- Introduces a proper `cleanup()` helper that disconnects the observer and clears the timeout, called both on navigation changes (via `watchEffect`) and `onUnmounted`.

**`src/router/index.ts`**: 
- adds the guard that checks `document.querySelector(to.hash)` before returning `{ el: to.hash }` in `scrollBehavior`, falling back to false for async content so `useHashScroll` can take over (avoids warning in console).