### PR TITLE
[Simplifions] Ajoute un bouton demande d'accès dans la zone éditeur

### DIFF
--- a/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
+++ b/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
@@ -589,6 +589,24 @@ describe("Simplifions Cas d'usages Show page - accordions behaviour", () => {
     })
   })
 
+  it('should display a "Demander un accès" button in the "logiciel métier" accordion when an access link exists', () => {
+    setupWithTwoAccordions({
+      access_link_with_fallback: 'https://example.com/access'
+    })
+
+    cy.get('button.fr-accordion__btn').eq(1).click()
+    cy.get('.test__access-link-logiciel')
+      .should('contain.text', 'Demander un accès')
+      .and('have.attr', 'href', 'https://example.com/access')
+  })
+
+  it('should not display the "logiciel métier" access button when no access link is provided', () => {
+    setupWithTwoAccordions()
+
+    cy.get('button.fr-accordion__btn').eq(1).click()
+    cy.get('.test__access-link-logiciel').should('not.exist')
+  })
+
   it("should not affect another reco-card's accordion when one is opened", () => {
     cy.baseMocksForSimplifions()
 

--- a/src/custom/simplifions/components/SimplifionsReco.vue
+++ b/src/custom/simplifions/components/SimplifionsReco.vue
@@ -129,6 +129,31 @@
           <strong>Liste des logiciels métier, sur étagère</strong> conçus pour
           le cas d'usage «<i>&nbsp;{{ recommandation.Nom_complet_du_cas_d_usage }}&nbsp;</i>» :
         </p>
+
+        <template #demande-acces>
+          <div v-if="access_url" class="fr-mt-2w">
+            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+              <p class="fr-col fr-mb-0">
+                Vous êtes déjà client d'un de ces éditeurs ? Demandez un accès
+                à «&nbsp;{{ recommandation.Nom_de_la_recommandation }}&nbsp;»
+                pour votre logiciel :
+              </p>
+              <a
+                rel="noopener noreferrer"
+                :href="access_url"
+                class="fr-btn test__access-link-logiciel"
+                target="_blank"
+              >
+                Demander un accès
+              </a>
+            </div>
+            <p class="fr-text--sm fr-mb-0 fr-mt-1w">
+              Si vous n'êtes pas déjà client, contactez d'abord l'éditeur avant
+              de demander un accès à
+              «&nbsp;{{ recommandation.Nom_de_la_recommandation }}&nbsp;».
+            </p>
+          </div>
+        </template>
       </SimplifionsRecoIntegratingSolutionsAccordion>
 
       <SimplifionsRecoIntegratingSolutionsAccordion

--- a/src/custom/simplifions/components/SimplifionsRecoIntegratingSolutionsAccordion.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoIntegratingSolutionsAccordion.vue
@@ -25,6 +25,7 @@
         />
       </div>
     </div>
+    <slot name="demande-acces" />
   </DsfrAccordion>
 </template>
 


### PR DESCRIPTION
Solution intermédiaire pour mettre en avant le bouton demande d'accès en attendant d'avoir un bouton spécifique par solution : 
<img width="1224" height="564" alt="image" src="https://github.com/user-attachments/assets/dd952274-dc1d-4ca3-b4f3-d192a6309051" />
