### PR TITLE
feat(meteo): add conditional custom filter for clim data

### DIFF
--- a/src/custom/meteo-france/assets/datasets.json
+++ b/src/custom/meteo-france/assets/datasets.json
@@ -5,42 +5,48 @@
       "dev": "653a68f2c52ecb6d2e96fe3e",
       "id": "DECAD",
       "departement": true,
-      "periode": true
+      "periode": true,
+      "showCustomFilter": true
     },
     "Données horaires": {
       "prod": "6569b4473bedf2e7abad3b72",
       "dev": "653a68f2c52ecb6d2e96fe3f",
       "id": "HOR",
       "departement": true,
-      "periode": true
+      "periode": true,
+      "showCustomFilter": false
     },
     "Données quotidiennes": {
       "prod": "6569b51ae64326786e4e8e1a",
       "dev": "653a68f2ba54993957fa00af",
       "id": "QUOT",
       "departement": true,
-      "periode": true
+      "periode": true,
+      "showCustomFilter": true
     },
     "Données mensuelles": {
       "prod": "6569b3d7d193b4daf2b43edc",
       "dev": "654c962a3b8186a2b5bbc995",
       "id": "MENS",
       "departement": true,
-      "periode": true
+      "periode": true,
+      "showCustomFilter": true
     },
     "Données minutes": {
       "prod": "6569ad61106d1679c93cdf77",
       "dev": "65649a720baab9dbf8f36731",
       "id": "MIN",
       "departement": true,
-      "periode": true
+      "periode": true,
+      "showCustomFilter": false
     },
     "Données décadaires agro": {
       "prod": "6569af36ba0c3d2f9d4bf98c",
       "dev": "65649a1b0baab9dbf8f36730",
       "id": "DECADAGRO",
       "departement": true,
-      "periode": true
+      "periode": true,
+      "showCustomFilter": true
     }
   },
   "Données climatologiques de référence pour le changement climatique": {

--- a/src/custom/meteo-france/types.ts
+++ b/src/custom/meteo-france/types.ts
@@ -38,6 +38,7 @@ export interface Dataset {
   id: string
   departement: boolean
   periode: boolean
+  showCustomFilter?: boolean
   indicateur?: boolean
   indicateursListe?: Indicateur[]
 }

--- a/src/custom/meteo-france/views/FormMF.vue
+++ b/src/custom/meteo-france/views/FormMF.vue
@@ -191,7 +191,7 @@ async function onSelectDep(event: Event) {
   res = [...new Set(res)]
   optionsPeriod.value = res
   showPeriod.value = true
-  if (selectedDataPack.value == 'Données climatologiques de base') {
+  if (selectedDataset.value?.showCustomFilter) {
     for (const obj of deps) {
       if (obj.code === selectedDep.value) {
         mapOptions.value = obj


### PR DESCRIPTION
Following https://github.com/datagouv/api-meteo/pull/3, we are using Tabular API.
Custom filters fail due to huge number of rows (currently limited to 50000 on Tabular) for MIN and HOR datasets.

Seeing the very low usage rate of these custom filters, we deactivate it entirely.