### PR TITLE
fix(search): persist custom filters on reload

### DIFF
--- a/cypress/e2e/custom/ecospheres/datasets/list.cy.ts
+++ b/cypress/e2e/custom/ecospheres/datasets/list.cy.ts
@@ -1,4 +1,5 @@
 import type { DatasetV2 } from '@datagouv/components-next'
+import { datagouvResponseBuilder } from 'cypress/support/datagouv_mocks'
 import { datasetFactory } from 'cypress/support/factories/datasets_factory'
 import { createIndicator } from '../indicators/support'
 
@@ -87,6 +88,41 @@ describe('Datasets - List Page', () => {
     cy.contains('label', 'API').click()
     cy.url().should('include', '/dataservices')
     cy.url().should('not.include', 'org=')
+  })
+
+  it('should persist filtered results on page reload', () => {
+    const filteredDataset = datasetFactory.one({
+      overrides: { title: 'Filtered Dataset' }
+    })
+
+    // Filtered request returns immediately with data.
+    // Other datasets requests (initial unfiltered + indicators) return empty after a delay
+    // We're testing that initial unfiltered results (fired first, arriving last) do not overwrite filtered ones
+    cy.intercept('GET', /.*data\.gouv\.fr\/api\/\d\/datasets.*/, (req) => {
+      if (req.url.includes('tag=adresses')) {
+        req.reply({
+          statusCode: 200,
+          body: datagouvResponseBuilder([filteredDataset])
+        })
+      } else {
+        req.reply({
+          delay: 300,
+          statusCode: 200,
+          body: datagouvResponseBuilder([])
+        })
+      }
+    }).as('get_datasets_list')
+
+    // Visit with the custom filter already in the URL (simulates a page reload)
+    cy.visit('/datasets?inspire=adresses')
+
+    // Filtered results should appear once the filtered request completes
+    cy.get('.search-results').should('contain', 'Filtered Dataset')
+
+    // Wait beyond the stale response delay (300ms) so it has time to land.
+    cy.wait(400)
+
+    cy.get('.search-results').should('contain', 'Filtered Dataset')
   })
 
   it('should display indicator datasets with the Indicateur badge', () => {

--- a/cypress/support/datagouv_mocks.ts
+++ b/cypress/support/datagouv_mocks.ts
@@ -3,7 +3,7 @@ import type {
   DatasetV2WithFullObject
 } from '@datagouv/components-next'
 
-const datagouvResponseBuilder = (data: object[]) => {
+export const datagouvResponseBuilder = (data: object[]) => {
   return {
     data: data.slice(0, 20),
     next_page: null,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "type-check:cypress": "tsc --noEmit --project cypress/tsconfig.json"
   },
   "dependencies": {
-    "@datagouv/components-next": "1.0.2-dev.124",
+    "@datagouv/components-next": "1.0.2-dev.126",
     "@gouvfr/dsfr": "~1.14.4",
     "@gouvfr/dsfr-chart": "^2.0.4",
     "@gouvminint/vue-dsfr": "^8.15.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "type-check:cypress": "tsc --noEmit --project cypress/tsconfig.json"
   },
   "dependencies": {
-    "@datagouv/components-next": "1.2.0",
+    "@datagouv/components-next": "1.0.2-dev.124",
     "@gouvfr/dsfr": "~1.14.4",
     "@gouvfr/dsfr-chart": "^2.0.4",
     "@gouvminint/vue-dsfr": "^8.15.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "type-check:cypress": "tsc --noEmit --project cypress/tsconfig.json"
   },
   "dependencies": {
-    "@datagouv/components-next": "1.0.2-dev.126",
+    "@datagouv/components-next": "1.3.0",
     "@gouvfr/dsfr": "~1.14.4",
     "@gouvfr/dsfr-chart": "^2.0.4",
     "@gouvminint/vue-dsfr": "^8.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
   .:
     dependencies:
       '@datagouv/components-next':
-        specifier: 1.2.0
-        version: 1.2.0(core-js@3.47.0)(echarts@6.1.0)(resize-detector@0.3.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))
+        specifier: 1.0.2-dev.124
+        version: 1.0.2-dev.124(core-js@3.47.0)(echarts@6.1.0)(resize-detector@0.3.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))
       '@gouvfr/dsfr':
         specifier: ~1.14.4
         version: 1.14.4
@@ -24,7 +24,7 @@ importers:
         version: 7.0.6
       '@sentry/vite-plugin':
         specifier: ^4.6.1
-        version: 4.6.1
+        version: 4.6.1(supports-color@8.1.1)
       '@sentry/vue':
         specifier: ^10.27.0
         version: 10.27.0(pinia@2.3.1(typescript@5.7.3)(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))
@@ -45,7 +45,7 @@ importers:
         version: 12.8.2(axios@1.16.0)(focus-trap@7.8.0)(sortablejs@1.15.3)(typescript@5.7.3)
       axios:
         specifier: ^1.16.0
-        version: 1.16.0(debug@4.4.3)
+        version: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
@@ -91,7 +91,7 @@ importers:
     devDependencies:
       '@babel/eslint-parser':
         specifier: ^7.28.5
-        version: 7.28.5(@babel/core@7.28.5)(eslint@9.39.1)
+        version: 7.28.5(@babel/core@7.28.5)(eslint@9.39.1(supports-color@8.1.1))
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
@@ -118,10 +118,10 @@ importers:
         version: 5.2.4(vite@6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.30(typescript@5.7.3))
       '@vue/eslint-config-prettier':
         specifier: ^10.2.0
-        version: 10.2.0(eslint@9.39.1)(prettier@3.6.2)
+        version: 10.2.0(eslint@9.39.1(supports-color@8.1.1))(prettier@3.6.2)
       '@vue/eslint-config-typescript':
         specifier: ^14.6.0
-        version: 14.6.0(eslint-plugin-vue@9.33.0(eslint@9.39.1))(eslint@9.39.1)(typescript@5.7.3)
+        version: 14.6.0(eslint-plugin-vue@9.33.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)
       '@vue/tsconfig':
         specifier: ^0.7.0
         version: 0.7.0(typescript@5.7.3)(vue@3.5.30(typescript@5.7.3))
@@ -136,16 +136,16 @@ importers:
         version: 1.7.0(axe-core@4.11.0)(cypress@15.16.0)
       eslint:
         specifier: ^9.39.1
-        version: 9.39.1
+        version: 9.39.1(supports-color@8.1.1)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.1)
+        version: 10.1.8(eslint@9.39.1(supports-color@8.1.1))
       eslint-plugin-json:
         specifier: ^4.0.1
         version: 4.0.1
       eslint-plugin-vue:
         specifier: ^9.33.0
-        version: 9.33.0(eslint@9.39.1)
+        version: 9.33.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)
       happy-dom:
         specifier: ^20.8.9
         version: 20.8.9
@@ -157,7 +157,7 @@ importers:
         version: 4.2.0
       lint-staged:
         specifier: ^15.5.2
-        version: 15.5.2
+        version: 15.5.2(supports-color@8.1.1)
       mimicry-js:
         specifier: ^1.3.0
         version: 1.3.0
@@ -172,13 +172,13 @@ importers:
         version: 4.3.0(prettier@3.6.2)(typescript@5.7.3)(vue-tsc@2.2.12(typescript@5.7.3))
       start-server-and-test:
         specifier: ^2.1.3
-        version: 2.1.3
+        version: 2.1.3(supports-color@8.1.1)
       typescript:
         specifier: ~5.7.3
         version: 5.7.3
       typescript-eslint:
         specifier: ^8.48.0
-        version: 8.48.0(eslint@9.39.1)(typescript@5.7.3)
+        version: 8.48.0(eslint@9.39.1(supports-color@8.1.1))(typescript@5.7.3)
       unplugin-auto-import:
         specifier: ^19.3.0
         version: 19.3.0(@vueuse/core@12.8.2(typescript@5.7.3))
@@ -193,7 +193,7 @@ importers:
         version: 1.6.0
       vite-plugin-vue-devtools:
         specifier: ^7.7.9
-        version: 7.7.9(rollup@4.60.1)(vite@6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.30(typescript@5.7.3))
+        version: 7.7.9(rollup@4.60.1)(supports-color@8.1.1)(vite@6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.30(typescript@5.7.3))
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@22.19.1)(happy-dom@20.8.9)(vite@6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3))
@@ -483,10 +483,10 @@ packages:
         integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==
       }
 
