### PR TITLE
[Simplifions] Permet de filtre les articles par mots clés

### DIFF
--- a/src/custom/simplifions/components/article/SimplifionsArticleLayout.vue
+++ b/src/custom/simplifions/components/article/SimplifionsArticleLayout.vue
@@ -41,6 +41,20 @@
             </ul>
 
             <ul
+              v-if="groupedKeywords.articleTypeKeywords.length || groupedKeywords.dataTypeKeywords.length"
+              class="article-hero__badge-list fr-p-0 fr-m-0"
+            >
+              <li v-for="keyword in groupedKeywords.articleTypeKeywords" :key="keyword.label">
+                <p class="fr-badge fr-badge--sm fr-m-0">{{ keyword.label }}</p>
+              </li>
+              <li v-for="keyword in groupedKeywords.dataTypeKeywords" :key="keyword.label">
+                <p class="fr-badge fr-badge--sm fr-badge--blue-ecume fr-m-0">
+                  {{ keyword.label }}
+                </p>
+              </li>
+            </ul>
+
+            <ul
               v-if="groupedKeywords.otherKeywords.length"
               class="article-hero__tag-list fr-p-0 fr-m-0"
             >

--- a/src/custom/simplifions/components/article/SimplifionsArticleLayout.vue
+++ b/src/custom/simplifions/components/article/SimplifionsArticleLayout.vue
@@ -41,20 +41,6 @@
             </ul>
 
             <ul
-              v-if="groupedKeywords.articleTypeKeywords.length || groupedKeywords.dataTypeKeywords.length"
-              class="article-hero__badge-list fr-p-0 fr-m-0"
-            >
-              <li v-for="keyword in groupedKeywords.articleTypeKeywords" :key="keyword.label">
-                <p class="fr-badge fr-badge--sm fr-m-0">{{ keyword.label }}</p>
-              </li>
-              <li v-for="keyword in groupedKeywords.dataTypeKeywords" :key="keyword.label">
-                <p class="fr-badge fr-badge--sm fr-badge--blue-ecume fr-m-0">
-                  {{ keyword.label }}
-                </p>
-              </li>
-            </ul>
-
-            <ul
               v-if="groupedKeywords.otherKeywords.length"
               class="article-hero__tag-list fr-p-0 fr-m-0"
             >

--- a/src/custom/simplifions/views/articles/ArticlesListView.vue
+++ b/src/custom/simplifions/views/articles/ArticlesListView.vue
@@ -51,7 +51,19 @@ useMeta({
     'Guides et explications pour comprendre et intégrer les API utiles à la simplification de vos démarches.',
   canonicalUrl: useCanonicalUrl()
 })
