### PR TITLE
[Simplifions] Affiche les solutions intégrant une API/data recommandée pour un cas d'usage

### DIFF
--- a/src/custom/simplifions/components/SimplifionsRecoDataApi.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoDataApi.vue
@@ -356,6 +356,10 @@ const tabTitles = computed(() => {
   return titles
 })
 
+watch(tabTitles, () => {
+  activeTab.value = 0
+})
+
 const hasIntegratingSolutions = computed(() => tabTitles.value.length > 0)
 </script>
 

--- a/src/custom/simplifions/components/SimplifionsRecoDataApi.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoDataApi.vue
@@ -74,6 +74,143 @@
       title-tag="h5"
       @resource-fetched="handleResourceFetched"
     />
+      <div v-if="hasIntegratingSolutions" class="fr-col-12 fr-p-0 fr-mt-4w">
+        <DsfrAccordionsGroup v-model="activeIntegratingAccordion">
+          <DsfrAccordion title-tag="h5">
+            <template #title>
+              <strong
+                >Solutions intégrant «&nbsp;{{
+                  recommandation.Nom_de_la_recommandation
+                }}&nbsp;»</strong
+              >
+            </template>
+            <DsfrTabs
+              v-model="activeTab"
+              tab-list-name="Catégories de solutions intégratrices"
+              :tab-titles="tabTitles"
+            >
+              <DsfrTabContent
+                v-if="integratingSolutionsLogicielsMetiers?.length"
+                panel-id="tab-content-logiciel-metier"
+                tab-id="tab-logiciel-metier"
+                style="background-color: white"
+              >
+                <p>
+                  <strong>Liste des logiciels métier, sur étagère</strong>
+                  conçus pour le cas d’usage «<i
+                    >&nbsp;{{
+                      recommandation.Nom_complet_du_cas_d_usage
+                    }}&nbsp;</i
+                  >» :
+                </p>
+                <div
+                  class="reco-solution fr-grid-row fr-grid-row--gutters fr-mt-2w"
+                >
+                  <div
+                    v-for="solution in integratingSolutionsLogicielsMetiers"
+                    :key="solution.id"
+                    class="fr-col-12 fr-col-sm-6 fr-col-lg-4 fr-col-xl-3 fr-col-2xl-2"
+                  >
+                    <SimplifionsRecoSolutionsIntegratricesCard
+                      :solution="solution"
+                      :integration-score="
+                        integrationScorePerSolution.get(solution.id)
+                      "
+                      :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+                      :type-label="typeLabel"
+                    />
+                  </div>
+                </div>
+              </DsfrTabContent>
+
+              <DsfrTabContent
+                v-if="integratingSolutionsBriquesTechniques?.length"
+                panel-id="tab-content-brique-technique"
+                tab-id="tab-brique-technique"
+                style="background-color: white"
+              >
+                <p>
+                  <strong>Briques techniques logicielles</strong> destinées à
+                  être intégrées dans un système informatique existant et
+                  conçues pour le cas d’usage «<i
+                    >&nbsp;{{
+                      recommandation.Nom_complet_du_cas_d_usage
+                    }}&nbsp;</i
+                  >» :
+                </p>
+                <div
+                  class="reco-solution fr-grid-row fr-grid-row--gutters fr-mt-2w"
+                >
+                  <div
+                    v-for="solution in integratingSolutionsBriquesTechniques"
+                    :key="solution.id"
+                    class="fr-col-12 fr-col-sm-6 fr-col-lg-4 fr-col-xl-3 fr-col-2xl-2"
+                  >
+                    <SimplifionsRecoSolutionsIntegratricesCard
+                      :solution="solution"
+                      :integration-score="
+                        integrationScorePerSolution.get(solution.id)
+                      "
+                      :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+                      :type-label="typeLabel"
+                    />
+                  </div>
+                </div>
+              </DsfrTabContent>
+
+              <DsfrTabContent
+                v-if="integratingSolutionsPortailsConsultation?.length"
+                panel-id="tab-content-portail-consultation"
+                tab-id="tab-portail-consultation"
+                style="background-color: white"
+              >
+                <p>
+                  <b
+                    >Ces sites vous permettent de consulter certaines des
+                    données utiles pour ce cas d’usage :</b
+                  >
+                </p>
+                <div
+                  class="fr-m-2w fr-highlight--orange-terre-battue fr-highlight"
+                >
+                  <p class="fr-mb-0">
+                    💡 Pour vraiment simplifier la vie des usagers,
+                    l'intégration directe de cette API ou de jeu de données dans
+                    vos logiciels métiers est à privilégier car elle permet de
+                    mettre en oeuvre le <i>dites-le-nous une fois</i> et la
+                    proactivité !
+                  </p>
+                </div>
+                <div
+                  class="reco-solution fr-grid-row fr-grid-row--gutters fr-mt-2w"
+                >
+                  <div
+                    v-for="solution in integratingSolutionsPortailsConsultation"
+                    :key="solution.id"
+                    class="fr-col-12 fr-col-sm-6 fr-col-lg-4 fr-col-xl-3 fr-col-2xl-2"
+                  >
+                    <SimplifionsRecoSolutionsIntegratricesCard
+                      :solution="solution"
+                      :integration-score="
+                        integrationScorePerSolution.get(solution.id)
+                      "
+                      :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+                      :type-label="typeLabel"
+                    />
+                  </div>
+                </div>
+              </DsfrTabContent>
+            </DsfrTabs>
+            <p class="fr-text--sm fr-mx-3w fr-mt-2w">
+              <i
+                >Une solution n'est pas listée parmi les solutions intégrant
+                «&nbsp;{{ recommandation.Nom_de_la_recommandation }}&nbsp;» ?
+              </i>
+              <a href="#modification-contenu">✒️ Proposer un contenu</a>.
+            </p>
+          </DsfrAccordion>
+        </DsfrAccordionsGroup>
+      </div>
   </div>
 </template>
 
