### PR TITLE
feat(icons): refactor and add ri collection icon

### DIFF
--- a/src/components/OrganizationCard.vue
+++ b/src/components/OrganizationCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import VIconCustom from '@/components/VIconCustom.vue'
+import VIconDsfr from '@/components/VIconDsfr.vue'
 import { stripFromMarkdown } from '@/utils'
 
 const props = defineProps({
@@ -46,13 +46,13 @@ const isPublicService = (): boolean =>
             class="fr-tile__link"
             :to="`/organizations/${organization.slug}`"
           >
-            <VIconCustom
+            <VIconDsfr
               v-if="isPublicService()"
               name="bank-line"
               class="fr-icon--sm fr-mr-1v badge"
             />
             {{ organization.name }}
-            <VIconCustom
+            <VIconDsfr
               v-if="isCertified()"
               name="checkbox-circle-line"
               class="fr-icon--sm fr-mr-1v badge"

--- a/src/components/SearchComponent.vue
+++ b/src/components/SearchComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import VIconCustom from '@/components/VIconCustom.vue'
+import VIconDsfr from '@/components/VIconDsfr.vue'
 import { ref } from 'vue'
 
 import { useRouter } from 'vue-router'
@@ -77,7 +77,7 @@ const doSimpleSearch = (event: string) => {
       :title="!labelVisible ? searchLabel : undefined"
     >
       <template #before-input>
-        <VIconCustom name="search-line" class="search-icon" />
+        <VIconDsfr name="search-line" class="search-icon" />
       </template>
     </DsfrInputGroup>
   </search>

--- a/src/components/VIconDsfr.vue
+++ b/src/components/VIconDsfr.vue
@@ -4,7 +4,8 @@ import type { Property } from 'csstype'
 defineProps({
   name: {
     type: String,
-    required: true
+    required: true,
+    validator: (value: string) => !value.includes(':')
   },
   small: {
     type: Boolean,

--- a/src/components/VIconRi.vue
+++ b/src/components/VIconRi.vue
@@ -26,11 +26,11 @@ withDefaults(
 
 <style scoped>
 .v-icon-ri {
-  --icon-size: 1.5rem;
+  --icon-size: 1.25rem;
   width: var(--icon-size);
   height: var(--icon-size);
 }
 .v-icon-ri--sm {
-  --icon-size: 1rem;
+  --icon-size: 0.9rem;
 }
 </style>

--- a/src/components/VIconRi.vue
+++ b/src/components/VIconRi.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { Property } from 'csstype'
+import type { Component } from 'vue'
+
+withDefaults(
+  defineProps<{
+    icon: Component
+    small?: boolean
+    align?: Property.VerticalAlign
+  }>(),
+  {
+    small: false,
+    align: ''
+  }
+)
+</script>
+
+<template>
+  <component
+    :is="icon"
+    aria-hidden="true"
+    :class="['v-icon-ri', { 'v-icon-ri--sm': small }]"
+    :style="align ? { verticalAlign: align } : undefined"
+  />
+</template>
+
+<style scoped>
+.v-icon-ri {
+  --icon-size: 1.5rem;
+  width: var(--icon-size);
+  height: var(--icon-size);
+}
+.v-icon-ri--sm {
+  --icon-size: 1rem;
+}
+</style>

--- a/src/components/datasets/DatasetSidebar.vue
+++ b/src/components/datasets/DatasetSidebar.vue
@@ -4,7 +4,7 @@ import MetricsStatBoxes from '@/components/MetricsStatBoxes.vue'
 import SidebarItem from '@/components/SidebarItem.vue'
 import SidebarList from '@/components/SidebarList.vue'
 import SidebarOwner from '@/components/SidebarOwner.vue'
-import VIconCustom from '@/components/VIconCustom.vue'
+import VIconDsfr from '@/components/VIconDsfr.vue'
 import config from '@/config'
 import type { TypedHarvest } from '@/model/dataset'
 import { formatDate } from '@/utils'
@@ -89,7 +89,7 @@ const showHarvestQualityWarning = computed(() => {
       v-if="showHarvestQualityWarning"
       class="text-mention-grey fr-text--sm fr-my-1v"
     >
-      <VIconCustom name="warning-line" class="fr-icon--sm" />
+      <VIconDsfr name="warning-line" class="fr-icon--sm" />
       La qualité des métadonnées peut être trompeuse car les métadonnées de la
       source originale peuvent avoir été perdues lors de leur récupération. Nous
       travaillons actuellement à améliorer la situation.

--- a/src/components/forms/ErrorMessage.vue
+++ b/src/components/forms/ErrorMessage.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import VIconCustom from '@/components/VIconCustom.vue'
+import VIconDsfr from '@/components/VIconDsfr.vue'
 
 defineProps({
   inputName: { type: String, required: true },
@@ -9,7 +9,7 @@ defineProps({
 
 <template v-if="errorMessage">
   <p :id="`errors-${inputName}`" class="error">
-    <VIconCustom name="error-fill" />
+    <VIconDsfr name="error-fill" />
     {{ errorMessage }}
   </p>
 </template>

--- a/src/components/topics/DataserviceInTopicCard.vue
+++ b/src/components/topics/DataserviceInTopicCard.vue
@@ -7,7 +7,7 @@ import {
 import type { RouteLocationRaw } from 'vue-router'
 
 import OrganizationLogo from '@/components/OrganizationLogo.vue'
-import VIconCustom from '@/components/VIconCustom.vue'
+import VIconDsfr from '@/components/VIconDsfr.vue'
 import { getOwnerAvatar } from '@/utils/avatar'
 import { useOwnerName } from '@/utils/owned'
 
@@ -81,10 +81,7 @@ const dataserviceLink: RouteLocationRaw = {
     </div>
 
     <p class="fr-mb-2v fr-text--sm flex align-center fr-pt-3v text-grey-425">
-      <VIconCustom
-        name="time-line"
-        class="fr-mr-1w text-grey-425 fr-icon--sm"
-      />
+      <VIconDsfr name="time-line" class="fr-mr-1w text-grey-425 fr-icon--sm" />
       Mis à jour
       {{ formatRelativeIfRecentDate(dataservice.metadata_modified_at) }}
     </p>

--- a/src/components/topics/TopicCard.vue
+++ b/src/components/topics/TopicCard.vue
@@ -120,12 +120,7 @@ const tags = useTags(props.pageKey, props.topic)
 
     <div class="fr-grid-row flex-gap card-footer">
       <span class="fr-tag">
-        <VIconDsfr
-          name="database-line"
-          class="fr-mr-1v"
-          size="lg"
-          align="text-top"
-        />
+        <VIconDsfr name="database-line" class="fr-mr-1v" align="text-top" />
         <span class="fr-mr-1v">
           {{
             `${nbFactors > 0 ? nbFactors : 'Aucune'} donnée${nbFactors > 1 ? 's' : ''}`
@@ -134,12 +129,7 @@ const tags = useTags(props.pageKey, props.topic)
       </span>
 
       <span v-if="spatialCoverage" class="fr-tag">
-        <VIconDsfr
-          name="road-map-line"
-          class="fr-mr-1v"
-          size="lg"
-          align="text-top"
-        />
+        <VIconDsfr name="road-map-line" class="fr-mr-1v" align="text-top" />
         <span class="fr-mr-1v">
           {{ spatialCoverage.name }}
         </span>

--- a/src/components/topics/TopicCard.vue
+++ b/src/components/topics/TopicCard.vue
@@ -8,7 +8,7 @@ import { type RouteLocationRaw } from 'vue-router'
 
 import OrganizationLogo from '@/components/OrganizationLogo.vue'
 import TagComponent from '@/components/TagComponent.vue'
-import VIconCustom from '@/components/VIconCustom.vue'
+import VIconDsfr from '@/components/VIconDsfr.vue'
 import type { Topic } from '@/model/topic'
 import { stripFromMarkdown } from '@/utils'
 import { getOwnerAvatar } from '@/utils/avatar'
@@ -114,16 +114,13 @@ const tags = useTags(props.pageKey, props.topic)
     </div>
 
     <p class="fr-mb-2v fr-text--sm flex align-center fr-pt-3v text-grey-425">
-      <VIconCustom
-        name="time-line"
-        class="fr-mr-1w text-grey-425 fr-icon--sm"
-      />
+      <VIconDsfr name="time-line" class="fr-mr-1w text-grey-425 fr-icon--sm" />
       Mis à jour {{ formatRelativeIfRecentDate(topic.last_modified) }}
     </p>
 
     <div class="fr-grid-row flex-gap card-footer">
       <span class="fr-tag">
-        <VIconCustom
+        <VIconDsfr
           name="database-line"
           class="fr-mr-1v"
           size="lg"
@@ -137,7 +134,7 @@ const tags = useTags(props.pageKey, props.topic)
       </span>
 
       <span v-if="spatialCoverage" class="fr-tag">
-        <VIconCustom
+        <VIconDsfr
           name="road-map-line"
           class="fr-mr-1v"
           size="lg"

--- a/src/components/topics/TopicInTopicCard.vue
+++ b/src/components/topics/TopicInTopicCard.vue
@@ -3,10 +3,12 @@ import {
   OrganizationNameWithCertificate,
   useFormatDate
 } from '@datagouv/components-next'
+import { RiBookShelfLine } from '@remixicon/vue'
 import type { RouteLocationRaw } from 'vue-router'
 
 import OrganizationLogo from '@/components/OrganizationLogo.vue'
-import VIconCustom from '@/components/VIconCustom.vue'
+import VIconDsfr from '@/components/VIconDsfr.vue'
+import VIconRi from '@/components/VIconRi.vue'
 import type { Topic } from '@/model/topic'
 import { useCurrentPageConf } from '@/router/utils'
 import { getOwnerAvatar } from '@/utils/avatar'
@@ -38,7 +40,7 @@ const topicLink: RouteLocationRaw = {
       class="absolute top-0 fr-grid-row fr-grid-row--middle fr-mt-n3v fr-ml-n1v"
     >
       <p class="fr-badge fr-badge--sm fr-badge--mention-grey fr-mr-1w">
-        <span class="fr-icon-plant-line fr-icon--sm" aria-hidden="true"></span>
+        <VIconRi :icon="RiBookShelfLine" small />
         {{ labels.singular }}
       </p>
     </div>
@@ -78,10 +80,7 @@ const topicLink: RouteLocationRaw = {
     </div>
 
     <p class="fr-mb-2v fr-text--sm flex align-center fr-pt-3v text-grey-425">
-      <VIconCustom
-        name="time-line"
-        class="fr-mr-1w text-grey-425 fr-icon--sm"
-      />
+      <VIconDsfr name="time-line" class="fr-mr-1w text-grey-425 fr-icon--sm" />
       Mis à jour {{ formatRelativeIfRecentDate(topic.last_modified) }}
     </p>
   </article>

--- a/src/custom/accessibilite/views/ThemesView.vue
+++ b/src/custom/accessibilite/views/ThemesView.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import VIconCustom from '@/components/VIconCustom.vue'
+import VIconDsfr from '@/components/VIconDsfr.vue'
 import { useUserStore } from '@/store/UserStore'
 import { usePageConf } from '@/utils/config'
 import { useLabels } from '@/utils/labels'
@@ -52,7 +52,7 @@ const doSearch = (q: string) => {
         >
           <div class="fr-col-auto">
             <router-link :to="createUrl" class="fr-btn fr-mb-1w">
-              <VIconCustom
+              <VIconDsfr
                 name="add-circle-line"
                 class="fr-mr-1w"
                 align="middle"

--- a/src/views/UnifiedSearchView.vue
+++ b/src/views/UnifiedSearchView.vue
@@ -2,7 +2,7 @@
 import SearchOrganizationFilter from '@/components/search/SearchOrganizationFilter.vue'
 import SearchSelectFilter from '@/components/search/SearchSelectFilter.vue'
 import TopicCard from '@/components/topics/TopicCard.vue'
-import VIconCustom from '@/components/VIconCustom.vue'
+import VIconDsfr from '@/components/VIconDsfr.vue'
 import { useUserStore } from '@/store/UserStore'
 import { fromMarkdown } from '@/utils'
 import { useAsyncComponent } from '@/utils/component'
@@ -107,11 +107,7 @@ onMounted(() => {
       >
         <div class="fr-col-auto">
           <router-link :to="createUrl" class="fr-btn fr-mb-1w">
-            <VIconCustom
-              name="add-circle-line"
-              class="fr-mr-1w"
-              align="middle"
-            />
+            <VIconDsfr name="add-circle-line" class="fr-mr-1w" align="middle" />
             Ajouter {{ labels.articles.un }} {{ labels.singular }}
           </router-link>
         </div>

--- a/src/views/dataservices/DataserviceDetailView.vue
+++ b/src/views/dataservices/DataserviceDetailView.vue
@@ -10,7 +10,7 @@ import MetricsStatBoxes from '@/components/MetricsStatBoxes.vue'
 import SidebarItem from '@/components/SidebarItem.vue'
 import SidebarList from '@/components/SidebarList.vue'
 import SidebarOwner from '@/components/SidebarOwner.vue'
-import VIconCustom from '@/components/VIconCustom.vue'
+import VIconDsfr from '@/components/VIconDsfr.vue'
 import { useCurrentPageConf, useRouteParamsAsString } from '@/router/utils'
 import { useDataserviceStore } from '@/store/DataserviceStore'
 import { descriptionFromMarkdown, formatDate } from '@/utils'
@@ -222,8 +222,8 @@ onMounted(() => {
         @click="isSwaggerOpened = !isSwaggerOpened"
       >
         <span class="fr-text--bold">Swagger</span>
-        <VIconCustom v-if="isSwaggerOpened" name="arrow-up-s-line" />
-        <VIconCustom v-else name="arrow-down-s-line" />
+        <VIconDsfr v-if="isSwaggerOpened" name="arrow-up-s-line" />
+        <VIconDsfr v-else name="arrow-down-s-line" />
       </button>
       <OpenApiViewer
         v-if="isSwaggerOpened"

--- a/src/views/topics/TopicDraftsView.vue
+++ b/src/views/topics/TopicDraftsView.vue
@@ -6,7 +6,7 @@ import { useRoute } from 'vue-router'
 
 import GenericContainer from '@/components/GenericContainer.vue'
 import TopicCard from '@/components/topics/TopicCard.vue'
-import VIconCustom from '@/components/VIconCustom.vue'
+import VIconDsfr from '@/components/VIconDsfr.vue'
 import { useTopicStore } from '@/store/TopicStore'
 import { debounceWait, usePageConf } from '@/utils/config'
 import { useLabels } from '@/utils/labels'
@@ -82,7 +82,7 @@ useMeta({
       <h1 class="fr-mb-0">Mes brouillons</h1>
       <div class="fr-col-auto">
         <router-link :to="createUrl" class="fr-btn">
-          <VIconCustom name="add-circle-line" class="fr-mr-1w" align="middle" />
+          <VIconDsfr name="add-circle-line" class="fr-mr-1w" align="middle" />
           Ajouter {{ labels.articles.un }} {{ labels.singular }}
         </router-link>
       </div>


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1168

We need an icon not included in dsfr for https://github.com/ecolabdata/ecospheres/issues/1168 (to match the icon used by upstream `GlobalSearch`).

This PR:
- adds a `VIconRi` that lets us use any remix icon properly (ie not using a CDN), with the same semantics as previous `VIconCustom`
-  renames `VIconCustom` to `VIconDsfr` for consistency (and adds a guard for remix icon usage, discouraged here)

<img width="649" height="294" alt="Capture d’écran 2026-06-24 à 12 48 48" src="https://github.com/user-attachments/assets/03cd585c-09b8-4789-9bb2-44930955b2ac" />