-  '@datagouv/components-next@1.2.0':
+  '@datagouv/components-next@1.0.2-dev.124':
     resolution:
       {
-        integrity: sha512-oHmosjaNlQ9+8rUtQ8Zy0j+mCwNvi/TOB7p/htkTMllLOsuo2XUfIaouU49S0TsHxlYvGIfQSjrReEOwSTFAaw==
+        integrity: sha512-20PAzT1ccGEE/xaeosDaK9SSASiiRfQKZVHe7l2O38TJTRu+mdpMbKBxvvU51FEWqegsq47iEKF28R/ZevLSNA==
       }
     engines:
       {
@@ -1038,10 +1038,22 @@ packages:
         integrity: sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==
       }
 
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution:
+      {
+        integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==
+      }
+
   '@mapbox/unitbezier@0.0.1':
     resolution:
       {
         integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==
+      }
+
+  '@mapbox/unitbezier@1.0.0':
+    resolution:
+      {
+        integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==
       }
 
   '@mapbox/vector-tile@2.0.4':
@@ -1057,10 +1069,23 @@ packages:
       }
     engines: { node: '>=6.0.0' }
 
+  '@maplibre/geojson-vt@6.1.0':
+    resolution:
+      {
+        integrity: sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==
+      }
+
   '@maplibre/maplibre-gl-style-spec@23.3.0':
     resolution:
       {
         integrity: sha512-IGJtuBbaGzOUgODdBRg66p8stnwj9iDXkgbYKoYcNiiQmaez5WVRfXm4b03MCDwmZyX93csbfHFWEJJYHnn5oA==
+      }
+    hasBin: true
+
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    resolution:
+      {
+        integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==
       }
     hasBin: true
 
@@ -1077,10 +1102,22 @@ packages:
         integrity: sha512-anR8WxKIgZUJQLlZtID0v06wd9Q//9K/6lLLU3dOzmeO/xLEzAwmEqP24jEnEUBcnZGkM4vidz9H6Q4guNAAlw==
       }
 
+  '@maplibre/mlt@1.1.11':
+    resolution:
+      {
+        integrity: sha512-dKvjKdITw9d0y3ndGkSqLUEpWCizMtdq8NB06cHohH/JZ2sJoM7dClR9wzJLUWykjbw9RXDFmhjjNBnNW27mzw==
+      }
+
   '@maplibre/vt-pbf@4.0.3':
     resolution:
       {
         integrity: sha512-YsW99BwnT+ukJRkseBcLuZHfITB4puJoxnqPVjo72rhW/TaawVYsgQHcqWLzTxqknttYoDpgyERzWSa/XrETdA==
+      }
+
+  '@maplibre/vt-pbf@4.3.2':
+    resolution:
+      {
+        integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==
       }
 
   '@napi-rs/canvas-android-arm64@0.1.96':
@@ -1293,10 +1330,10 @@ packages:
         integrity: sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==
       }
 
-  '@remixicon/vue@4.7.0':
+  '@remixicon/vue@4.9.0':
     resolution:
       {
-        integrity: sha512-kwl1BIEnNoZ5IZ4NJZPOQmA2PfxKlOmogWcJBStuDynoyYpsYSvU22ZkerpdofgjsLS/FiLKhJ/ddpP8U8znVw==
+        integrity: sha512-4P0MY5ScL+MRLnHu1iT3xHAsliBwOGDIgSgHCZhSj2wkLa5NzqiQ4SGD/04VoHM+BRr8+xjmF7ZemkOUlMDJ3A==
       }
     peerDependencies:
       vue: '>= 3'
@@ -2442,6 +2479,12 @@ packages:
       }
     engines: { node: '>=14.6' }
 
+  '@zarrita/storage@0.2.0':
+    resolution:
+      {
+        integrity: sha512-855ZXqtnds7spnT8vNvD+MXa3QExP1m2GqShe8yt7uZXHnQLgJHgkpVwFjE1B0KDDRO0ki09hmk6OboTaIfPsQ==
+      }
+
   abbrev@2.0.0:
     resolution:
       {
@@ -3369,6 +3412,12 @@ packages:
         integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==
       }
 
+  dompurify@3.4.10:
+    resolution:
+      {
+        integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==
+      }
+
   domutils@2.8.0:
     resolution:
       {
@@ -4114,6 +4163,13 @@ packages:
     resolution:
       {
         integrity: sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==
+      }
+    engines: { node: '>=10.19' }
+
+  geotiff@3.0.5:
+    resolution:
+      {
+        integrity: sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==
       }
     engines: { node: '>=10.19' }
 
@@ -5208,6 +5264,13 @@ packages:
       }
     engines: { node: '>=16.14.0', npm: '>=8.1.0' }
 
+  maplibre-gl@5.24.0:
+    resolution:
+      {
+        integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==
+      }
+    engines: { node: '>=16.14.0', npm: '>=8.1.0' }
+
   markdown-table@2.0.0:
     resolution:
       {
@@ -5868,6 +5931,12 @@ packages:
         integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
       }
 
+  numcodecs@0.3.2:
+    resolution:
+      {
+        integrity: sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==
+      }
+
   object-inspect@1.13.4:
     resolution:
       {
@@ -5929,6 +5998,12 @@ packages:
     resolution:
       {
         integrity: sha512-122U5gamPqNgLpLOkogFJhgpywvd/5en2kETIDW+Ubfi9lPnZ0G9HWRdG+CX0oP8od2d6u6ky3eewIYYlrVczw==
+      }
+
+  ol@10.9.0:
+    resolution:
+      {
+        integrity: sha512-svbbgVQUmEHaKpLQ8kRySojs59Brvgl2zYIrqG9eQNXGfsbi55rQasZIDpwpQzDL6OlzrUb0H4hQaiX9wDoGmA==
       }
 
   once@1.4.0:
@@ -6113,6 +6188,13 @@ packages:
       }
     hasBin: true
 
+  pbf@5.1.0:
+    resolution:
+      {
+        integrity: sha512-Wv0yo0+uZepnoNEKsquhar1F18LogB8oeEikIhUXG16udbiXG7JecHGySwoo6kuMgjmbQYzdrTZlO+/K9t8eZg==
+      }
+    hasBin: true
+
   pdfjs-dist@4.10.38:
     resolution:
       {
@@ -6197,10 +6279,10 @@ packages:
         integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==
       }
 
