### PR TITLE
fix(tests): gvt1.com exception match

### DIFF
--- a/cypress/support/generic_mocks.ts
+++ b/cypress/support/generic_mocks.ts
@@ -10,19 +10,22 @@ const allowedDomains = [
   'android.clients.google.com',
   'safebrowsing.googleapis.com',
   'accounts.google.com',
-  'gvt1.com'
+  '*.gvt1.com'
 ]
 
 Cypress.Commands.add('catchUnmockedRequests', () => {
-  const escapedDomains = allowedDomains
-    .map((domain) => domain.replace(/\./g, '\\.'))
-    .join('|')
-  const regex = new RegExp(`^https?:\\/\\/(?!(${escapedDomains})(:|\/|$)).*`)
-
-  cy.intercept(regex, (req) => {
-    throw new Error(
-      `Unmocked external API call detected: ${req.method} ${req.url}`
+  cy.intercept('*', (req) => {
+    const { hostname } = new URL(req.url)
+    const allowed = allowedDomains.some((domain) =>
+      domain.startsWith('*.')
+        ? hostname.endsWith(domain.slice(1))
+        : hostname === domain
     )
+    if (!allowed) {
+      throw new Error(
+        `Unmocked external API call detected: ${req.method} ${req.url}`
+      )
+    }
   }).as('catchExternalRequests')
 })
 


### PR DESCRIPTION
Allows basic wildcard support so that `r5---sn-2imeyn7k.gvt1.com` matches `*.gvt1.com` exception. Also refactors to use a simpler string based matching rather than (two) complicated regex.

Ref https://github.com/opendatateam/udata-front-kit/actions/runs/28378598322/job/84074749533