### PR TITLE
[Simplifions] Carroussel en fin d'article affichant l'ensemble des topics mentionnés

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -141,7 +141,7 @@ provide(AccessibilityPropertiesKey, setAccessibilityProperties)
   </main>
 
   <DsfrFooter
-    class="fr-mt-16w"
+    :class="[siteID, 'fr-mt-16w']"
     :logo-text="rf_title"
     :operator-img-src="logo?.src"
     :operator-img-style="{
@@ -169,5 +169,8 @@ provide(AccessibilityPropertiesKey, setAccessibilityProperties)
 }
 .fr-footer__logo {
   max-width: 100%;
+}
+.simplifions.fr-mt-16w {
+  margin-top: 0 !important;
 }
 </style>

--- a/src/custom/simplifions/components/CarouselTrack.vue
+++ b/src/custom/simplifions/components/CarouselTrack.vue
@@ -1,0 +1,101 @@
+<template>
+  <ul ref="track" class="carousel__track fr-m-0 fr-p-0" @scroll.passive="onScroll">
+    <slot />
+  </ul>
+  <div
+    v-show="hasOverflow"
+    class="fr-mt-2w fr-pb-2w fr-grid-row fr-grid-row--center"
+  >
+    <div class="carousel__nav">
+      <button
+        type="button"
+        class="fr-link fr-link--sm fr-link--icon-left fr-icon-arrow-left-s-line fr-mr-2w"
+        :disabled="!canPrev"
+        @click="prev"
+      >
+        Précédent
+      </button>
+      <button
+        type="button"
+        class="fr-link fr-link--sm fr-link--icon-right fr-icon-arrow-right-s-line"
+        :disabled="!canNext"
+        @click="next"
+      >
+        Suivant
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const track = ref<HTMLElement | null>(null)
+const scrollLeft = ref(0)
+const scrollMax = ref(0)
+
+const hasOverflow = computed(() => scrollMax.value > 0)
+const canPrev = computed(() => scrollLeft.value > 4)
+const canNext = computed(() => scrollLeft.value < scrollMax.value - 4)
+
+const updateScrollState = () => {
+  if (!track.value) return
+  scrollMax.value = track.value.scrollWidth - track.value.clientWidth
+  scrollLeft.value = track.value.scrollLeft
+}
+
+const onScroll = () => {
+  if (!track.value) return
+  scrollLeft.value = track.value.scrollLeft
+}
+
+const itemWidth = () => {
+  const item = track.value?.firstElementChild as HTMLElement | null
+  if (!item) return 300
+  const gap = track.value
+    ? parseFloat(getComputedStyle(track.value).columnGap) || 0
+    : 0
+  return item.offsetWidth + gap
+}
+
+const prev = () =>
+  track.value?.scrollBy({ left: -itemWidth(), behavior: 'smooth' })
+const next = () =>
+  track.value?.scrollBy({ left: itemWidth(), behavior: 'smooth' })
+
+const ro = new ResizeObserver(() => {
+  updateScrollState()
+})
+
+onMounted(async () => {
+  if (!track.value) return
+  await nextTick()
+  updateScrollState()
+  ro.observe(track.value)
+})
+
+onUnmounted(() => ro.disconnect())
+
+defineExpose({
+  getEl: () => track.value,
+  updateScrollState
+})
+</script>
+
+<style scoped>
+.carousel__track {
+  display: flex;
+  align-items: stretch;
+  gap: 1rem;
+  list-style: none;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+}
+.carousel__track::-webkit-scrollbar {
+  display: none;
+}
+
+.carousel__nav button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+</style>