-  pmtiles@4.3.0:
+  pmtiles@4.4.1:
     resolution:
       {
-        integrity: sha512-wnzQeSiYT/MyO63o7AVxwt7+uKqU0QUy2lHrivM7GvecNy0m1A4voVyGey7bujnEW5Hn+ZzLdvHPoFaqrOzbPA==
+        integrity: sha512-5oTeQc/yX/ft1evbpIlnoCZugQuug/iYIAj/ZTqIqzdGek4uZEho99En890EE6NOSI3JTI3IG8R7r8+SltphxA==
       }
 
   popmotion@11.0.5:
@@ -6454,6 +6536,12 @@ packages:
         integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
       }
     engines: { node: '>=8.10.0' }
+
+  reference-spec-reader@0.2.0:
+    resolution:
+      {
+        integrity: sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==
+      }
 
   regexp.prototype.flags@1.5.4:
     resolution:
@@ -7471,6 +7559,12 @@ packages:
         integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==
       }
 
+  unist-util-visit@5.1.0:
+    resolution:
+      {
+        integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==
+      }
+
   universalify@2.0.1:
     resolution:
       {
@@ -7554,6 +7648,13 @@ packages:
         integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
       }
     engines: { node: '>=8' }
+
+  unzipit@2.0.0:
+    resolution:
+      {
+        integrity: sha512-DVeVIWUZCAQPNzm5sB0hpsG1GygTTdBnzNtYYEpInkttx5evkyqRgZi6rTczoySqp8hO5jHVKzrH0f23X8FZLg==
+      }
+    engines: { node: '>=18' }
 
   update-browserslist-db@1.1.4:
     resolution:
@@ -8113,6 +8214,14 @@ packages:
     engines: { node: '>= 14.6' }
     hasBin: true
 
+  yaml@2.9.0:
+    resolution:
+      {
+        integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
+      }
+    engines: { node: '>= 14.6' }
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution:
       {
@@ -8148,6 +8257,12 @@ packages:
       }
     engines: { node: '>=18' }
 
+  zarrita@0.7.3:
+    resolution:
+      {
+        integrity: sha512-wChTQ1Ox75INoQCzKAfLWAfB70JJ4KjdW8Sz5x4ZWrFB4Dw+YZdnxHTL0xSdsrB9EmKSeK7fS1Y+I2ibhfGbkw==
+      }
+
   zrender@6.1.0:
     resolution:
       {
@@ -8158,6 +8273,12 @@ packages:
     resolution:
       {
         integrity: sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==
+      }
+
+  zstddec@0.2.0:
+    resolution:
+      {
+        integrity: sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==
       }
 
   zwitch@1.0.5:
@@ -8190,10 +8311,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
       '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.0
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -8203,18 +8324,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.28.5(@babel/core@7.28.5)(eslint@9.39.1)':
+  '@babel/eslint-parser@7.28.5(@babel/core@7.28.5)(eslint@9.39.1(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.28.5
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.39.1
+      eslint: 9.39.1(supports-color@8.1.1)
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
   '@babel/generator@7.28.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -8256,7 +8377,7 @@ snapshots:
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8300,7 +8421,7 @@ snapshots:
   '@babel/helpers@7.28.4':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.28.5':
     dependencies:
@@ -8360,17 +8481,17 @@ snapshots:
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
 
   '@babel/traverse@7.28.5':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.0
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -8412,25 +8533,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@datagouv/components-next@1.2.0(core-js@3.47.0)(echarts@6.1.0)(resize-detector@0.3.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))':
+  '@datagouv/components-next@1.0.2-dev.124(core-js@3.47.0)(echarts@6.1.0)(resize-detector@0.3.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))':
     dependencies:
       '@floating-ui/vue': 1.1.11(vue@3.5.30(typescript@5.7.3))
       '@headlessui/vue': 1.7.23(vue@3.5.30(typescript@5.7.3))
-      '@remixicon/vue': 4.7.0(vue@3.5.30(typescript@5.7.3))
+      '@remixicon/vue': 4.9.0(vue@3.5.30(typescript@5.7.3))
       '@types/hast': 3.0.4
       '@types/leaflet': 1.9.21
       '@vueuse/core': 14.3.0(vue@3.5.30(typescript@5.7.3))
       '@vueuse/router': 14.3.0(vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))
       chart.js: 4.5.1
-      dompurify: 3.4.0
+      dompurify: 3.4.10
       echarts: 6.1.0
       geopf-extensions-openlayers: 1.0.0-beta.11
       leaflet: 1.9.4
-      maplibre-gl: 5.13.0
+      maplibre-gl: 5.24.0
       ofetch: 1.5.1
-      ol: 10.7.0
+      ol: 10.9.0
       pdfjs-dist: 4.10.38
-      pmtiles: 4.3.0
+      pmtiles: 4.4.1
       popmotion: 11.0.5
       rehype-highlight: 7.0.2
       rehype-raw: 7.0.0
@@ -8445,7 +8566,7 @@ snapshots:
       strip-markdown: 6.0.0
       stylefire: 7.0.3
       unified: 11.0.5
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vue: 3.5.30(typescript@5.7.3)
       vue-content-loader: 2.0.1(vue@3.5.30(typescript@5.7.3))
       vue-router: 4.6.4(vue@3.5.30(typescript@5.7.3))
@@ -8453,7 +8574,7 @@ snapshots:
       vue3-json-viewer: 2.4.1(vue@3.5.30(typescript@5.7.3))
       vue3-text-clamp: 0.1.2(resize-detector@0.3.0)(vue@3.5.30(typescript@5.7.3))
       vue3-xml-viewer: 0.0.14(core-js@3.47.0)(vue@3.5.30(typescript@5.7.3))
-      yaml: 2.8.3
+      yaml: 2.9.0
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@nuxt/schema'
@@ -8544,12 +8665,12 @@ snapshots:
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1)':
     dependencies:
