### PR TITLE
feat(dataset): display spatial resolution metadata

### DIFF
--- a/src/components/datasets/DatasetInformationPanel.vue
+++ b/src/components/datasets/DatasetInformationPanel.vue
@@ -6,6 +6,8 @@ import {
   DatasetInformationSection,
   DatasetSchemaSection,
   DatasetSpatialSection,
+  DescriptionListDetails,
+  DescriptionListTerm,
   ExtraAccordion
 } from '@datagouv/components-next'
 
@@ -38,6 +40,12 @@ const goToHarvester = (sourceId: string) => {
       <template #map="{ geojson }">
         <LeafletMap :geojson="geojson" width="350px" height="350px" />
       </template>
+      <div v-if="dataset.extras?.dcat?.spatial_resolution">
+        <DescriptionListTerm>Niveau de détail</DescriptionListTerm>
+        <DescriptionListDetails>{{
+          dataset.extras.dcat.spatial_resolution
+        }}</DescriptionListDetails>
+      </div>
     </DatasetSpatialSection>
     <!-- Suspense component (experimental) is required here because `DatasetSchemaSection`
         is a component with an async setup(). If Suspense is removed from vue, `DatasetSchemaSection` must be

--- a/src/components/datasets/DatasetInformationPanel.vue
+++ b/src/components/datasets/DatasetInformationPanel.vue
@@ -41,7 +41,9 @@ const goToHarvester = (sourceId: string) => {
         <LeafletMap :geojson="geojson" width="350px" height="350px" />
       </template>
       <div v-if="dataset.extras?.dcat?.spatial_resolution">
-        <DescriptionListTerm>Niveau de détail</DescriptionListTerm>
+        <DescriptionListTerm
+          >Résolution ou échelle équivalente</DescriptionListTerm
+        >
         <DescriptionListDetails>{{
           dataset.extras.dcat.spatial_resolution
         }}</DescriptionListDetails>


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1176

Used "Niveau de détail" instead of "Résolution" because the metadata can be a resolution or a scale.

<img width="600" src="https://github.com/user-attachments/assets/75d35a6b-c5a3-46a3-9332-f7c7c04ab277" />