--- a/src/custom/simplifions/components/SimplifionsCasDusageCard.vue
+++ b/src/custom/simplifions/components/SimplifionsCasDusageCard.vue
@@ -89,14 +89,18 @@ const hasDetails = computed(
 
 <style scoped>
 .simplifions-card-link {
-  display: block;
+  display: flex;
+  flex-direction: column;
   margin-bottom: 1rem;
   background: none;
 }
 
-
 .topic-card {
   border: 1px solid var(--border-default-grey);
+  background-color: var(--background-default-grey);
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }
 .topic-card:hover {
   background-color: var(--background-alt-grey);
@@ -140,9 +144,7 @@ const hasDetails = computed(
 .description-topic {
   padding: 16px;
   min-height: 80px;
-  background-color: var(--background-default-grey);
 }
-
 
 .card-arrow {
   display: flex;

--- a/src/custom/simplifions/components/SimplifionsDataApi.vue
+++ b/src/custom/simplifions/components/SimplifionsDataApi.vue
@@ -51,12 +51,15 @@ import { DatasetCard } from '@datagouv/components-next'
 import * as Sentry from '@sentry/vue'
 import type { ApiOrDataset } from '../model/grist'
 
-const props = withDefaults(defineProps<{
-  apiOrDataset: ApiOrDataset
-  titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
-}>(), {
-  titleTag: 'h3'
-})
+const props = withDefaults(
+  defineProps<{
+    apiOrDataset: ApiOrDataset
+    titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  }>(),
+  {
+    titleTag: 'h3'
+  }
+)
 
 const emit = defineEmits<{
   resourceFetched: [resource: DatasetV2 | Dataservice]

--- a/src/custom/simplifions/components/SimplifionsSolutionCard.vue
+++ b/src/custom/simplifions/components/SimplifionsSolutionCard.vue
@@ -106,7 +106,8 @@ const imageUrl = solution?.Image?.[0] ? grist.imageUrl(solution.Image[0]) : ''
 
 <style scoped>
 .simplifions-card-link {
-  display: block;
+  display: flex;
+  flex-direction: column;
   margin-bottom: 1rem;
   background: none;
 }
@@ -137,6 +138,12 @@ const imageUrl = solution?.Image?.[0] ? grist.imageUrl(solution.Image[0]) : ''
 .card-image {
   max-height: 250px;
   object-position: top center;
+}
+
+.topic-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 .topic-card--private {

--- a/src/custom/simplifions/components/article/SimplifionsArticleLayout.vue
+++ b/src/custom/simplifions/components/article/SimplifionsArticleLayout.vue
@@ -117,16 +117,18 @@
           </nav>
         </aside>
 
-        <main
-          ref="articleRef"
-          class="fr-col-12 fr-col-lg-9 article-content-col"
-        >
+        <div ref="articleRef" class="fr-col-12 fr-col-lg-9 article-content-col">
           <div class="article-content">
             <slot />
           </div>
-        </main>
+        </div>
       </div>
     </div>
+
+    <SimplifionsArticleRelatedTopics
+      :entries="topicEntries"
+      :gradient="heroBackdropGradient"
+    />
   </div>
 </template>
 
@@ -134,7 +136,9 @@
 import type { BreadcrumbItem } from '@/model/breadcrumb'
 import { useCanonicalUrl, useMeta } from '@/utils/seo'
 import { provide, useSlots } from 'vue'
+import { provideArticleTopicsRegistry } from '../../composables/useArticleTopicsRegistry'
 import { articleSectionKey } from './articleSectionKey'
+import SimplifionsArticleRelatedTopics from './SimplifionsArticleRelatedTopics.vue'
 
 type ArticleSection = {
   id: string
@@ -168,7 +172,7 @@ const props = withDefaults(
     kicker: '',
     heroImageSrc: '',
     articleTags: () => [],
-    heroBackdropGradient: 'linear-gradient(135deg, #1b1b35 0%, #1e1e1e 100%)',
+    heroBackdropGradient: 'linear-gradient(135deg, var(--background-action-low-blue-ecume) 0%, var(--background-contrast-blue-ecume) 100%)',
     heroPanelBackground: 'var(--background-alt-beige-gris-galet)',
     breadcrumbLinks: () => []
   }
@@ -185,6 +189,8 @@ useMeta({
 
 const sections = ref<ArticleSection[]>([])
 provide(articleSectionKey, (id, label) => sections.value.push({ id, label }))
+
+const topicEntries = provideArticleTopicsRegistry()
 
 const sidemenuExpanded = ref(true)
 
@@ -220,6 +226,7 @@ onMounted(() => {
 
   if (!targets.length || typeof IntersectionObserver === 'undefined') return
 
+  const elementById = new Map(targets.map((el) => [el.id, el]))
   const visibleSections = new Set<string>()
 
   observer = new IntersectionObserver(
@@ -245,7 +252,7 @@ onMounted(() => {
       const zoneTop = window.innerHeight * 0.1
       let last = ''
       for (const section of sections.value) {
-        const el = container.querySelector<HTMLElement>(`#${section.id}`)
+        const el = elementById.get(section.id)
         if (el && el.getBoundingClientRect().top < zoneTop) last = section.id
       }
       if (last) activeSection.value = last

--- a/src/custom/simplifions/components/article/SimplifionsArticleRelatedTopics.vue
+++ b/src/custom/simplifions/components/article/SimplifionsArticleRelatedTopics.vue
@@ -1,0 +1,106 @@
+<template>
+  <section
+    v-if="props.entries.length > 0"
+    class="topics-carousel fr-mt-6w fr-py-5w"
+    :style="{ backgroundImage: gradient }"
+  >
+    <div class="fr-container">
+      <h2 class="fr-h5 fr-mb-3w">Sont mentionnés dans cet article :</h2>
+
+      <CarouselTrack ref="carouselRef">
+        <li
+          v-for="entry in props.entries"
+          :key="entry.slug"
+          class="carousel__item"
+        >
+          <SimplifionsSolutionCard
+            v-if="entry.pageKey === 'solutions'"
+            :topic="entry.topic as TopicSolution"
+            :page-key="entry.pageKey"
+            :show-description="false"
+            :show-image="true"
+            :show-fournisseurs="false"
+            :show-simplification-tags="false"
+          />
+          <SimplifionsCasDusageCard
+            v-else
+            :topic="entry.topic as TopicCasUsage"
+            :page-key="entry.pageKey"
+            :show-description="false"
+            :show-fournisseurs="false"
+            :show-simplification-tags="false"
+          />
+        </li>
+      </CarouselTrack>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { TopicCasUsage, TopicSolution } from '../../model/topics'
+import CarouselTrack from '../CarouselTrack.vue'
+import SimplifionsCasDusageCard from '../SimplifionsCasDusageCard.vue'
+import SimplifionsSolutionCard from '../SimplifionsSolutionCard.vue'
+import type { ArticleTopicEntry } from './articleTopicsRegistryKey'
+
+const props = defineProps<{
+  entries: readonly ArticleTopicEntry[]
+  gradient?: string
+}>()
+
+const carouselRef = ref<InstanceType<typeof CarouselTrack> | null>(null)
+
+watch(
+  () => props.entries.map((e) => e.slug),
+  async (slugs) => {
+    if (slugs.length === 0) return
+    await nextTick()
+    const el = carouselRef.value?.getEl()
+    if (el) el.scrollLeft = 0
+    carouselRef.value?.updateScrollState()
+  },
+  { immediate: true }
+)
+</script>
+
+<style scoped>
+.topics-carousel {
+  background-color: var(--background-action-low-blue-ecume);
+  background-size: cover;
+}
+
+.topics-carousel :deep(.fr-link:hover),
+.topics-carousel :deep(.fr-link:focus) {
+  background-color: transparent;
+}
+
+.carousel__item {
+  flex: 0 0 280px;
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+}
+
+.carousel__item :deep(.simplifions-card-link) {
+  flex: 1;
+  height: 100%;
+  margin-bottom: 0;
+}
+
+.carousel__item :deep(.header-topic) {
+  height: 140px;
+  overflow: hidden;
+}
+
+.carousel__item :deep(.title-topic) {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.carousel__item :deep(.fr-card__body) {
+  flex: 1;
+}
+</style>

--- a/src/custom/simplifions/components/article/SimplifionsArticleTopicSpotlight.vue
+++ b/src/custom/simplifions/components/article/SimplifionsArticleTopicSpotlight.vue
@@ -45,6 +45,7 @@
 <script setup lang="ts">
 import type { Topic } from '@/model/topic'
 import { useTopicStore } from '@/store/TopicStore'
+import { injectArticleTopicsRegistry } from '../../composables/useArticleTopicsRegistry'
 import type { TopicCasUsage, TopicSolution } from '../../model/topics'
 import SimplifionsCasDusageCard from '../SimplifionsCasDusageCard.vue'
 import SimplifionsSolutionCard from '../SimplifionsSolutionCard.vue'
@@ -96,6 +97,8 @@ onBeforeUnmount(() => {
   cancelled = true
 })
 
+const registry = injectArticleTopicsRegistry()
+
 onMounted(async () => {
   const results = await Promise.allSettled(
     props.slugs.map((slug) => topicStore.load(slug))
@@ -108,6 +111,13 @@ onMounted(async () => {
     .filter((r): r is PromiseFulfilledResult<Topic> => r.status === 'fulfilled')
     .map((r) => r.value)
   loading.value = false
+  topics.value.forEach((topic) =>
+    registry?.register(
+      topic.slug,
+      props.pageKey,
+      topic as unknown as TopicSolution | TopicCasUsage
+    )
+  )
 })
 </script>
 

--- a/src/custom/simplifions/components/article/articleTopicsRegistryKey.ts
+++ b/src/custom/simplifions/components/article/articleTopicsRegistryKey.ts
@@ -1,0 +1,20 @@
+import type { InjectionKey } from 'vue'
+import type { TopicCasUsage, TopicSolution } from '../../model/topics'
+
+export type ArticleTopicEntry = {
+  slug: string
+  pageKey: 'solutions' | 'cas-d-usages'
+  topic: TopicSolution | TopicCasUsage
+}
+
+export type ArticleTopicsRegistry = {
+  register: (
+    slug: string,
+    pageKey: 'solutions' | 'cas-d-usages',
+    topic: TopicSolution | TopicCasUsage
+  ) => void
+  entries: Readonly<ArticleTopicEntry[]>
+}
+
+export const articleTopicsRegistryKey: InjectionKey<ArticleTopicsRegistry> =
+  Symbol('articleTopicsRegistry')

--- a/src/custom/simplifions/composables/useArticleTopicsRegistry.ts
+++ b/src/custom/simplifions/composables/useArticleTopicsRegistry.ts
@@ -1,0 +1,31 @@
+import { inject, provide, reactive } from 'vue'
+import {
+  articleTopicsRegistryKey,
+  type ArticleTopicEntry,
+  type ArticleTopicsRegistry
+} from '../components/article/articleTopicsRegistryKey'
+import type { TopicCasUsage, TopicSolution } from '../model/topics'
+
+export const provideArticleTopicsRegistry = (): Readonly<
+  ArticleTopicEntry[]
+> => {
+  const entries = reactive<ArticleTopicEntry[]>([])
+
+  const register = (
+    slug: string,
+    pageKey: 'solutions' | 'cas-d-usages',
+    topic: TopicSolution | TopicCasUsage
+  ) => {
+    if (!entries.some((e) => e.slug === slug)) {
+      entries.push({ slug, pageKey, topic })
+    }
+  }
+
+  provide(articleTopicsRegistryKey, { register, entries })
+
+  return entries
+}
+
+export const injectArticleTopicsRegistry = (): ArticleTopicsRegistry | null => {
+  return inject(articleTopicsRegistryKey, null)
+}


### PR DESCRIPTION
Dépend de : https://github.com/opendatateam/udata-front-kit/pull/1271

Cette PR introduit un carrousel des solutions et cas d'usages mentionnés dans un article, de façon automatique :  

> ⚠️ Cette PR retire une margin top 16 qui était au dessus du footer pour toutes les verticales, et qui empêche toute section d'être collée au footer (ce qui est attendu ici)... vérifier si ça ne casse pas le style d'autres verticales

<img width="2344" height="1294" alt="image" src="https://github.com/user-attachments/assets/adef1e39-d738-4331-8008-8b079a9d469a" />
<img width="2342" height="1218" alt="image" src="https://github.com/user-attachments/assets/76f36fe7-2461-4f95-8e6e-ec98b9f92f0e" />