-      eslint: 9.39.1
+      eslint: 9.39.1(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.1':
+  '@eslint/config-array@0.21.1(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@8.1.1)
@@ -8565,7 +8686,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.1':
+  '@eslint/eslintrc@3.3.1(supports-color@8.1.1)':
     dependencies:
       ajv: 6.14.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -8728,7 +8849,11 @@ snapshots:
 
   '@mapbox/tiny-sdf@2.0.7': {}
 
+  '@mapbox/tiny-sdf@2.2.0': {}
+
   '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/unitbezier@1.0.0': {}
 
   '@mapbox/vector-tile@2.0.4':
     dependencies:
@@ -8738,6 +8863,10 @@ snapshots:
 
   '@mapbox/whoots-js@3.1.0': {}
 
+  '@maplibre/geojson-vt@6.1.0':
+    dependencies:
+      kdbush: 4.0.2
+
   '@maplibre/maplibre-gl-style-spec@23.3.0':
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.2
@@ -8746,6 +8875,15 @@ snapshots:
       minimist: 1.2.8
       quickselect: 3.0.0
       rw: 1.3.3
+      tinyqueue: 3.0.0
+
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 1.0.0
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
       tinyqueue: 3.0.0
 
   '@maplibre/maplibre-gl-style-spec@24.3.1':
@@ -8762,6 +8900,10 @@ snapshots:
     dependencies:
       '@mapbox/point-geometry': 1.1.0
 
+  '@maplibre/mlt@1.1.11':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
   '@maplibre/vt-pbf@4.0.3':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
@@ -8771,6 +8913,12 @@ snapshots:
       geojson-vt: 4.0.2
       pbf: 4.0.1
       supercluster: 8.0.1
+
+  '@maplibre/vt-pbf@4.3.2':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 5.1.0
 
   '@napi-rs/canvas-android-arm64@0.1.96':
     optional: true
@@ -8874,7 +9022,7 @@ snapshots:
       style-value-types: 3.2.0
       tslib: 1.14.1
 
-  '@remixicon/vue@4.7.0(vue@3.5.30(typescript@5.7.3))':
+  '@remixicon/vue@4.9.0(vue@3.5.30(typescript@5.7.3))':
     dependencies:
       vue: 3.5.30(typescript@5.7.3)
 
@@ -8996,11 +9144,11 @@ snapshots:
       '@sentry-internal/replay-canvas': 10.27.0
       '@sentry/core': 10.27.0
 
-  '@sentry/bundler-plugin-core@4.6.1':
+  '@sentry/bundler-plugin-core@4.6.1(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.28.5
       '@sentry/babel-plugin-component-annotate': 4.6.1
-      '@sentry/cli': 2.58.2
+      '@sentry/cli': 2.58.2(supports-color@8.1.1)
       dotenv: 16.6.1
       find-up: 5.0.0
       glob: 10.5.0
@@ -9034,9 +9182,9 @@ snapshots:
   '@sentry/cli-win32-x64@2.58.2':
     optional: true
 
-  '@sentry/cli@2.58.2':
+  '@sentry/cli@2.58.2(supports-color@8.1.1)':
     dependencies:
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       node-fetch: 2.7.0
       progress: 2.0.3
       proxy-from-env: 1.1.0
@@ -9056,9 +9204,9 @@ snapshots:
 
   '@sentry/core@10.27.0': {}
 
-  '@sentry/vite-plugin@4.6.1':
+  '@sentry/vite-plugin@4.6.1(supports-color@8.1.1)':
     dependencies:
-      '@sentry/bundler-plugin-core': 4.6.1
+      '@sentry/bundler-plugin-core': 4.6.1(supports-color@8.1.1)
       unplugin: 1.0.1
     transitivePeerDependencies:
       - encoding
@@ -9214,15 +9362,15 @@ snapshots:
     dependencies:
       '@types/node': 22.19.1
 
-  '@typescript-eslint/eslint-plugin@8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1)(typescript@5.7.3))(eslint@9.39.1)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint@9.39.1(supports-color@8.1.1))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.48.0(eslint@9.39.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.48.0
-      '@typescript-eslint/type-utils': 8.48.0(eslint@9.39.1)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.48.0(eslint@9.39.1(supports-color@8.1.1))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1(supports-color@8.1.1))(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.48.0
-      eslint: 9.39.1
+      eslint: 9.39.1(supports-color@8.1.1)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -9231,14 +9379,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.48.0(eslint@9.39.1)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.48.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.48.0
       '@typescript-eslint/types': 8.48.0
       '@typescript-eslint/typescript-estree': 8.48.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.48.0
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.1
+      eslint: 9.39.1(supports-color@8.1.1)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -9261,13 +9409,13 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  '@typescript-eslint/type-utils@8.48.0(eslint@9.39.1)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.48.0(eslint@9.39.1(supports-color@8.1.1))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/types': 8.48.0
       '@typescript-eslint/typescript-estree': 8.48.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1(supports-color@8.1.1))(typescript@5.7.3)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.1
+      eslint: 9.39.1(supports-color@8.1.1)
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -9290,13 +9438,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.48.0(eslint@9.39.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.48.0(eslint@9.39.1(supports-color@8.1.1))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1)
       '@typescript-eslint/scope-manager': 8.48.0
       '@typescript-eslint/types': 8.48.0
       '@typescript-eslint/typescript-estree': 8.48.0(typescript@5.7.3)
-      eslint: 9.39.1
+      eslint: 9.39.1(supports-color@8.1.1)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -9494,23 +9642,23 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/eslint-config-prettier@10.2.0(eslint@9.39.1)(prettier@3.6.2)':
+  '@vue/eslint-config-prettier@10.2.0(eslint@9.39.1(supports-color@8.1.1))(prettier@3.6.2)':
     dependencies:
-      eslint: 9.39.1
-      eslint-config-prettier: 10.1.8(eslint@9.39.1)
-      eslint-plugin-prettier: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1))(eslint@9.39.1)(prettier@3.6.2)
+      eslint: 9.39.1(supports-color@8.1.1)
+      eslint-config-prettier: 10.1.8(eslint@9.39.1(supports-color@8.1.1))
+      eslint-plugin-prettier: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1(supports-color@8.1.1)))(eslint@9.39.1(supports-color@8.1.1))(prettier@3.6.2)
       prettier: 3.6.2
     transitivePeerDependencies:
       - '@types/eslint'
 
-  '@vue/eslint-config-typescript@14.6.0(eslint-plugin-vue@9.33.0(eslint@9.39.1))(eslint@9.39.1)(typescript@5.7.3)':
+  '@vue/eslint-config-typescript@14.6.0(eslint-plugin-vue@9.33.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1)(typescript@5.7.3)
-      eslint: 9.39.1
-      eslint-plugin-vue: 9.33.0(eslint@9.39.1)
+      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1(supports-color@8.1.1))(typescript@5.7.3)
+      eslint: 9.39.1(supports-color@8.1.1)
+      eslint-plugin-vue: 9.33.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)
       fast-glob: 3.3.3
-      typescript-eslint: 8.48.0(eslint@9.39.1)(typescript@5.7.3)
-      vue-eslint-parser: 10.2.0(eslint@9.39.1)
+      typescript-eslint: 8.48.0(eslint@9.39.1(supports-color@8.1.1))(typescript@5.7.3)
+      vue-eslint-parser: 10.2.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -9591,7 +9739,7 @@ snapshots:
       '@vueuse/shared': 12.8.2(typescript@5.7.3)
       vue: 3.5.30(typescript@5.7.3)
     optionalDependencies:
-      axios: 1.16.0(debug@4.4.3)
+      axios: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       focus-trap: 7.8.0
       sortablejs: 1.15.3
     transitivePeerDependencies:
@@ -9619,6 +9767,11 @@ snapshots:
 
   '@xmldom/xmldom@0.9.10': {}
 
+  '@zarrita/storage@0.2.0':
+    dependencies:
+      reference-spec-reader: 0.2.0
+      unzipit: 2.0.0
+
   abbrev@2.0.0: {}
 
   acorn-jsx@5.3.2(acorn@8.15.0):
@@ -9627,7 +9780,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -9720,13 +9873,13 @@ snapshots:
 
   axios-mock-adapter@2.1.0(axios@1.16.0):
     dependencies:
-      axios: 1.16.0(debug@4.4.3)
+      axios: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       fast-deep-equal: 3.1.3
       is-buffer: 2.0.5
 
-  axios@1.16.0(debug@4.4.3):
+  axios@1.16.0(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -10140,6 +10293,10 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  dompurify@3.4.10:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   domutils@2.8.0:
     dependencies:
       dom-serializer: 1.4.1
@@ -10282,34 +10439,34 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.39.1):
+  eslint-config-prettier@10.1.8(eslint@9.39.1(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.1
+      eslint: 9.39.1(supports-color@8.1.1)
 
   eslint-plugin-json@4.0.1:
     dependencies:
       lodash: 4.18.1
       vscode-json-languageservice: 4.2.1
 
-  eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1))(eslint@9.39.1)(prettier@3.6.2):
+  eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1(supports-color@8.1.1)))(eslint@9.39.1(supports-color@8.1.1))(prettier@3.6.2):
     dependencies:
