### PR TITLE
fix(dataset): proper harvest/non-harvest dates

### DIFF
--- a/src/components/datasets/DatasetTemporalitySection.vue
+++ b/src/components/datasets/DatasetTemporalitySection.vue
@@ -17,31 +17,32 @@ const props = defineProps<{
 const { formatDate } = useFormatDate()
 
 const harvest = props.dataset.harvest as TypedHarvest
-const harvestCreatedAt = harvest?.created_at
-const harvestIssuedAt = harvest?.issued_at
-const harvestModifiedAt = harvest?.modified_at
+const createdAt = harvest ? harvest?.created_at : props.dataset.created_at
+const issuedAt = harvest?.issued_at
+const modifiedAt = harvest ? harvest?.modified_at : props.dataset.last_update
+const modifiedLabel = harvest ? 'révision' : 'mise à jour'
 </script>
 
 <template>
   <div class="space-y-1 py-6">
     <h3 class="uppercase text-gray-plain text-sm font-bold">Temporalité</h3>
     <dl class="grid grid-cols-1 md:grid-cols-3 gap-6 p-0">
-      <div>
+      <div v-if="createdAt">
         <DescriptionListTerm>Création</DescriptionListTerm>
         <DescriptionListDetails>{{
-          formatDate(harvestCreatedAt)
+          formatDate(createdAt)
         }}</DescriptionListDetails>
       </div>
-      <div v-if="harvestIssuedAt">
+      <div v-if="issuedAt">
         <DescriptionListTerm>Publication</DescriptionListTerm>
         <DescriptionListDetails>{{
-          formatDate(harvestIssuedAt)
+          formatDate(issuedAt)
         }}</DescriptionListDetails>
       </div>
-      <div v-if="harvestModifiedAt">
-        <DescriptionListTerm>Dernière révision</DescriptionListTerm>
+      <div v-if="modifiedAt">
+        <DescriptionListTerm>Dernière {{ modifiedLabel }}</DescriptionListTerm>
         <DescriptionListDetails>{{
-          formatDate(harvestModifiedAt)
+          formatDate(modifiedAt)
         }}</DescriptionListDetails>
       </div>
       <div v-if="dataset.frequency">

--- a/src/components/datasets/DatasetTemporalitySection.vue
+++ b/src/components/datasets/DatasetTemporalitySection.vue
@@ -29,7 +29,7 @@ const harvestModifiedAt = harvest?.modified_at
       <div>
         <DescriptionListTerm>Création</DescriptionListTerm>
         <DescriptionListDetails>{{
-          formatDate(harvestCreatedAt ?? dataset.created_at)
+          formatDate(harvestCreatedAt)
         }}</DescriptionListDetails>
       </div>
       <div v-if="harvestIssuedAt">


### PR DESCRIPTION
Display different set of dates depending harvest status.

**Non harvested :** Display datagouv dates.
<img width="800" src="https://github.com/user-attachments/assets/fcd18dbc-0b00-49c6-9a40-01cf2c106acb" />

**Harvested :** Display harvest dates. Exemple has no harvested creation date => do not display "Création".
<img width="800" src="https://github.com/user-attachments/assets/62c9a3b8-f138-46d8-be46-c5eb4a1438f3" />