@@ -81,8 +218,9 @@
 import { fromMarkdown } from '@/utils'
 import type { Dataservice, DatasetV2 } from '@datagouv/components-next'
 import { grist } from '../grist.ts'
-import type { ApiOrDataset, Recommandation } from '../model/grist'
+import type { ApiOrDataset, Recommandation, SolutionRecord } from '../model/grist'
 import SimplifionsDataApi from './SimplifionsDataApi.vue'
+import SimplifionsRecoSolutionsIntegratricesCard from './SimplifionsRecoSolutionsIntegratricesCard.vue'
 
 const props = defineProps<{
   recommandation: Recommandation
@@ -119,6 +257,106 @@ grist
   .then((data) => {
     apiOrDataset.value = data.fields as ApiOrDataset
   })
+
+const fetchSolutionsForCategory = async (ids: number[]) => {
+  const data = await grist.getRecordsByIds('Solutions', ids)
+  return (data as SolutionRecord[])
+    .filter((record) => record.fields.Visible_sur_simplifions)
+    .sort((a, b) =>
+      a.fields.Nom.localeCompare(b.fields.Nom, 'fr', { sensitivity: 'base' })
+    )
+}
+
+const integratingSolutionsLogicielsMetiers = ref<SolutionRecord[]>([])
+const integratingSolutionsBriquesTechniques = ref<SolutionRecord[]>([])
+const integratingSolutionsPortailsConsultation = ref<SolutionRecord[]>([])
+
+if (props.recommandation.Solutions_integratrices_categorie_logiciel_metier?.length) {
+  fetchSolutionsForCategory(
+    props.recommandation.Solutions_integratrices_categorie_logiciel_metier
+  ).then((solutions) => {
+    integratingSolutionsLogicielsMetiers.value = solutions
+  })
+}
+
+if (props.recommandation.Solutions_integratrices_categorie_briques_techniques?.length) {
+  fetchSolutionsForCategory(
+    props.recommandation.Solutions_integratrices_categorie_briques_techniques
+  ).then((solutions) => {
+    integratingSolutionsBriquesTechniques.value = solutions
+  })
+}
+
+if (props.recommandation.Solutions_integratrices_categorie_portail_de_consultation?.length) {
+  fetchSolutionsForCategory(
+    props.recommandation.Solutions_integratrices_categorie_portail_de_consultation
+  ).then((solutions) => {
+    integratingSolutionsPortailsConsultation.value = solutions
+  })
+}
+
+const usefulApiId = props.recommandation.API_ou_datasets_recommandes
+
+const integrationScorePerSolution = computed(() => {
+  const allSolutions = [
+    ...integratingSolutionsLogicielsMetiers.value,
+    ...integratingSolutionsBriquesTechniques.value,
+    ...integratingSolutionsPortailsConsultation.value
+  ]
+  return new Map(
+    allSolutions.map((solution) => [
+      solution.id,
+      {
+        integratedCount: (solution.fields.API_ou_datasets_integres ?? []).includes(
+          usefulApiId
+        )
+          ? 1
+          : 0,
+        totalCount: 1
+      }
+    ])
+  )
+})
+
+const typeLabel = computed(() => {
+  const t = props.recommandation.Type_de_recommandation
+  if (t === 'API') return 'API'
+  if (t === 'Jeu de données') return 'jeu de données'
+  return 'API ou jeu de données'
+})
+
+const activeIntegratingAccordion = ref(0)
+const activeTab = ref(0)
+const tabTitles = computed(() => {
+  const titles = []
+  if (integratingSolutionsLogicielsMetiers.value.length > 0) {
+    const count = integratingSolutionsLogicielsMetiers.value.length
+    titles.push({
+      title: `Logiciels métiers (${count}) 💠💠💠`,
+      tabId: 'tab-logiciel-metier',
+      panelId: 'tab-content-logiciel-metier'
+    })
+  }
+  if (integratingSolutionsBriquesTechniques.value.length > 0) {
+    const count = integratingSolutionsBriquesTechniques.value.length
+    titles.push({
+      title: `Briques techniques (${count}) 💠💠💠`,
+      tabId: 'tab-brique-technique',
+      panelId: 'tab-content-brique-technique'
+    })
+  }
+  if (integratingSolutionsPortailsConsultation.value.length > 0) {
+    const count = integratingSolutionsPortailsConsultation.value.length
+    titles.push({
+      title: `Portails de consultation (${count})`,
+      tabId: 'tab-portail-consultation',
+      panelId: 'tab-content-portail-consultation'
+    })
+  }
+  return titles
+})
+
+const hasIntegratingSolutions = computed(() => tabTitles.value.length > 0)
 </script>
 
 <style scoped>

--- a/src/custom/simplifions/components/SimplifionsRecoDataApi.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoDataApi.vue
@@ -74,143 +74,144 @@
       title-tag="h5"
       @resource-fetched="handleResourceFetched"
     />
-      <div v-if="hasIntegratingSolutions" class="fr-col-12 fr-p-0 fr-mt-4w">
-        <DsfrAccordionsGroup v-model="activeIntegratingAccordion">
-          <DsfrAccordion title-tag="h5">
-            <template #title>
-              <strong
-                >Solutions intégrant «&nbsp;{{
-                  recommandation.Nom_de_la_recommandation
-                }}&nbsp;»</strong
-              >
-            </template>
-            <DsfrTabs
-              v-model="activeTab"
-              tab-list-name="Catégories de solutions intégratrices"
-              :tab-titles="tabTitles"
+
+    <div v-if="hasIntegratingSolutions" class="fr-col-12 fr-p-0 fr-mt-4w">
+      <DsfrAccordionsGroup v-model="activeIntegratingAccordion">
+        <DsfrAccordion title-tag="h5">
+          <template #title>
+            <strong
+              >Solutions intégrant «&nbsp;{{
+                recommandation.Nom_de_la_recommandation
+              }}&nbsp;»</strong
             >
-              <DsfrTabContent
-                v-if="integratingSolutionsLogicielsMetiers?.length"
-                :panel-id="`${uid}-tab-content-logiciel-metier`"
-                :tab-id="`${uid}-tab-logiciel-metier`"
-                style="background-color: white"
+          </template>
+          <DsfrTabs
+            v-model="activeTab"
+            tab-list-name="Catégories de solutions intégratrices"
+            :tab-titles="tabTitles"
+          >
+            <DsfrTabContent
+              v-if="integratingSolutionsLogicielsMetiers?.length"
+              :panel-id="`${uid}-tab-content-logiciel-metier`"
+              :tab-id="`${uid}-tab-logiciel-metier`"
+              style="background-color: white"
+            >
+              <p>
+                <strong>Liste des logiciels métier, sur étagère</strong>
+                conçus pour le cas d'usage «<i
+                  >&nbsp;{{
+                    recommandation.Nom_complet_du_cas_d_usage
+                  }}&nbsp;</i
+                >» :
+              </p>
+              <div
+                class="reco-solution fr-grid-row fr-grid-row--gutters fr-mt-2w"
               >
-                <p>
-                  <strong>Liste des logiciels métier, sur étagère</strong>
-                  conçus pour le cas d’usage «<i
-                    >&nbsp;{{
-                      recommandation.Nom_complet_du_cas_d_usage
-                    }}&nbsp;</i
-                  >» :
-                </p>
                 <div
-                  class="reco-solution fr-grid-row fr-grid-row--gutters fr-mt-2w"
+                  v-for="solution in integratingSolutionsLogicielsMetiers"
+                  :key="solution.id"
+                  class="fr-col-12 fr-col-sm-6 fr-col-lg-4 fr-col-xl-3 fr-col-2xl-2"
                 >
-                  <div
-                    v-for="solution in integratingSolutionsLogicielsMetiers"
-                    :key="solution.id"
-                    class="fr-col-12 fr-col-sm-6 fr-col-lg-4 fr-col-xl-3 fr-col-2xl-2"
-                  >
-                    <SimplifionsRecoSolutionsIntegratricesCard
-                      :solution="solution"
-                      :integration-score="
-                        integrationScorePerSolution.get(solution.id)
-                      "
-                      :nom-fournisseur="recommandation.Nom_de_la_recommandation"
-                      :type-label="typeLabel"
-                    />
-                  </div>
+                  <SimplifionsRecoSolutionsIntegratricesCard
+                    :solution="solution"
+                    :integration-score="
+                      integrationScorePerSolution.get(solution.id)
+                    "
+                    :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+                    :type-label="typeLabel"
+                  />
                 </div>
-              </DsfrTabContent>
+              </div>
+            </DsfrTabContent>
 
-              <DsfrTabContent
-                v-if="integratingSolutionsBriquesTechniques?.length"
-                :panel-id="`${uid}-tab-content-brique-technique`"
-                :tab-id="`${uid}-tab-brique-technique`"
-                style="background-color: white"
+            <DsfrTabContent
+              v-if="integratingSolutionsBriquesTechniques?.length"
+              :panel-id="`${uid}-tab-content-brique-technique`"
+              :tab-id="`${uid}-tab-brique-technique`"
+              style="background-color: white"
+            >
+              <p>
+                <strong>Briques techniques logicielles</strong> destinées à
+                être intégrées dans un système informatique existant et
+                conçues pour le cas d'usage «<i
+                  >&nbsp;{{
+                    recommandation.Nom_complet_du_cas_d_usage
+                  }}&nbsp;</i
+                >» :
+              </p>
+              <div
+                class="reco-solution fr-grid-row fr-grid-row--gutters fr-mt-2w"
               >
-                <p>
-                  <strong>Briques techniques logicielles</strong> destinées à
-                  être intégrées dans un système informatique existant et
-                  conçues pour le cas d’usage «<i
-                    >&nbsp;{{
-                      recommandation.Nom_complet_du_cas_d_usage
-                    }}&nbsp;</i
-                  >» :
-                </p>
                 <div
-                  class="reco-solution fr-grid-row fr-grid-row--gutters fr-mt-2w"
+                  v-for="solution in integratingSolutionsBriquesTechniques"
+                  :key="solution.id"
+                  class="fr-col-12 fr-col-sm-6 fr-col-lg-4 fr-col-xl-3 fr-col-2xl-2"
                 >
-                  <div
-                    v-for="solution in integratingSolutionsBriquesTechniques"
-                    :key="solution.id"
-                    class="fr-col-12 fr-col-sm-6 fr-col-lg-4 fr-col-xl-3 fr-col-2xl-2"
-                  >
-                    <SimplifionsRecoSolutionsIntegratricesCard
-                      :solution="solution"
-                      :integration-score="
-                        integrationScorePerSolution.get(solution.id)
-                      "
-                      :nom-fournisseur="recommandation.Nom_de_la_recommandation"
-                      :type-label="typeLabel"
-                    />
-                  </div>
+                  <SimplifionsRecoSolutionsIntegratricesCard
+                    :solution="solution"
+                    :integration-score="
+                      integrationScorePerSolution.get(solution.id)
+                    "
+                    :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+                    :type-label="typeLabel"
+                  />
                 </div>
-              </DsfrTabContent>
+              </div>
+            </DsfrTabContent>
 
-              <DsfrTabContent
-                v-if="integratingSolutionsPortailsConsultation?.length"
-                :panel-id="`${uid}-tab-content-portail-consultation`"
-                :tab-id="`${uid}-tab-portail-consultation`"
-                style="background-color: white"
+            <DsfrTabContent
+              v-if="integratingSolutionsPortailsConsultation?.length"
+              :panel-id="`${uid}-tab-content-portail-consultation`"
+              :tab-id="`${uid}-tab-portail-consultation`"
+              style="background-color: white"
+            >
+              <p>
+                <b
+                  >Ces sites vous permettent de consulter certaines des
+                  données utiles pour ce cas d'usage :</b
+                >
+              </p>
+              <div
+                class="fr-m-2w fr-highlight--orange-terre-battue fr-highlight"
               >
-                <p>
-                  <b
-                    >Ces sites vous permettent de consulter certaines des
-                    données utiles pour ce cas d’usage :</b
-                  >
+                <p class="fr-mb-0">
+                  💡 Pour vraiment simplifier la vie des usagers,
+                  l'intégration directe de cette API ou de jeu de données dans
+                  vos logiciels métiers est à privilégier car elle permet de
+                  mettre en oeuvre le <i>dites-le-nous une fois</i> et la
+                  proactivité !
                 </p>
+              </div>
+              <div
+                class="reco-solution fr-grid-row fr-grid-row--gutters fr-mt-2w"
+              >
                 <div
-                  class="fr-m-2w fr-highlight--orange-terre-battue fr-highlight"
+                  v-for="solution in integratingSolutionsPortailsConsultation"
+                  :key="solution.id"
+                  class="fr-col-12 fr-col-sm-6 fr-col-lg-4 fr-col-xl-3 fr-col-2xl-2"
                 >
-                  <p class="fr-mb-0">
-                    💡 Pour vraiment simplifier la vie des usagers,
-                    l'intégration directe de cette API ou de jeu de données dans
-                    vos logiciels métiers est à privilégier car elle permet de
-                    mettre en oeuvre le <i>dites-le-nous une fois</i> et la
-                    proactivité !
-                  </p>
+                  <SimplifionsRecoSolutionsIntegratricesCard
+                    :solution="solution"
+                    :integration-score="
+                      integrationScorePerSolution.get(solution.id)
+                    "
+                    :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+                    :type-label="typeLabel"
+                  />
                 </div>
-                <div
-                  class="reco-solution fr-grid-row fr-grid-row--gutters fr-mt-2w"
-                >
-                  <div
-                    v-for="solution in integratingSolutionsPortailsConsultation"
-                    :key="solution.id"
-                    class="fr-col-12 fr-col-sm-6 fr-col-lg-4 fr-col-xl-3 fr-col-2xl-2"
-                  >
-                    <SimplifionsRecoSolutionsIntegratricesCard
-                      :solution="solution"
-                      :integration-score="
-                        integrationScorePerSolution.get(solution.id)
-                      "
-                      :nom-fournisseur="recommandation.Nom_de_la_recommandation"
-                      :type-label="typeLabel"
-                    />
-                  </div>
-                </div>
-              </DsfrTabContent>
-            </DsfrTabs>
-            <p class="fr-text--sm fr-mx-3w fr-mt-2w">
-              <i
-                >Une solution n'est pas listée parmi les solutions intégrant
-                «&nbsp;{{ recommandation.Nom_de_la_recommandation }}&nbsp;» ?
-              </i>
-              <a href="#modification-contenu">✒️ Proposer un contenu</a>.
-            </p>
-          </DsfrAccordion>
-        </DsfrAccordionsGroup>
-      </div>
+              </div>
+            </DsfrTabContent>
+          </DsfrTabs>
+          <p class="fr-text--sm fr-mx-3w fr-mt-2w">
+            <i
+              >Une solution n'est pas listée parmi les solutions intégrant
+              «&nbsp;{{ recommandation.Nom_de_la_recommandation }}&nbsp;» ?
+            </i>
+            <a href="#modification-contenu">✒️ Proposer un contenu</a>.
+          </p>
+        </DsfrAccordion>
+      </DsfrAccordionsGroup>
+    </div>
   </div>
 </template>
 

--- a/src/custom/simplifions/components/SimplifionsRecoDataApi.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoDataApi.vue
@@ -91,8 +91,8 @@
             >
               <DsfrTabContent
                 v-if="integratingSolutionsLogicielsMetiers?.length"
-                panel-id="tab-content-logiciel-metier"
-                tab-id="tab-logiciel-metier"
+                :panel-id="`${uid}-tab-content-logiciel-metier`"
+                :tab-id="`${uid}-tab-logiciel-metier`"
                 style="background-color: white"
               >
                 <p>
@@ -125,8 +125,8 @@
 
               <DsfrTabContent
                 v-if="integratingSolutionsBriquesTechniques?.length"
-                panel-id="tab-content-brique-technique"
-                tab-id="tab-brique-technique"
+                :panel-id="`${uid}-tab-content-brique-technique`"
+                :tab-id="`${uid}-tab-brique-technique`"
                 style="background-color: white"
               >
                 <p>
@@ -160,8 +160,8 @@
 
               <DsfrTabContent
                 v-if="integratingSolutionsPortailsConsultation?.length"
-                panel-id="tab-content-portail-consultation"
-                tab-id="tab-portail-consultation"
+                :panel-id="`${uid}-tab-content-portail-consultation`"
+                :tab-id="`${uid}-tab-portail-consultation`"
                 style="background-color: white"
               >
                 <p>
@@ -225,6 +225,8 @@ import SimplifionsRecoSolutionsIntegratricesCard from './SimplifionsRecoSolution
 const props = defineProps<{
   recommandation: Recommandation
 }>()
+
+const uid = useId()
 
 const apiOrDataset = ref<ApiOrDataset | undefined>(undefined)
 const fetchedResource = ref<DatasetV2 | Dataservice | undefined>(undefined)
@@ -333,24 +335,24 @@ const tabTitles = computed(() => {
     const count = integratingSolutionsLogicielsMetiers.value.length
     titles.push({
       title: `Logiciels métiers (${count}) 💠💠💠`,
-      tabId: 'tab-logiciel-metier',
-      panelId: 'tab-content-logiciel-metier'
+      tabId: `${uid}-tab-logiciel-metier`,
+      panelId: `${uid}-tab-content-logiciel-metier`
     })
   }
   if (integratingSolutionsBriquesTechniques.value.length > 0) {
     const count = integratingSolutionsBriquesTechniques.value.length
     titles.push({
       title: `Briques techniques (${count}) 💠💠💠`,
-      tabId: 'tab-brique-technique',
-      panelId: 'tab-content-brique-technique'
+      tabId: `${uid}-tab-brique-technique`,
+      panelId: `${uid}-tab-content-brique-technique`
     })
   }
   if (integratingSolutionsPortailsConsultation.value.length > 0) {
     const count = integratingSolutionsPortailsConsultation.value.length
     titles.push({
       title: `Portails de consultation (${count})`,
-      tabId: 'tab-portail-consultation',
-      panelId: 'tab-content-portail-consultation'
+      tabId: `${uid}-tab-portail-consultation`,
+      panelId: `${uid}-tab-content-portail-consultation`
     })
   }
   return titles

--- a/src/custom/simplifions/components/SimplifionsRecoSolutions.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutions.vue
@@ -496,6 +496,10 @@ const tabTitles = computed(() => {
 })
 
 const hasIntegratingSolutions = computed(() => tabTitles.value.length > 0)
+
+watch(tabTitles, () => {
+  activeTab.value = 0
+})
 </script>
 
 <style scoped>

--- a/src/custom/simplifions/components/SimplifionsRecoSolutions.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutions.vue
@@ -158,8 +158,8 @@
             >
               <DsfrTabContent
                 v-if="integratingSolutionsLogicielsMetiers?.length"
-                panel-id="tab-content-logiciel-metier"
-                tab-id="tab-logiciel-metier"
+                :panel-id="`${uid}-tab-content-logiciel-metier`"
+                :tab-id="`${uid}-tab-logiciel-metier`"
                 style="background-color: white"
               >
                 <p>
@@ -192,8 +192,8 @@
 
               <DsfrTabContent
                 v-if="integratingSolutionsBriquesTechniques?.length"
-                panel-id="tab-content-brique-technique"
-                tab-id="tab-brique-technique"
+                :panel-id="`${uid}-tab-content-brique-technique`"
+                :tab-id="`${uid}-tab-brique-technique`"
                 style="background-color: white"
               >
                 <p>
@@ -227,8 +227,8 @@
 
               <DsfrTabContent
                 v-if="integratingSolutionsPortailsConsultation?.length"
-                panel-id="tab-content-portail-consultation"
-                tab-id="tab-portail-consultation"
+                :panel-id="`${uid}-tab-content-portail-consultation`"
+                :tab-id="`${uid}-tab-portail-consultation`"
                 style="background-color: white"
               >
                 <p>
@@ -299,6 +299,8 @@ import SimplifionsRecoSolutionsIntegratricesCard from './SimplifionsRecoSolution
 const props = defineProps<{
   recommandation: Recommandation
 }>()
+
+const uid = useId()
 
 const recommandation = props.recommandation
 
@@ -472,24 +474,24 @@ const tabTitles = computed(() => {
     const count = integratingSolutionsLogicielsMetiers.value.length
     titles.push({
       title: `Logiciels métiers (${count}) 💠💠💠`,
-      tabId: 'tab-logiciel-metier',
-      panelId: 'tab-content-logiciel-metier'
+      tabId: `${uid}-tab-logiciel-metier`,
+      panelId: `${uid}-tab-content-logiciel-metier`
     })
   }
   if (integratingSolutionsBriquesTechniques.value.length > 0) {
     const count = integratingSolutionsBriquesTechniques.value.length
     titles.push({
       title: `Briques techniques (${count}) 💠💠💠`,
-      tabId: 'tab-brique-technique',
-      panelId: 'tab-content-brique-technique'
+      tabId: `${uid}-tab-brique-technique`,
+      panelId: `${uid}-tab-content-brique-technique`
     })
   }
   if (integratingSolutionsPortailsConsultation.value.length > 0) {
     const count = integratingSolutionsPortailsConsultation.value.length
     titles.push({
       title: `Portails de consultation (${count})`,
-      tabId: 'tab-portail-consultation',
-      panelId: 'tab-content-portail-consultation'
+      tabId: `${uid}-tab-portail-consultation`,
+      panelId: `${uid}-tab-content-portail-consultation`
     })
   }
   return titles


### PR DESCRIPTION
Cette PR met en place le même système déjà présent pour les solutions recommandées dans les cas d'usages.

**Qu'est-ce que ça change pour l'usager de simplifions ?**
Désormais plutôt que de voir uniquement les logiciels intégrant les API qui ont une fiche solution, il peut voir aussi quels logiciels ont intégré toutes les API recommandées sur un cas d'usage

**Du côté du code:** 
Elle reprend le code présent dans `SimplifionsRecoSolutions` et l'applique dans `SimplifionsRecoDataApi`

<img width="2320" height="1722" alt="image" src="https://github.com/user-attachments/assets/92e7c6d6-cc6c-4997-904f-e2693613b6c0" />