-      eslint: 9.39.1
+      eslint: 9.39.1(supports-color@8.1.1)
       prettier: 3.6.2
       prettier-linter-helpers: 1.0.0
       synckit: 0.11.11
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@9.39.1)
+      eslint-config-prettier: 10.1.8(eslint@9.39.1(supports-color@8.1.1))
 
-  eslint-plugin-vue@9.33.0(eslint@9.39.1):
+  eslint-plugin-vue@9.33.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1)
-      eslint: 9.39.1
+      eslint: 9.39.1(supports-color@8.1.1)
       globals: 13.24.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
       semver: 7.7.3
-      vue-eslint-parser: 9.4.3(eslint@9.39.1)
+      vue-eslint-parser: 9.4.3(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -10335,14 +10492,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.1:
+  eslint@9.39.1(supports-color@8.1.1):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1
+      '@eslint/config-array': 0.21.1(supports-color@8.1.1)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.1
+      '@eslint/eslintrc': 3.3.1(supports-color@8.1.1)
       '@eslint/js': 9.39.1
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
@@ -10554,7 +10711,7 @@ snapshots:
     dependencies:
       tabbable: 6.4.0
 
-  follow-redirects@1.16.0(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
@@ -10663,6 +10820,17 @@ snapshots:
       web-worker: 1.5.0
       xml-utils: 1.10.2
       zstddec: 0.1.0
+
+  geotiff@3.0.5:
+    dependencies:
+      '@petamoriken/float16': 3.9.3
+      lerc: 3.0.0
+      pako: 2.1.0
+      parse-headers: 2.0.6
+      quick-lru: 6.1.2
+      web-worker: 1.5.0
+      xml-utils: 1.10.2
+      zstddec: 0.2.0
 
   get-caller-file@2.0.5: {}
 
@@ -10910,9 +11078,9 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -11185,7 +11353,7 @@ snapshots:
 
   lilconfig@3.1.3: {}
 
-  lint-staged@15.5.2:
+  lint-staged@15.5.2(supports-color@8.1.1):
     dependencies:
       chalk: 5.6.2
       commander: 13.1.0
@@ -11311,6 +11479,28 @@ snapshots:
       potpack: 2.1.0
       quickselect: 3.0.0
       supercluster: 8.0.1
+      tinyqueue: 3.0.0
+
+  maplibre-gl@5.24.0:
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.4
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 6.1.0
+      '@maplibre/maplibre-gl-style-spec': 24.10.0
+      '@maplibre/mlt': 1.1.11
+      '@maplibre/vt-pbf': 4.3.2
+      '@types/geojson': 7946.0.16
+      earcut: 3.0.2
+      gl-matrix: 3.4.4
+      kdbush: 4.0.2
+      murmurhash-js: 1.0.0
+      pbf: 4.0.1
+      potpack: 2.1.0
+      quickselect: 3.0.0
       tinyqueue: 3.0.0
 
   markdown-table@2.0.0:
@@ -11874,6 +12064,10 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  numcodecs@0.3.2:
+    dependencies:
+      fflate: 0.8.2
+
   object-inspect@1.13.4: {}
 
   object-is@1.1.6:
@@ -11918,6 +12112,15 @@ snapshots:
       geotiff: 2.1.3
       pbf: 4.0.1
       rbush: 4.0.1
+
+  ol@10.9.0:
+    dependencies:
+      '@types/rbush': 4.0.0
+      earcut: 3.0.2
+      geotiff: 3.0.5
+      pbf: 4.0.1
+      rbush: 4.0.1
+      zarrita: 0.7.3
 
   once@1.4.0:
     dependencies:
@@ -12023,6 +12226,10 @@ snapshots:
     dependencies:
       resolve-protobuf-schema: 2.1.0
 
+  pbf@5.1.0:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   pdfjs-dist@4.10.38:
     optionalDependencies:
       '@napi-rs/canvas': 0.1.96
@@ -12065,7 +12272,7 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  pmtiles@4.3.0:
+  pmtiles@4.4.1:
     dependencies:
       fflate: 0.8.2
 
@@ -12192,6 +12399,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
+
+  reference-spec-reader@0.2.0: {}
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -12510,7 +12719,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  start-server-and-test@2.1.3:
+  start-server-and-test@2.1.3(supports-color@8.1.1):
     dependencies:
       arg: 5.0.2
       bluebird: 3.7.2
@@ -12519,7 +12728,7 @@ snapshots:
       execa: 5.1.1
       lazy-ass: 1.6.0
       ps-tree: 1.2.0
-      wait-on: 9.0.3(debug@4.4.3)
+      wait-on: 9.0.3(debug@4.4.3(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -12740,13 +12949,13 @@ snapshots:
 
   type-fest@0.8.1: {}
 
-  typescript-eslint@8.48.0(eslint@9.39.1)(typescript@5.7.3):
+  typescript-eslint@8.48.0(eslint@9.39.1(supports-color@8.1.1))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1)(typescript@5.7.3))(eslint@9.39.1)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.48.0(eslint@9.39.1)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3))(eslint@9.39.1(supports-color@8.1.1))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.7.3)
       '@typescript-eslint/typescript-estree': 8.48.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1)(typescript@5.7.3)
-      eslint: 9.39.1
+      '@typescript-eslint/utils': 8.48.0(eslint@9.39.1(supports-color@8.1.1))(typescript@5.7.3)
+      eslint: 9.39.1(supports-color@8.1.1)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -12880,6 +13089,12 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@2.0.1: {}
 
   unplugin-auto-import@19.3.0(@vueuse/core@12.8.2(typescript@5.7.3)):
@@ -12923,6 +13138,8 @@ snapshots:
       webpack-virtual-modules: 0.6.2
 
   untildify@4.0.0: {}
+
+  unzipit@2.0.0: {}
 
   update-browserslist-db@1.1.4(browserslist@4.28.0):
     dependencies:
@@ -12996,7 +13213,7 @@ snapshots:
       pathe: 0.2.0
       vite: 6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3)
 
-  vite-plugin-inspect@0.8.9(rollup@4.60.1)(vite@6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3)):
+  vite-plugin-inspect@0.8.9(rollup@4.60.1)(supports-color@8.1.1)(vite@6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
@@ -13012,7 +13229,7 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-vue-devtools@7.7.9(rollup@4.60.1)(vite@6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.30(typescript@5.7.3)):
+  vite-plugin-vue-devtools@7.7.9(rollup@4.60.1)(supports-color@8.1.1)(vite@6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.30(typescript@5.7.3)):
     dependencies:
       '@vue/devtools-core': 7.7.9(vite@6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3))(vue@3.5.30(typescript@5.7.3))
       '@vue/devtools-kit': 7.7.9
@@ -13020,7 +13237,7 @@ snapshots:
       execa: 9.6.0
       sirv: 3.0.2
       vite: 6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3)