-const selectedKeywords = ref<string[]>([])
+
+const route = useRoute()
+const router = useRouter()
+
+const selectedKeywords = ref<string[]>(
+  typeof route.query.keywords === 'string' ? route.query.keywords.split(',') : []
+)
+
+watch(selectedKeywords, (keywords) => {
+  router.replace({
+    query: { ...route.query, keywords: keywords.length ? keywords.join(',') : undefined }
+  })
+})
 
 const keywordGroups = computed(() => {
   const counts = new Map<string, number>()

--- a/src/custom/simplifions/views/articles/ArticlesListView.vue
+++ b/src/custom/simplifions/views/articles/ArticlesListView.vue
@@ -4,37 +4,12 @@
 
 
     <div class="fr-grid-row fr-grid-row--gutters">
-      <aside class="fr-col-12 fr-col-lg-3">
-        <div v-for="group in keywordGroups" :key="group.category" class="fr-mb-3w">
-          <p class="fr-text--bold fr-mb-1w">{{ group.category }}</p>
-          <ul class="fr-tags-group fr-mb-0">
-            <li v-for="keyword in group.keywords" :key="keyword.label">
-              <button
-                class="fr-tag"
-                :aria-pressed="selectedKeywords.includes(keyword.label)"
-                :disabled="keyword.count === 0"
-                @click="toggleKeyword(keyword.label)"
-              >
-                {{ keyword.label }} ({{ keyword.count }})
-              </button>
-            </li>
-          </ul>
-        </div>
-      </aside>
-
-      <div class="fr-col-12 fr-col-lg-9">
-        <p v-if="filteredArticles.length === 0" class="fr-text--lg">
-          Aucun article ne correspond aux tags sélectionnés.
-        </p>
-        <div v-else class="fr-grid-row fr-grid-row--gutters">
-          <div
-            v-for="article in filteredArticles"
-            :key="article.slug"
-            class="fr-col-12 fr-col-md-6 fr-col-lg-4"
-          >
-            <ArticleCard :article="article" />
-          </div>
-        </div>
+      <div
+        v-for="article in articles"
+        :key="article.slug"
+        class="fr-col-12 fr-col-md-6 fr-col-lg-4"
+      >
+        <ArticleCard :article="article" />
       </div>
     </div>
   </div>
@@ -43,8 +18,7 @@
 <script setup lang="ts">
 import { useCanonicalUrl, useMeta } from '@/utils/seo'
 import ArticleCard from '../../components/article/ArticleCard.vue'
-import type { ArticleKeywordCategory } from '../../model/articles'
-import { ARTICLE_KEYWORD_CATEGORIES, ARTICLE_KEYWORDS, articles } from '../../model/articles'
+import { articles } from '../../model/articles'
 
 useMeta({
   title: () => 'Articles',
@@ -52,66 +26,4 @@ useMeta({
     'Guides et explications pour comprendre et intégrer les API utiles à la simplification de vos démarches.',
   canonicalUrl: useCanonicalUrl()
 })
-
-const route = useRoute()
-const router = useRouter()
-
-const selectedKeywords = ref<string[]>(
-  typeof route.query.keywords === 'string' ? route.query.keywords.split(',') : []
-)
-
-watch(selectedKeywords, (keywords) => {
-  router.replace({
-    query: { ...route.query, keywords: keywords.length ? keywords.join(',') : undefined }
-  })
-})
-
-const selectedKeywordsByCategory = computed(() => {
-  const byCategory = new Map<ArticleKeywordCategory, string[]>()
-  for (const label of selectedKeywords.value) {
-    const keyword = Object.values(ARTICLE_KEYWORDS).find((k) => k.label === label)
-    if (!keyword) continue
-    byCategory.set(keyword.category, [...(byCategory.get(keyword.category) ?? []), label])
-  }
-  return byCategory
-})
-
-function matchesSelectedCategories(
-  article: (typeof articles)[number],
-  excludedCategory?: ArticleKeywordCategory
-) {
-  for (const [category, labels] of selectedKeywordsByCategory.value) {
-    if (category === excludedCategory) continue
-    if (!article.articleKeywords.some((keyword) => labels.includes(keyword.label))) return false
-  }
-  return true
-}
-
-const filteredArticles = computed(() =>
-  articles.filter((article) => matchesSelectedCategories(article))
-)
-
-const keywordGroups = computed(() =>
-  ARTICLE_KEYWORD_CATEGORIES.map((category) => {
-    const relevantArticles = articles.filter((article) =>
-      matchesSelectedCategories(article, category)
-    )
-    const counts = new Map<string, number>()
-    for (const keyword of relevantArticles.flatMap((article) => article.articleKeywords)) {
-      counts.set(keyword.label, (counts.get(keyword.label) ?? 0) + 1)
-    }
-    return {
-      category,
-      keywords: Object.values(ARTICLE_KEYWORDS)
-        .filter((keyword) => keyword.category === category)
-        .map((keyword) => ({ label: keyword.label, count: counts.get(keyword.label) ?? 0 }))
-    }
-  }).filter((group) => group.keywords.length > 0)
-)
-
-function toggleKeyword(keyword: string) {
-  selectedKeywords.value = selectedKeywords.value.includes(keyword)
-    ? selectedKeywords.value.filter((k) => k !== keyword)
-    : [...selectedKeywords.value, keyword]
-}
 </script>

--- a/src/custom/simplifions/views/articles/ArticlesListView.vue
+++ b/src/custom/simplifions/views/articles/ArticlesListView.vue
@@ -4,12 +4,37 @@
 
 
     <div class="fr-grid-row fr-grid-row--gutters">
-      <div
-        v-for="article in articles"
-        :key="article.slug"
-        class="fr-col-12 fr-col-md-6 fr-col-lg-4"
-      >
-        <ArticleCard :article="article" />
+      <aside class="fr-col-12 fr-col-lg-3">
+        <div v-for="group in keywordGroups" :key="group.category" class="fr-mb-3w">
+          <p class="fr-text--bold fr-mb-1w">{{ group.category }}</p>
+          <ul class="fr-tags-group fr-mb-0">
+            <li v-for="keyword in group.keywords" :key="keyword.label">
+              <button
+                class="fr-tag"
+                :aria-pressed="selectedKeywords.includes(keyword.label)"
+                :disabled="keyword.count === 0"
+                @click="toggleKeyword(keyword.label)"
+              >
+                {{ keyword.label }} ({{ keyword.count }})
+              </button>
+            </li>
+          </ul>
+        </div>
+      </aside>
+
+      <div class="fr-col-12 fr-col-lg-9">
+        <p v-if="filteredArticles.length === 0" class="fr-text--lg">
+          Aucun article ne correspond aux tags sélectionnés.
+        </p>
+        <div v-else class="fr-grid-row fr-grid-row--gutters">
+          <div
+            v-for="article in filteredArticles"
+            :key="article.slug"
+            class="fr-col-12 fr-col-md-6 fr-col-lg-4"
+          >
+            <ArticleCard :article="article" />
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -18,7 +43,7 @@
 <script setup lang="ts">
 import { useCanonicalUrl, useMeta } from '@/utils/seo'
 import ArticleCard from '../../components/article/ArticleCard.vue'
-import { articles } from '../../model/articles'
+import { ARTICLE_KEYWORD_CATEGORIES, ARTICLE_KEYWORDS, articles } from '../../model/articles'
 
 useMeta({
   title: () => 'Articles',
@@ -26,4 +51,32 @@ useMeta({
     'Guides et explications pour comprendre et intégrer les API utiles à la simplification de vos démarches.',
   canonicalUrl: useCanonicalUrl()
 })
+const selectedKeywords = ref<string[]>([])
+
+const keywordGroups = computed(() => {
+  const counts = new Map<string, number>()
+  for (const keyword of articles.flatMap((article) => article.articleKeywords)) {
+    counts.set(keyword.label, (counts.get(keyword.label) ?? 0) + 1)
+  }
+  return ARTICLE_KEYWORD_CATEGORIES.map((category) => ({
+    category,
+    keywords: Object.values(ARTICLE_KEYWORDS)
+      .filter((keyword) => keyword.category === category)
+      .map((keyword) => ({ label: keyword.label, count: counts.get(keyword.label) ?? 0 }))
+  })).filter((group) => group.keywords.length > 0)
+})
+
+const filteredArticles = computed(() =>
+  selectedKeywords.value.length === 0
+    ? articles
+    : articles.filter((article) =>
+        article.articleKeywords.some((keyword) => selectedKeywords.value.includes(keyword.label))
+      )
+)
+
+function toggleKeyword(keyword: string) {
+  selectedKeywords.value = selectedKeywords.value.includes(keyword)
+    ? selectedKeywords.value.filter((k) => k !== keyword)
+    : [...selectedKeywords.value, keyword]
+}
 </script>

--- a/src/custom/simplifions/views/articles/ArticlesListView.vue
+++ b/src/custom/simplifions/views/articles/ArticlesListView.vue
@@ -43,6 +43,7 @@
 <script setup lang="ts">
 import { useCanonicalUrl, useMeta } from '@/utils/seo'
 import ArticleCard from '../../components/article/ArticleCard.vue'
+import type { ArticleKeywordCategory } from '../../model/articles'
 import { ARTICLE_KEYWORD_CATEGORIES, ARTICLE_KEYWORDS, articles } from '../../model/articles'
 
 useMeta({
@@ -65,25 +66,47 @@ watch(selectedKeywords, (keywords) => {
   })
 })
 
-const keywordGroups = computed(() => {
-  const counts = new Map<string, number>()
-  for (const keyword of articles.flatMap((article) => article.articleKeywords)) {
-    counts.set(keyword.label, (counts.get(keyword.label) ?? 0) + 1)
+const selectedKeywordsByCategory = computed(() => {
+  const byCategory = new Map<ArticleKeywordCategory, string[]>()
+  for (const label of selectedKeywords.value) {
+    const keyword = Object.values(ARTICLE_KEYWORDS).find((k) => k.label === label)
+    if (!keyword) continue
+    byCategory.set(keyword.category, [...(byCategory.get(keyword.category) ?? []), label])
   }
-  return ARTICLE_KEYWORD_CATEGORIES.map((category) => ({
-    category,
-    keywords: Object.values(ARTICLE_KEYWORDS)
-      .filter((keyword) => keyword.category === category)
-      .map((keyword) => ({ label: keyword.label, count: counts.get(keyword.label) ?? 0 }))
-  })).filter((group) => group.keywords.length > 0)
+  return byCategory
 })
 
+function matchesSelectedCategories(
+  article: (typeof articles)[number],
+  excludedCategory?: ArticleKeywordCategory
+) {
+  for (const [category, labels] of selectedKeywordsByCategory.value) {
+    if (category === excludedCategory) continue
+    if (!article.articleKeywords.some((keyword) => labels.includes(keyword.label))) return false
+  }
+  return true
+}
+
 const filteredArticles = computed(() =>
-  selectedKeywords.value.length === 0
-    ? articles
-    : articles.filter((article) =>
-        article.articleKeywords.some((keyword) => selectedKeywords.value.includes(keyword.label))
-      )
+  articles.filter((article) => matchesSelectedCategories(article))
+)
+
+const keywordGroups = computed(() =>
+  ARTICLE_KEYWORD_CATEGORIES.map((category) => {
+    const relevantArticles = articles.filter((article) =>
+      matchesSelectedCategories(article, category)
+    )
+    const counts = new Map<string, number>()
+    for (const keyword of relevantArticles.flatMap((article) => article.articleKeywords)) {
+      counts.set(keyword.label, (counts.get(keyword.label) ?? 0) + 1)
+    }
+    return {
+      category,
+      keywords: Object.values(ARTICLE_KEYWORDS)
+        .filter((keyword) => keyword.category === category)
+        .map((keyword) => ({ label: keyword.label, count: counts.get(keyword.label) ?? 0 }))
+    }
+  }).filter((group) => group.keywords.length > 0)
 )
 
 function toggleKeyword(keyword: string) {

--- a/src/custom/simplifions/views/articles/ArticlesListView.vue
+++ b/src/custom/simplifions/views/articles/ArticlesListView.vue
@@ -2,14 +2,42 @@
   <div class="fr-container fr-py-8v">
     <h1>Articles</h1>
 
-
     <div class="fr-grid-row fr-grid-row--gutters">
-      <div
-        v-for="article in articles"
-        :key="article.slug"
-        class="fr-col-12 fr-col-md-6 fr-col-lg-4"
-      >
-        <ArticleCard :article="article" />
+      <aside class="fr-col-12 fr-col-lg-3">
+        <div
+          v-for="group in keywordGroups"
+          :key="group.category"
+          class="fr-mb-3w"
+        >
+          <p class="fr-text--bold fr-mb-1w">{{ group.category }}</p>
+          <ul class="fr-tags-group fr-mb-0">
+            <li v-for="keyword in group.keywords" :key="keyword.label">
+              <button
+                class="fr-tag"
+                :aria-pressed="selectedKeywords.includes(keyword.label)"
+                :disabled="keyword.count === 0"
+                @click="toggleKeyword(keyword.label)"
+              >
+                {{ keyword.label }} ({{ keyword.count }})
+              </button>
+            </li>
+          </ul>
+        </div>
+      </aside>
+
+      <div class="fr-col-12 fr-col-lg-9">
+        <p v-if="filteredArticles.length === 0" class="fr-text--lg">
+          Aucun article ne correspond aux tags sélectionnés.
+        </p>
+        <div v-else class="fr-grid-row fr-grid-row--gutters">
+          <div
+            v-for="article in filteredArticles"
+            :key="article.slug"
+            class="fr-col-12 fr-col-md-6 fr-col-lg-4"
+          >
+            <ArticleCard :article="article" />
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -18,7 +46,12 @@
 <script setup lang="ts">
 import { useCanonicalUrl, useMeta } from '@/utils/seo'
 import ArticleCard from '../../components/article/ArticleCard.vue'
-import { articles } from '../../model/articles'
+import type { ArticleKeywordCategory } from '../../model/articles'
+import {
+  ARTICLE_KEYWORD_CATEGORIES,
+  ARTICLE_KEYWORDS,
+  articles
+} from '../../model/articles'
 
 useMeta({
   title: () => 'Articles',
@@ -26,4 +59,84 @@ useMeta({
     'Guides et explications pour comprendre et intégrer les API utiles à la simplification de vos démarches.',
   canonicalUrl: useCanonicalUrl()
 })
+
+const route = useRoute()
+const router = useRouter()
+
+const selectedKeywords = ref<string[]>(
+  typeof route.query.keywords === 'string'
+    ? route.query.keywords.split(',')
+    : []
+)
+
+watch(selectedKeywords, (keywords) => {
+  router.replace({
+    query: {
+      ...route.query,
+      keywords: keywords.length ? keywords.join(',') : undefined
+    }
+  })
+})
+
+const selectedKeywordsByCategory = computed(() => {
+  const byCategory = new Map<ArticleKeywordCategory, string[]>()
+  for (const label of selectedKeywords.value) {
+    const keyword = Object.values(ARTICLE_KEYWORDS).find(
+      (k) => k.label === label
+    )
+    if (!keyword) continue
+    byCategory.set(keyword.category, [
+      ...(byCategory.get(keyword.category) ?? []),
+      label
+    ])
+  }
+  return byCategory
+})
+
+function matchesSelectedCategories(
+  article: (typeof articles)[number],
+  excludedCategory?: ArticleKeywordCategory
+) {
+  for (const [category, labels] of selectedKeywordsByCategory.value) {
+    if (category === excludedCategory) continue
+    if (
+      !article.articleKeywords.some((keyword) => labels.includes(keyword.label))
+    )
+      return false
+  }
+  return true
+}
+
+const filteredArticles = computed(() =>
+  articles.filter((article) => matchesSelectedCategories(article))
+)
+
+const keywordGroups = computed(() =>
+  ARTICLE_KEYWORD_CATEGORIES.map((category) => {
+    const relevantArticles = articles.filter((article) =>
+      matchesSelectedCategories(article, category)
+    )
+    const counts = new Map<string, number>()
+    for (const keyword of relevantArticles.flatMap(
+      (article) => article.articleKeywords
+    )) {
+      counts.set(keyword.label, (counts.get(keyword.label) ?? 0) + 1)
+    }
+    return {
+      category,
+      keywords: Object.values(ARTICLE_KEYWORDS)
+        .filter((keyword) => keyword.category === category)
+        .map((keyword) => ({
+          label: keyword.label,
+          count: counts.get(keyword.label) ?? 0
+        }))
+    }
+  }).filter((group) => group.keywords.length > 0)
+)
+
+function toggleKeyword(keyword: string) {
+  selectedKeywords.value = selectedKeywords.value.includes(keyword)
+    ? selectedKeywords.value.filter((k) => k !== keyword)
+    : [...selectedKeywords.value, keyword]
+}
 </script>


### PR DESCRIPTION
Les mots clés permettent de filtrer les articles. Avec un OR dans les catégories, et un AND entre catégories.
Les filtres apparaissent dans l'URL : 

<img width="1465" height="815" alt="image" src="https://github.com/user-attachments/assets/6bae5b48-59ab-4046-8d57-c3153329a3d9" />

<img width="1389" height="743" alt="image" src="https://github.com/user-attachments/assets/a92a1462-42c2-49a0-829d-027f8041ef9c" />