-      vite-plugin-inspect: 0.8.9(rollup@4.60.1)(vite@6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3))
+      vite-plugin-inspect: 0.8.9(rollup@4.60.1)(supports-color@8.1.1)(vite@6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3))
       vite-plugin-vue-inspector: 5.3.2(vite@6.4.2(@types/node@22.19.1)(terser@5.44.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -13111,10 +13328,10 @@ snapshots:
     dependencies:
       vue: 3.5.30(typescript@5.7.3)
 
-  vue-eslint-parser@10.2.0(eslint@9.39.1):
+  vue-eslint-parser@10.2.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.1
+      eslint: 9.39.1(supports-color@8.1.1)
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -13123,10 +13340,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-eslint-parser@9.4.3(eslint@9.39.1):
+  vue-eslint-parser@9.4.3(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.1
+      eslint: 9.39.1(supports-color@8.1.1)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
@@ -13180,9 +13397,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.7.3
 
-  wait-on@9.0.3(debug@4.4.3):
+  wait-on@9.0.3(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
-      axios: 1.16.0(debug@4.4.3)
+      axios: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       joi: 18.0.2
       lodash: 4.18.1
       minimist: 1.2.8
@@ -13292,6 +13509,8 @@ snapshots:
 
   yaml@2.8.3: {}
 
+  yaml@2.9.0: {}
+
   yargs-parser@21.1.1: {}
 
   yargs@17.7.2:
@@ -13312,11 +13531,18 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
+  zarrita@0.7.3:
+    dependencies:
+      '@zarrita/storage': 0.2.0
+      numcodecs: 0.3.2
+
   zrender@6.1.0:
     dependencies:
       tslib: 2.3.0
 
   zstddec@0.1.0: {}
+
+  zstddec@0.2.0: {}
 
   zwitch@1.0.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
     dependencies:
       '@datagouv/components-next':
         specifier: 1.0.2-dev.124
-        version: 1.0.2-dev.124(core-js@3.47.0)(echarts@6.1.0)(resize-detector@0.3.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))
+        version: 1.0.2-dev.124(core-js@3.47.0)(echarts@6.1.0)(resize-detector@0.3.0)(supports-color@8.1.1)(vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))
       '@gouvfr/dsfr':
         specifier: ~1.14.4
         version: 1.14.4
@@ -8533,7 +8533,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@datagouv/components-next@1.0.2-dev.124(core-js@3.47.0)(echarts@6.1.0)(resize-detector@0.3.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))':
+  '@datagouv/components-next@1.0.2-dev.124(core-js@3.47.0)(echarts@6.1.0)(resize-detector@0.3.0)(supports-color@8.1.1)(vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))':
     dependencies:
       '@floating-ui/vue': 1.1.11(vue@3.5.30(typescript@5.7.3))
       '@headlessui/vue': 1.7.23(vue@3.5.30(typescript@5.7.3))
@@ -8545,7 +8545,7 @@ snapshots:
       chart.js: 4.5.1
       dompurify: 3.4.10
       echarts: 6.1.0
-      geopf-extensions-openlayers: 1.0.0-beta.11
+      geopf-extensions-openlayers: 1.0.0-beta.11(supports-color@8.1.1)
       leaflet: 1.9.4
       maplibre-gl: 5.24.0
       ofetch: 1.5.1
@@ -8663,7 +8663,7 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1)':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1(supports-color@8.1.1))':
     dependencies:
       eslint: 9.39.1(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
@@ -9255,11 +9255,11 @@ snapshots:
 
   '@textlint/ast-node-types@15.7.1': {}
 
-  '@textlint/markdown-to-ast@15.7.1':
+  '@textlint/markdown-to-ast@15.7.1(supports-color@8.1.1)':
     dependencies:
       '@textlint/ast-node-types': 15.7.1
       debug: 4.4.3(supports-color@8.1.1)
-      mdast-util-gfm-autolink-literal: 0.1.3
+      mdast-util-gfm-autolink-literal: 0.1.3(supports-color@8.1.1)
       neotraverse: 0.6.18
       remark-footnotes: 3.0.0
       remark-frontmatter: 3.0.0
@@ -9440,7 +9440,7 @@ snapshots:
 
   '@typescript-eslint/utils@8.48.0(eslint@9.39.1(supports-color@8.1.1))(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.48.0
       '@typescript-eslint/types': 8.48.0
       '@typescript-eslint/typescript-estree': 8.48.0(typescript@5.7.3)
@@ -10265,9 +10265,9 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  doctoc@2.4.1:
+  doctoc@2.4.1(supports-color@8.1.1):
     dependencies:
-      '@textlint/markdown-to-ast': 15.7.1
+      '@textlint/markdown-to-ast': 15.7.1(supports-color@8.1.1)
       anchor-markdown-header: 0.8.4
       htmlparser2: 7.2.0
       loglevel: 1.9.2
@@ -10459,7 +10459,7 @@ snapshots:
 
   eslint-plugin-vue@9.33.0(eslint@9.39.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(supports-color@8.1.1))
       eslint: 9.39.1(supports-color@8.1.1)
       globals: 13.24.0
       natural-compare: 1.4.0
@@ -10494,7 +10494,7 @@ snapshots:
 
   eslint@9.39.1(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1(supports-color@8.1.1)
       '@eslint/config-helpers': 0.4.2
@@ -10776,7 +10776,7 @@ snapshots:
 
   geojson-vt@4.0.2: {}
 
-  geopf-extensions-openlayers@1.0.0-beta.11:
+  geopf-extensions-openlayers@1.0.0-beta.11(supports-color@8.1.1):
     dependencies:
       '@gouvfr/dsfr': 1.14.4
       '@mapbox/mapbox-gl-style-spec': 14.8.0
@@ -10784,7 +10784,7 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       clusterize.js: 1.0.0
-      doctoc: 2.4.1
+      doctoc: 2.4.1(supports-color@8.1.1)
       dompurify: 3.4.0
       eventbusjs: 0.2.0
       geoportal-access-lib: 3.4.6
@@ -11536,7 +11536,7 @@ snapshots:
   mdast-util-footnote@0.1.7:
     dependencies:
       mdast-util-to-markdown: 0.6.5
-      micromark: 2.11.4
+      micromark: 2.11.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11544,7 +11544,7 @@ snapshots:
     dependencies:
       '@types/mdast': 3.0.15
       mdast-util-to-string: 2.0.0
-      micromark: 2.11.4
+      micromark: 2.11.4(supports-color@8.1.1)
       parse-entities: 2.0.0
       unist-util-stringify-position: 2.0.3
     transitivePeerDependencies:
@@ -11571,11 +11571,11 @@ snapshots:
     dependencies:
       micromark-extension-frontmatter: 0.2.2
 
-  mdast-util-gfm-autolink-literal@0.1.3:
+  mdast-util-gfm-autolink-literal@0.1.3(supports-color@8.1.1):
     dependencies:
       ccount: 1.1.0
       mdast-util-find-and-replace: 1.1.1
-      micromark: 2.11.4
+      micromark: 2.11.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11639,7 +11639,7 @@ snapshots:
 
   mdast-util-gfm@0.1.2:
     dependencies:
-      mdast-util-gfm-autolink-literal: 0.1.3
+      mdast-util-gfm-autolink-literal: 0.1.3(supports-color@8.1.1)
       mdast-util-gfm-strikethrough: 0.2.3
       mdast-util-gfm-table: 0.1.6
       mdast-util-gfm-task-list-item: 0.1.6
@@ -11735,7 +11735,7 @@ snapshots:
 
   micromark-extension-footnote@0.3.2:
     dependencies:
-      micromark: 2.11.4
+      micromark: 2.11.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11745,7 +11745,7 @@ snapshots:
 
   micromark-extension-gfm-autolink-literal@0.5.7:
     dependencies:
-      micromark: 2.11.4
+      micromark: 2.11.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11769,7 +11769,7 @@ snapshots:
 
   micromark-extension-gfm-strikethrough@0.6.5:
     dependencies:
-      micromark: 2.11.4
+      micromark: 2.11.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11784,7 +11784,7 @@ snapshots:
 
   micromark-extension-gfm-table@0.4.3:
     dependencies:
-      micromark: 2.11.4
+      micromark: 2.11.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11804,7 +11804,7 @@ snapshots:
 
   micromark-extension-gfm-task-list-item@0.3.3:
     dependencies:
-      micromark: 2.11.4
+      micromark: 2.11.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11818,7 +11818,7 @@ snapshots:
 
   micromark-extension-gfm@0.3.3:
     dependencies:
-      micromark: 2.11.4
+      micromark: 2.11.4(supports-color@8.1.1)
       micromark-extension-gfm-autolink-literal: 0.5.7
       micromark-extension-gfm-strikethrough: 0.6.5
       micromark-extension-gfm-table: 0.4.3
@@ -11930,7 +11930,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@2.11.4:
+  micromark@2.11.4(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       parse-entities: 2.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
   .:
     dependencies:
       '@datagouv/components-next':
-        specifier: 1.0.2-dev.124
-        version: 1.0.2-dev.124(core-js@3.47.0)(echarts@6.1.0)(resize-detector@0.3.0)(supports-color@8.1.1)(vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))
+        specifier: 1.0.2-dev.126
+        version: 1.0.2-dev.126(core-js@3.47.0)(echarts@6.1.0)(resize-detector@0.3.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))
       '@gouvfr/dsfr':
         specifier: ~1.14.4
         version: 1.14.4
@@ -483,10 +483,10 @@ packages:
         integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==
       }
 
-  '@datagouv/components-next@1.0.2-dev.124':
+  '@datagouv/components-next@1.0.2-dev.126':
     resolution:
       {
-        integrity: sha512-20PAzT1ccGEE/xaeosDaK9SSASiiRfQKZVHe7l2O38TJTRu+mdpMbKBxvvU51FEWqegsq47iEKF28R/ZevLSNA==
+        integrity: sha512-vBmQ32ICzDuEax+2eN0xLOi77BwlUvkrY2xxFCxahJ8qFbFABIhtMPlxgi9FHV3mngwySUb5r1g+aurDMhyXjA==
       }
     engines:
       {
@@ -4159,13 +4159,6 @@ packages:
       }
     engines: { node: '>=20' }
 
-  geotiff@2.1.3:
-    resolution:
-      {
-        integrity: sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==
-      }
-    engines: { node: '>=10.19' }
-
   geotiff@3.0.5:
     resolution:
       {
@@ -5994,12 +5987,6 @@ packages:
     peerDependencies:
       ol: '*'
 
-  ol@10.7.0:
-    resolution:
-      {
-        integrity: sha512-122U5gamPqNgLpLOkogFJhgpywvd/5en2kETIDW+Ubfi9lPnZ0G9HWRdG+CX0oP8od2d6u6ky3eewIYYlrVczw==
-      }
-
   ol@10.9.0:
     resolution:
       {
@@ -7553,12 +7540,6 @@ packages:
         integrity: sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==
       }
 
-  unist-util-visit@5.0.0:
-    resolution:
-      {
-        integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==
-      }
-
   unist-util-visit@5.1.0:
     resolution:
       {
@@ -8269,12 +8250,6 @@ packages:
         integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==
       }
 
-  zstddec@0.1.0:
-    resolution:
-      {
-        integrity: sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==
-      }
-
   zstddec@0.2.0:
     resolution:
       {
@@ -8533,7 +8508,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@datagouv/components-next@1.0.2-dev.124(core-js@3.47.0)(echarts@6.1.0)(resize-detector@0.3.0)(supports-color@8.1.1)(vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))':
+  '@datagouv/components-next@1.0.2-dev.126(core-js@3.47.0)(echarts@6.1.0)(resize-detector@0.3.0)(vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)))(vue@3.5.30(typescript@5.7.3))':
     dependencies:
       '@floating-ui/vue': 1.1.11(vue@3.5.30(typescript@5.7.3))
       '@headlessui/vue': 1.7.23(vue@3.5.30(typescript@5.7.3))
@@ -8545,7 +8520,7 @@ snapshots:
       chart.js: 4.5.1
       dompurify: 3.4.10
       echarts: 6.1.0
-      geopf-extensions-openlayers: 1.0.0-beta.11(supports-color@8.1.1)
+      geopf-extensions-openlayers: 1.0.0-beta.11
       leaflet: 1.9.4
       maplibre-gl: 5.24.0
       ofetch: 1.5.1
@@ -9255,11 +9230,11 @@ snapshots:
 
   '@textlint/ast-node-types@15.7.1': {}
 
-  '@textlint/markdown-to-ast@15.7.1(supports-color@8.1.1)':
+  '@textlint/markdown-to-ast@15.7.1':
     dependencies:
       '@textlint/ast-node-types': 15.7.1
       debug: 4.4.3(supports-color@8.1.1)
-      mdast-util-gfm-autolink-literal: 0.1.3(supports-color@8.1.1)
+      mdast-util-gfm-autolink-literal: 0.1.3
       neotraverse: 0.6.18
       remark-footnotes: 3.0.0
       remark-frontmatter: 3.0.0
@@ -10265,9 +10240,9 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  doctoc@2.4.1(supports-color@8.1.1):
+  doctoc@2.4.1:
     dependencies:
-      '@textlint/markdown-to-ast': 15.7.1(supports-color@8.1.1)
+      '@textlint/markdown-to-ast': 15.7.1
       anchor-markdown-header: 0.8.4
       htmlparser2: 7.2.0
       loglevel: 1.9.2
@@ -10776,7 +10751,7 @@ snapshots:
 
   geojson-vt@4.0.2: {}
 
-  geopf-extensions-openlayers@1.0.0-beta.11(supports-color@8.1.1):
+  geopf-extensions-openlayers@1.0.0-beta.11:
     dependencies:
       '@gouvfr/dsfr': 1.14.4
       '@mapbox/mapbox-gl-style-spec': 14.8.0
@@ -10784,15 +10759,15 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       clusterize.js: 1.0.0
-      doctoc: 2.4.1(supports-color@8.1.1)
-      dompurify: 3.4.0
+      doctoc: 2.4.1
+      dompurify: 3.4.10
       eventbusjs: 0.2.0
       geoportal-access-lib: 3.4.6
       loglevel: 1.9.2
       marked: 16.4.2
-      ol: 10.7.0
-      ol-contextmenu: 5.5.0(ol@10.7.0)
-      ol-mapbox-style: 12.6.1(ol@10.7.0)
+      ol: 10.9.0
+      ol-contextmenu: 5.5.0(ol@10.9.0)
+      ol-mapbox-style: 12.6.1(ol@10.9.0)
       proj4: 2.15.0
       sortablejs: 1.15.3
       typescript: 5.7.3
@@ -10809,17 +10784,6 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
-
-  geotiff@2.1.3:
-    dependencies:
-      '@petamoriken/float16': 3.9.3
-      lerc: 3.0.0
-      pako: 2.1.0
-      parse-headers: 2.0.6
-      quick-lru: 6.1.2
-      web-worker: 1.5.0
-      xml-utils: 1.10.2
-      zstddec: 0.1.0
 
   geotiff@3.0.5:
     dependencies:
@@ -10983,7 +10947,7 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       parse5: 7.3.0
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
       web-namespaces: 2.0.1
       zwitch: 2.0.4
@@ -11536,7 +11500,7 @@ snapshots:
   mdast-util-footnote@0.1.7:
     dependencies:
       mdast-util-to-markdown: 0.6.5
-      micromark: 2.11.4(supports-color@8.1.1)
+      micromark: 2.11.4
     transitivePeerDependencies:
       - supports-color
 
@@ -11544,7 +11508,7 @@ snapshots:
     dependencies:
       '@types/mdast': 3.0.15
       mdast-util-to-string: 2.0.0
-      micromark: 2.11.4(supports-color@8.1.1)
+      micromark: 2.11.4
       parse-entities: 2.0.0
       unist-util-stringify-position: 2.0.3
     transitivePeerDependencies:
@@ -11571,11 +11535,11 @@ snapshots:
     dependencies:
       micromark-extension-frontmatter: 0.2.2
 
-  mdast-util-gfm-autolink-literal@0.1.3(supports-color@8.1.1):
+  mdast-util-gfm-autolink-literal@0.1.3:
     dependencies:
       ccount: 1.1.0
       mdast-util-find-and-replace: 1.1.1
-      micromark: 2.11.4(supports-color@8.1.1)
+      micromark: 2.11.4
     transitivePeerDependencies:
       - supports-color
 
@@ -11639,7 +11603,7 @@ snapshots:
 
   mdast-util-gfm@0.1.2:
     dependencies:
-      mdast-util-gfm-autolink-literal: 0.1.3(supports-color@8.1.1)
+      mdast-util-gfm-autolink-literal: 0.1.3
       mdast-util-gfm-strikethrough: 0.2.3
       mdast-util-gfm-table: 0.1.6
       mdast-util-gfm-task-list-item: 0.1.6
@@ -11678,7 +11642,7 @@ snapshots:
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
 
   mdast-util-to-markdown@0.6.5:
@@ -11699,7 +11663,7 @@ snapshots:
       mdast-util-to-string: 4.0.0
       micromark-util-classify-character: 2.0.1
       micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
   mdast-util-to-string@2.0.0: {}
@@ -11735,7 +11699,7 @@ snapshots:
 
   micromark-extension-footnote@0.3.2:
     dependencies:
-      micromark: 2.11.4(supports-color@8.1.1)
+      micromark: 2.11.4
     transitivePeerDependencies:
       - supports-color
 
@@ -11745,7 +11709,7 @@ snapshots:
 
   micromark-extension-gfm-autolink-literal@0.5.7:
     dependencies:
-      micromark: 2.11.4(supports-color@8.1.1)
+      micromark: 2.11.4
     transitivePeerDependencies:
       - supports-color
 
@@ -11769,7 +11733,7 @@ snapshots:
 
   micromark-extension-gfm-strikethrough@0.6.5:
     dependencies:
-      micromark: 2.11.4(supports-color@8.1.1)
+      micromark: 2.11.4
     transitivePeerDependencies:
       - supports-color
 
@@ -11784,7 +11748,7 @@ snapshots:
 
   micromark-extension-gfm-table@0.4.3:
     dependencies:
-      micromark: 2.11.4(supports-color@8.1.1)
+      micromark: 2.11.4
     transitivePeerDependencies:
       - supports-color
 
@@ -11804,7 +11768,7 @@ snapshots:
 
   micromark-extension-gfm-task-list-item@0.3.3:
     dependencies:
-      micromark: 2.11.4(supports-color@8.1.1)
+      micromark: 2.11.4
     transitivePeerDependencies:
       - supports-color
 
@@ -11818,7 +11782,7 @@ snapshots:
 
   micromark-extension-gfm@0.3.3:
     dependencies:
-      micromark: 2.11.4(supports-color@8.1.1)
+      micromark: 2.11.4
       micromark-extension-gfm-autolink-literal: 0.5.7
       micromark-extension-gfm-strikethrough: 0.6.5
       micromark-extension-gfm-table: 0.4.3
@@ -11930,7 +11894,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@2.11.4(supports-color@8.1.1):
+  micromark@2.11.4:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       parse-entities: 2.0.0
@@ -12094,24 +12058,16 @@ snapshots:
       node-fetch-native: 1.6.7
       ufo: 1.6.1
 
-  ol-contextmenu@5.5.0(ol@10.7.0):
+  ol-contextmenu@5.5.0(ol@10.9.0):
     dependencies:
-      ol: 10.7.0
+      ol: 10.9.0
       tiny-emitter: 2.1.0
 
-  ol-mapbox-style@12.6.1(ol@10.7.0):
+  ol-mapbox-style@12.6.1(ol@10.9.0):
     dependencies:
       '@maplibre/maplibre-gl-style-spec': 23.3.0
       mapbox-to-css-font: 3.2.0
-      ol: 10.7.0
-
-  ol@10.7.0:
-    dependencies:
-      '@types/rbush': 4.0.0
-      earcut: 3.0.2
-      geotiff: 2.1.3
-      pbf: 4.0.1
-      rbush: 4.0.1
+      ol: 10.9.0
 
   ol@10.9.0:
     dependencies:
@@ -12416,7 +12372,7 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-text: 4.0.2
       lowlight: 3.3.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
 
   rehype-raw@7.0.0:
@@ -12436,7 +12392,7 @@ snapshots:
       github-slugger: 2.0.0
       hast-util-heading-rank: 3.0.0
       hast-util-to-string: 3.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   rehype-stringify@10.0.1:
     dependencies:
@@ -13083,12 +13039,6 @@ snapshots:
       unist-util-is: 5.2.1
       unist-util-visit-parents: 5.1.3
 
-  unist-util-visit@5.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.1
-      unist-util-visit-parents: 6.0.2
-
   unist-util-visit@5.1.0:
     dependencies:
       '@types/unist': 3.0.3
@@ -13539,8 +13489,6 @@ snapshots:
   zrender@6.1.0:
     dependencies:
       tslib: 2.3.0
-
-  zstddec@0.1.0: {}
 
   zstddec@0.2.0: {}
 

--- a/src/views/UnifiedSearchView.vue
+++ b/src/views/UnifiedSearchView.vue
@@ -44,20 +44,15 @@ const createUrl = computed(() => ({
   query: route.query
 }))
 
-// localType is needed because pageKey is read-only (derived from route), but
-// GlobalSearch needs a writable ref to track the active type (v-model:type).
-// When the user switches type, localType changes and the watch below navigates.
-// This watch keeps localType in sync when the route changes externally.
-const localType = ref(pageKey.value)
-watch(pageKey, (newKey) => {
-  localType.value = newKey
-})
-
-// When the user switches type, navigate to the new route. The guard prevents
-// a loop: when pageKey changes externally and syncs localType (watch above),
-// this fires but newType === pageKey.value so the push is skipped.
-watch(localType, async (newType) => {
-  if (newType !== pageKey.value) {
+// pageKey is read-only (derived from the route) so we need a writable computed
+// for v-model:type. A ref + watch doesn't work here: the watch fires after the
+// Vue flush, by which point GlobalSearch has already reacted to the type change
+// and issued a competing navigation that cancels ours. The computed setter runs
+// synchronously, so our router.push() starts before any watchers fire.
+const localType = computed({
+  get: () => pageKey.value,
+  set: async (newType) => {
+    if (newType === pageKey.value) return
     const scrollY = window.scrollY
     const { page, ...allQuery } = route.query
     // Org filter values are type-specific (different list per type) — don't carry them over


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1162 by including https://github.com/datagouv/cdata/pull/1146

Also make changes to the way we bind type model to `GlobalSearch`, since https://github.com/datagouv/cdata/pull/1148 subtly changed the way data flow is handled and it broke our type navigation.

\<rant>For the record, this has been an exhausting 2 days hunt fighting with a complex upstream component that can change under our feet.\</rant>