### PR TITLE
[Simplifions] Retire informations non requises des cartes cas usages et solutions

### DIFF
--- a/configs/simplifions/config.yaml
+++ b/configs/simplifions/config.yaml
@@ -225,7 +225,7 @@ shared_filter_values:
     - id: logiciel-metier
       name: Logiciel métier "clé en main"
     - id: portail-consultation
-      name: Portail de consultation
+      name: Site de consultation
 
   types_de_simplification: &types_de_simplification_values
     - id: proactivite

--- a/configs/simplifions/config.yaml
+++ b/configs/simplifions/config.yaml
@@ -220,10 +220,10 @@ shared_filter_values:
       name: Associations
 
   categorie_de_solution: &categorie_de_solution_values
+    - id: brique-technique
+      name: API, base de donnée ou brique logicielle
     - id: logiciel-metier
       name: Logiciel métier "clé en main"
-    - id: brique-technique
-      name: Brique technique
     - id: portail-consultation
       name: Portail de consultation
 

--- a/configs/simplifions/config.yaml
+++ b/configs/simplifions/config.yaml
@@ -229,11 +229,11 @@ shared_filter_values:
 
   types_de_simplification: &types_de_simplification_values
     - id: proactivite
-      name: 💠💠💠 Proactivité | L'usager n'a plus de démarche à faire
+      name: Proactivité
     - id: dlnuf
-      name: 💠💠 Dites-le nous une fois | L'usager n'a plus à fournir de justificatifs
+      name: Dites-le nous une fois
     - id: acces-facile
-      name: 💠 Accès facile | L'usager ou l'agent trouve l'information
+      name: Accès facile
 
 pages:
   # CAS D'USAGES

--- a/cypress/e2e/custom/simplifions/solutions_integratices.cy.ts
+++ b/cypress/e2e/custom/simplifions/solutions_integratices.cy.ts
@@ -253,9 +253,9 @@ describe('Solutions intégratrices block', () => {
     })
 
     cy.contains('button[role="tab"]', 'Logiciels métiers').should('exist')
-    cy.contains('button[role="tab"]', 'Briques techniques').should('exist')
+    cy.contains('button[role="tab"]', 'API, base de donnée ou brique logicielle').should('exist')
 
-    cy.contains('button[role="tab"]', 'Briques techniques').click()
+    cy.contains('button[role="tab"]', 'API, base de donnée ou brique logicielle').click()
     cy.get('.fr-tabs__panel')
       .filter(':visible')
       .find('.integrateur-card')
@@ -282,13 +282,13 @@ describe('Solutions intégratrices block', () => {
     })
 
     // Navigate to the second tab
-    cy.contains('button[role="tab"]', 'Briques techniques').click()
+    cy.contains('button[role="tab"]', 'API, base de donnée ou brique logicielle').click()
     cy.get('.integrateur-card').should('contain.text', 'Brique A')
 
     // Apply a filter that removes all solutions with fewer APIs, hiding Logiciel métier tab
     cy.get('#min-apis').select('Au moins 3')
 
-    // First (and only) tab should now be Briques techniques
+    // First (and only) tab should now be API, base de donnée ou brique logicielle
     cy.contains('button[role="tab"]', 'Logiciels métiers').should('not.exist')
     cy.get('.fr-tabs__panel')
       .filter(':visible')

--- a/cypress/e2e/custom/simplifions/solutions_integratices.cy.ts
+++ b/cypress/e2e/custom/simplifions/solutions_integratices.cy.ts
@@ -253,9 +253,15 @@ describe('Solutions intégratrices block', () => {
     })
 
     cy.contains('button[role="tab"]', 'Logiciels métiers').should('exist')
-    cy.contains('button[role="tab"]', 'API, base de donnée ou brique logicielle').should('exist')
+    cy.contains(
+      'button[role="tab"]',
+      'API, base de donnée ou brique logicielle'
+    ).should('exist')
 
-    cy.contains('button[role="tab"]', 'API, base de donnée ou brique logicielle').click()
+    cy.contains(
+      'button[role="tab"]',
+      'API, base de donnée ou brique logicielle'
+    ).click()
     cy.get('.fr-tabs__panel')
       .filter(':visible')
       .find('.integrateur-card')
@@ -282,7 +288,10 @@ describe('Solutions intégratrices block', () => {
     })
 
     // Navigate to the second tab
-    cy.contains('button[role="tab"]', 'API, base de donnée ou brique logicielle').click()
+    cy.contains(
+      'button[role="tab"]',
+      'API, base de donnée ou brique logicielle'
+    ).click()
     cy.get('.integrateur-card').should('contain.text', 'Brique A')
 
     // Apply a filter that removes all solutions with fewer APIs, hiding Logiciel métier tab

--- a/cypress/support/factories/custom/simplifions/grist_factory.ts
+++ b/cypress/support/factories/custom/simplifions/grist_factory.ts
@@ -25,7 +25,6 @@ export const gristCasUsageFactory = build<CasUsageRecord>({
       Nom_complet: sequence((x) => `🧑‍💼 Cas d'usage ${x}`),
       Pour_simplifier_les_demarches_de: [1, 2],
       Recommandations: [1, 2, 3],
-      Types_de_simplification: [1, 2],
       Visible_sur_simplifions: true
     }
   }
@@ -91,7 +90,6 @@ export const solutionFactory = build<SolutionRecord>({
       Prix: '',
       Public_ou_prive: sequence((x) => (x % 2 === 0 ? 'Public' : 'Privé')),
       Site_internet: sequence((x) => `https://solution${x}.example.com`),
-      Types_de_simplification: [1, 2],
       Visible_sur_simplifions: true,
       Recommande_pour_les_cas_d_usages: [1, 2],
       Type_de_solution: ['Éditeur'],

--- a/public/static/simplifions/pages/about.md
+++ b/public/static/simplifions/pages/about.md
@@ -6,7 +6,7 @@
 
 - **des <a class="fr-link" href="/cas-d-usages">cas d'usages</a>** : il s'agit des démarches des particuliers, entreprises et associations qui peuvent être facilitées grâce à l'utilisation de la donnée ;
 - **les API et les jeux de données** qui répondent aux besoins du cas d'usage ;
-- **les solutions** (logiciels métiers clés en main, briques techniques ou portails de consultation) qui permettent d'accéder à ces données pour simplifier les cas d'usages.
+- **les solutions** (logiciels métiers clés en main, briques logicielles ou sites de consultation) qui permettent d'accéder à ces données pour simplifier les cas d'usages.
 
 <h2 id="niveau-1-acces-facile" class="fr-h4 fr-my-0w">Le contenu est rédigé :</h2>
 

--- a/public/static/simplifions/pages/doctrine-referencement-solutions.md
+++ b/public/static/simplifions/pages/doctrine-referencement-solutions.md
@@ -58,7 +58,7 @@
                         <li><span style="background-color: #bfd9e3ff; padding: 2px; border-radius: 4px;"><b>OUI</b></span> <span style="background-color: #e7e7e7ff; padding: 2px; border-radius: 4px;">⬇️ Question suivante</span>
                         <br/>
                         <p class="fr-text--sm ">
-                        Si ce produit remplit les critères de référencement suivants, le niveau de simplification indiqué sera <b>Accès facile</b>, et non les niveaux supérieurs DLNUF ou proactivité. Il s'agit souvent de portails de consultation de données.
+                        Si ce produit remplit les critères de référencement suivants, le niveau de simplification indiqué sera <b>Accès facile</b>, et non les niveaux supérieurs DLNUF ou proactivité. Il s'agit souvent de sites de consultation de données.
                         </p>
                         </li>
                     </ul>

--- a/public/static/simplifions/pages/doctrine-referencement-solutions.md
+++ b/public/static/simplifions/pages/doctrine-referencement-solutions.md
@@ -58,7 +58,7 @@
                         <li><span style="background-color: #bfd9e3ff; padding: 2px; border-radius: 4px;"><b>OUI</b></span> <span style="background-color: #e7e7e7ff; padding: 2px; border-radius: 4px;">⬇️ Question suivante</span>
                         <br/>
                         <p class="fr-text--sm ">
-                        Si ce produit remplit les critères de référencement suivants, le niveau de simplification indiqué sera <b>💠 Accès facile</b>, et non les niveaux supérieurs DLNUF ou proactivité. Il s'agit souvent de portails de consultation de données.
+                        Si ce produit remplit les critères de référencement suivants, le niveau de simplification indiqué sera <b>Accès facile</b>, et non les niveaux supérieurs DLNUF ou proactivité. Il s'agit souvent de portails de consultation de données.
                         </p>
                         </li>
                     </ul>

--- a/public/static/simplifions/pages/niveaux-simplification.md
+++ b/public/static/simplifions/pages/niveaux-simplification.md
@@ -11,20 +11,20 @@
 <nav class="fr-summary" role="navigation" aria-labelledby="fr-summary-title">
   <ol>
       <li>
-          <a class="fr-summary__link" id="summary-link-2" href="#niveau-1-acces-facile">Niveau 1 : 💠 Accès facile</a>
+          <a class="fr-summary__link" id="summary-link-2" href="#niveau-1-acces-facile">Niveau 1 : Accès facile</a>
       </li>
       <li>
-          <a class="fr-summary__link" id="summary-link-2" href="#niveau-2-dlnuf">Niveau 2 : 💠💠 Dites-le-nous une fois</a>
+          <a class="fr-summary__link" id="summary-link-2" href="#niveau-2-dlnuf">Niveau 2 : Dites-le-nous une fois</a>
       </li>
       <li>
-          <a class="fr-summary__link" id="summary-link-2" href="#niveau-3-proactivite">Niveau 3 : 💠💠💠 Proactivité</a>
+          <a class="fr-summary__link" id="summary-link-2" href="#niveau-3-proactivite">Niveau 3 : Proactivité</a>
       </li>
   </ol>
 </nav>
 </div>
 </div>
 
-<h2 id="niveau-1-acces-facile" class="fr-h2 fr-my-0w" style="color: black; background-color: rgb(167, 212, 205); padding: 2px 4px; display: inline-block;">💠 Accès facile</h2>
+<h2 id="niveau-1-acces-facile" class="fr-h2 fr-my-0w" style="color: black; background-color: rgb(167, 212, 205); padding: 2px 4px; display: inline-block;">Accès facile</h2>
 
 <p class="fr-text--lead"><b>L'agent trouve facilement l'information</b></p>
 
@@ -32,9 +32,9 @@ Une première étape pour simplifier les démarches des usagers consiste à **re
 
 Les solutions de niveau 1 reférencées sur ce site sont fréquemment des portails d'accès aux données ou des annuaires.
 
-<a class="fr-btn" href="/cas-d-usages?types-de-simplification=acces-facile#list">Cas d'usages de niveau 1 💠</a> <a class="fr-ml-1w fr-btn fr-btn fr-btn--secondary" href="/solutions?types-de-simplification=acces-facile#list"> Solutions de niveau 1 💠</a>
+<a class="fr-btn" href="/cas-d-usages?types-de-simplification=acces-facile#list">Cas d'usages de niveau 1 </a> <a class="fr-ml-1w fr-btn fr-btn fr-btn--secondary" href="/solutions?types-de-simplification=acces-facile#list"> Solutions de niveau 1</a>
 
-<h2 id="niveau-2-dlnuf" class="fr-h2 fr-my-0w" style="color: black; background-color: rgb(167, 212, 205); padding: 2px 4px; display: inline-block;">💠💠 Dites-le-nous une fois</h2>
+<h2 id="niveau-2-dlnuf" class="fr-h2 fr-my-0w" style="color: black; background-color: rgb(167, 212, 205); padding: 2px 4px; display: inline-block;">Dites-le-nous une fois</h2>
 
 <p class="fr-text--lead"><b>L'usager n'a plus à fournir de justificatifs</b></p>
 
@@ -46,9 +46,9 @@ Contrairement au niveau 1, qui facilite principalement le travail des agents pub
 
 Les solutions de niveau 2 sont donc fréquemment des API ou des logiciels/formulaires en ligne intégrant des API ou des jeux de données.
 
-<a class="fr-btn" href="/cas-d-usages?types-de-simplification=dlnuf#list">Cas d'usages de niveau 2 💠💠</a> <a class="fr-ml-1w fr-btn fr-btn fr-btn--secondary" href="/solutions?types-de-simplification=dlnuf#list">Solutions de niveau 2 💠💠</a>
+<a class="fr-btn" href="/cas-d-usages?types-de-simplification=dlnuf#list">Cas d'usages de niveau 2</a> <a class="fr-ml-1w fr-btn fr-btn fr-btn--secondary" href="/solutions?types-de-simplification=dlnuf#list">Solutions de niveau 2</a>
 
-<h2 id="niveau-3-proactivite" class="fr-h2 fr-my-0w" style="color: black; background-color: rgb(167, 212, 205); padding: 2px 4px; display: inline-block;">💠💠💠 Proactivité</h2>
+<h2 id="niveau-3-proactivite" class="fr-h2 fr-my-0w" style="color: black; background-color: rgb(167, 212, 205); padding: 2px 4px; display: inline-block;">Proactivité</h2>
 
 <p class="fr-text--lead"><b>L'usager n'a plus de démarche à faire</b></p>
 
@@ -62,4 +62,4 @@ Pour terminer, le niveau 3 consiste presque à supprimer la démarche. Par l'ana
 
 Les solutions de niveau 3 sont donc fréquemment des API, des fichiers de données, ou des logiciels permettant la circulation de la donnée en temps réel entre les administrations.
 
-<a class="fr-btn" href="/cas-d-usages?types-de-simplification=proactivite#list">Cas d'usages de niveau 3 💠💠💠</a> <a class="fr-ml-1w fr-btn fr-btn fr-btn--secondary" href="/solutions?types-de-simplification=proactivite#list">Solutions de niveau 3 💠💠💠</a>
+<a class="fr-btn" href="/cas-d-usages?types-de-simplification=proactivite#list">Cas d'usages de niveau 3</a> <a class="fr-ml-1w fr-btn fr-btn fr-btn--secondary" href="/solutions?types-de-simplification=proactivite#list">Solutions de niveau 3</a>

--- a/src/custom/simplifions/components/SimplifionsCasDusageCard.vue
+++ b/src/custom/simplifions/components/SimplifionsCasDusageCard.vue
@@ -30,8 +30,6 @@
           :page-key="pageKey"
           :show-target-users="showTargetUsers"
           :show-fournisseurs="showFournisseurs"
-          :hide-simplification="!showSimplificationTags"
-          :show-categorie-de-solution="showCategorieDeSolution"
         />
         <div v-if="showArrow" class="card-arrow" aria-hidden="true">
           <span class="fr-icon-arrow-right-line" />
@@ -55,8 +53,6 @@ const props = withDefaults(
     showDescription?: boolean
     showTargetUsers?: boolean
     showFournisseurs?: boolean
-    showSimplificationTags?: boolean
-    showCategorieDeSolution?: boolean
     showArrow?: boolean
   }>(),
   {
@@ -64,8 +60,6 @@ const props = withDefaults(
     showDescription: true,
     showTargetUsers: true,
     showFournisseurs: true,
-    showSimplificationTags: true,
-    showCategorieDeSolution: true,
     showArrow: false
   }
 )
@@ -79,11 +73,7 @@ const pageKey = computed(
 )
 
 const hasDetails = computed(
-  () =>
-    props.showTargetUsers ||
-    props.showFournisseurs ||
-    props.showSimplificationTags ||
-    props.showCategorieDeSolution
+  () => props.showTargetUsers || props.showFournisseurs
 )
 </script>
 

--- a/src/custom/simplifions/components/SimplifionsReco.vue
+++ b/src/custom/simplifions/components/SimplifionsReco.vue
@@ -170,30 +170,30 @@
           </template>
         </SimplifionsRecoIntegratingSolutionsAccordion>
 
-      <SimplifionsRecoIntegratingSolutionsAccordion
-        title="Via un site de consultation"
-        solution-kind="portail"
-        :solutions="integratingSolutionsPortailsConsultation"
-        :integration-score-per-solution="integrationScorePerSolution"
-        :nom-fournisseur="recommandation.Nom_de_la_recommandation"
-        :type-label="typeLabel"
-      >
-        <p>
-          <b
-            >Ces sites vous permettent de consulter certaines des données utiles
-            pour ce cas d'usage :</b
-          >
-        </p>
-        <div class="fr-m-2w fr-highlight--orange-terre-battue fr-highlight">
-          <p class="fr-mb-0">
-            💡 Pour vraiment simplifier la vie des usagers, l'intégration
-            directe de cette API ou de jeu de données dans vos logiciels métiers
-            est à privilégier car elle permet de mettre en oeuvre le
-            <i>dites-le-nous une fois</i> et la proactivité !
+        <SimplifionsRecoIntegratingSolutionsAccordion
+          title="Via un site de consultation"
+          solution-kind="portail"
+          :solutions="integratingSolutionsPortailsConsultation"
+          :integration-score-per-solution="integrationScorePerSolution"
+          :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+          :type-label="typeLabel"
+        >
+          <p>
+            <b
+              >Ces sites vous permettent de consulter certaines des données utiles
+              pour ce cas d'usage :</b
+            >
           </p>
-        </div>
-      </SimplifionsRecoIntegratingSolutionsAccordion>
-    </DsfrAccordionsGroup>
+          <div class="fr-m-2w fr-highlight--orange-terre-battue fr-highlight">
+            <p class="fr-mb-0">
+              💡 Pour vraiment simplifier la vie des usagers, l'intégration
+              directe de cette API ou de jeu de données dans vos logiciels métiers
+              est à privilégier car elle permet de mettre en oeuvre le
+              <i>dites-le-nous une fois</i> et la proactivité !
+            </p>
+          </div>
+        </SimplifionsRecoIntegratingSolutionsAccordion>
+      </DsfrAccordionsGroup>
 
     <p class="fr-text--sm fr-mx-2w fr-mt-2w">
       <i

--- a/src/custom/simplifions/components/SimplifionsReco.vue
+++ b/src/custom/simplifions/components/SimplifionsReco.vue
@@ -180,28 +180,29 @@
         >
           <p>
             <b
-              >Ces sites vous permettent de consulter certaines des données utiles
-              pour ce cas d'usage :</b
+              >Ces sites vous permettent de consulter certaines des données
+              utiles pour ce cas d'usage :</b
             >
           </p>
           <div class="fr-m-2w fr-highlight--orange-terre-battue fr-highlight">
             <p class="fr-mb-0">
               💡 Pour vraiment simplifier la vie des usagers, l'intégration
-              directe de cette API ou de jeu de données dans vos logiciels métiers
-              est à privilégier car elle permet de mettre en oeuvre le
+              directe de cette API ou de jeu de données dans vos logiciels
+              métiers est à privilégier car elle permet de mettre en oeuvre le
               <i>dites-le-nous une fois</i> et la proactivité !
             </p>
           </div>
         </SimplifionsRecoIntegratingSolutionsAccordion>
       </DsfrAccordionsGroup>
 
-    <p class="fr-text--sm fr-mx-2w fr-mt-2w">
-      <i
-        >Une solution intégrant
-        «&nbsp;{{ recommandation.Nom_de_la_recommandation }}&nbsp;», n'est pas listée ?
-      </i>
-      <a href="#modification-contenu">✒️ Proposez-nous de l'ajouter</a>.
-    </p>
+      <p class="fr-text--sm fr-mx-2w fr-mt-2w">
+        <i
+          >Une solution intégrant «&nbsp;{{
+            recommandation.Nom_de_la_recommandation
+          }}&nbsp;», n'est pas listée ?
+        </i>
+        <a href="#modification-contenu">✒️ Proposez-nous de l'ajouter</a>.
+      </p>
     </div>
   </div>
 </template>

--- a/src/custom/simplifions/components/SimplifionsReco.vue
+++ b/src/custom/simplifions/components/SimplifionsReco.vue
@@ -170,39 +170,38 @@
           </template>
         </SimplifionsRecoIntegratingSolutionsAccordion>
 
-        <SimplifionsRecoIntegratingSolutionsAccordion
-          title="Via un portail de consultation"
-          solution-kind="portail"
-          :solutions="integratingSolutionsPortailsConsultation"
-          :integration-score-per-solution="integrationScorePerSolution"
-          :nom-fournisseur="recommandation.Nom_de_la_recommandation"
-          :type-label="typeLabel"
-        >
-          <p>
-            <b
-              >Ces sites vous permettent de consulter certaines des données
-              utiles pour ce cas d'usage :</b
-            >
+      <SimplifionsRecoIntegratingSolutionsAccordion
+        title="Via un site de consultation"
+        solution-kind="portail"
+        :solutions="integratingSolutionsPortailsConsultation"
+        :integration-score-per-solution="integrationScorePerSolution"
+        :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+        :type-label="typeLabel"
+      >
+        <p>
+          <b
+            >Ces sites vous permettent de consulter certaines des données utiles
+            pour ce cas d'usage :</b
+          >
+        </p>
+        <div class="fr-m-2w fr-highlight--orange-terre-battue fr-highlight">
+          <p class="fr-mb-0">
+            💡 Pour vraiment simplifier la vie des usagers, l'intégration
+            directe de cette API ou de jeu de données dans vos logiciels métiers
+            est à privilégier car elle permet de mettre en oeuvre le
+            <i>dites-le-nous une fois</i> et la proactivité !
           </p>
-          <div class="fr-m-2w fr-highlight--orange-terre-battue fr-highlight">
-            <p class="fr-mb-0">
-              💡 Pour vraiment simplifier la vie des usagers, l'intégration
-              directe de cette API ou de jeu de données dans vos logiciels
-              métiers est à privilégier car elle permet de mettre en oeuvre le
-              <i>dites-le-nous une fois</i> et la proactivité !
-            </p>
-          </div>
-        </SimplifionsRecoIntegratingSolutionsAccordion>
-      </DsfrAccordionsGroup>
+        </div>
+      </SimplifionsRecoIntegratingSolutionsAccordion>
+    </DsfrAccordionsGroup>
 
-      <p class="fr-text--sm fr-mx-2w fr-mt-2w">
-        <i
-          >Une solution intégrant «&nbsp;{{
-            recommandation.Nom_de_la_recommandation
-          }}&nbsp;», n'est pas listée ?
-        </i>
-        <a href="#modification-contenu">✒️ Proposez-nous de l'ajouter</a>.
-      </p>
+    <p class="fr-text--sm fr-mx-2w fr-mt-2w">
+      <i
+        >Une solution intégrant
+        «&nbsp;{{ recommandation.Nom_de_la_recommandation }}&nbsp;», n'est pas listée ?
+      </i>
+      <a href="#modification-contenu">✒️ Proposez-nous de l'ajouter</a>.
+    </p>
     </div>
   </div>
 </template>

--- a/src/custom/simplifions/components/SimplifionsRecoIntegratingSolutionsAccordion.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoIntegratingSolutionsAccordion.vue
@@ -105,9 +105,9 @@ const SOLUTION_KIND_CONFIG: Record<
   },
   portail: {
     icon: 'fr-icon-seo-fill',
-    emptyLabel: 'Aucun portail',
-    singular: 'portail',
-    plural: 'portails'
+    emptyLabel: 'Aucun site',
+    singular: 'site',
+    plural: 'sites'
   }
 }
 

--- a/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
@@ -114,7 +114,6 @@ const colorClass = computed(() => {
   if (pct >= 25) return 'indicator--orange'
   return 'indicator--red'
 })
-
 </script>
 
 <style scoped>

--- a/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoSolutionsIntegratricesCard.vue
@@ -14,21 +14,6 @@
           <h3 class="solution-integratrice-card__title fr-text--lg">
             {{ solution.fields.Nom }}
           </h3>
-          <!-- Simplification tags (diamonds) with tag styling -->
-          <div
-            v-if="simplificationTags.length"
-            class="fr-tags-group simplification-diamonds"
-          >
-            <p
-              v-for="tag in simplificationTags"
-              :key="tag.id"
-              class="fr-tag fr-tag--sm fr-m-0"
-              :aria-label="tag.name"
-              :title="tag.name"
-            >
-              {{ getShortLabelSimplificationTag(tag.name) }}
-            </p>
-          </div>
         </div>
         <SimplifionsSolutionOperateurTag :grist-solution="solution.fields" />
       </div>
@@ -99,7 +84,6 @@
 <script setup lang="ts">
 import TooltipWrapper from '@/components/TooltipWrapper.vue'
 import type { Topic } from '@/model/topic'
-import { useTagsByRef } from '@/utils/tags'
 import type { SolutionRecord } from '../model/grist'
 import TopicsAPI from '../simplifionsTopicsApi'
 import SimplifionsSolutionOperateurTag from './SimplifionsSolutionOperateurTag.vue'
@@ -121,12 +105,6 @@ topicsAPI.getTopicByTag(solutionTag).then((topic) => {
 
 const datagouvSlug = computed(() => solutionTopic.value?.slug)
 
-const topicTags = useTagsByRef('solutions', solutionTopic)
-
-const simplificationTags = computed(() => {
-  return topicTags.value.filter((tag) => tag.type === 'types-de-simplification')
-})
-
 const colorClass = computed(() => {
   if (!props.integrationScore) return ''
   const { integratedCount, totalCount } = props.integrationScore
@@ -137,12 +115,6 @@ const colorClass = computed(() => {
   return 'indicator--red'
 })
 
-const getShortLabelSimplificationTag = (name: string) => {
-  if (name.includes('Accès facile')) return '💠'
-  if (name.includes('Dites-le nous une fois')) return '💠💠'
-  if (name.toLowerCase().includes('proactivité')) return '💠💠💠'
-  return name
-}
 </script>
 
 <style scoped>
@@ -187,10 +159,6 @@ const getShortLabelSimplificationTag = (name: string) => {
   margin: 0;
 }
 
-.simplification-diamonds {
-  margin-left: auto;
-}
-
 .solution-integratrice-card__arrow {
   position: absolute;
   bottom: 1rem;
@@ -204,15 +172,6 @@ const getShortLabelSimplificationTag = (name: string) => {
 .integration-indicator__label {
   line-height: 0.1;
   margin-bottom: 0;
-}
-
-.fr-tags-group {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
 }
 
 @media (max-width: 767px) {

--- a/src/custom/simplifions/components/SimplifionsSolutionCard.vue
+++ b/src/custom/simplifions/components/SimplifionsSolutionCard.vue
@@ -28,8 +28,6 @@
               :page-key="pageKey"
               :show-target-users="showTargetUsers"
               :show-fournisseurs="showFournisseurs"
-              :hide-simplification="!showSimplificationTags"
-              :show-categorie-de-solution="showCategorieDeSolution"
             />
             <div v-if="showArrow" class="card-arrow" aria-hidden="true">
               <span class="fr-icon-arrow-right-line" />
@@ -77,8 +75,6 @@ const props = withDefaults(
     showOperateurTag?: boolean
     showTargetUsers?: boolean
     showFournisseurs?: boolean
-    showSimplificationTags?: boolean
-    showCategorieDeSolution?: boolean
     showArrow?: boolean
   }>(),
   {
@@ -88,8 +84,6 @@ const props = withDefaults(
     showOperateurTag: true,
     showTargetUsers: true,
     showFournisseurs: true,
-    showSimplificationTags: true,
-    showCategorieDeSolution: true,
     showArrow: false
   }
 )

--- a/src/custom/simplifions/components/SimplifionsSolutionDescription.vue
+++ b/src/custom/simplifions/components/SimplifionsSolutionDescription.vue
@@ -16,11 +16,7 @@
           {{ topic.description }}
         </p>
 
-        <SimplifionsTags
-          :topic="topic"
-          :page-key="pageKey"
-          :hide-simplification="true"
-        />
+        <SimplifionsTags :topic="topic" :page-key="pageKey" />
 
         <ul class="fr-mt-4w">
           <li>

--- a/src/custom/simplifions/components/SimplifionsSolutionIntegrateursTabs.vue
+++ b/src/custom/simplifions/components/SimplifionsSolutionIntegrateursTabs.vue
@@ -128,14 +128,14 @@ const tabTitles = computed(() => {
   const titles = []
   if (filteredLogicielsMetiers.value.length > 0) {
     titles.push({
-      title: `Logiciels métiers (${filteredLogicielsMetiers.value.length}) 💠💠💠`,
+      title: `Logiciels métiers (${filteredLogicielsMetiers.value.length})`,
       tabId: 'tab-logiciel-metier',
       panelId: 'tab-content-logiciel-metier'
     })
   }
   if (filteredBriquesTechniques.value.length > 0) {
     titles.push({
-      title: `Briques techniques (${filteredBriquesTechniques.value.length}) 💠💠💠`,
+      title: `API, base de donnée ou brique logicielle (${filteredBriquesTechniques.value.length})`,
       tabId: 'tab-brique-technique',
       panelId: 'tab-content-brique-technique'
     })

--- a/src/custom/simplifions/components/SimplifionsSolutionIntegrateursTabs.vue
+++ b/src/custom/simplifions/components/SimplifionsSolutionIntegrateursTabs.vue
@@ -142,7 +142,7 @@ const tabTitles = computed(() => {
   }
   if (filteredPortailsConsultation.value.length > 0) {
     titles.push({
-      title: `Portails de consultation (${filteredPortailsConsultation.value.length})`,
+      title: `Sites de consultation (${filteredPortailsConsultation.value.length})`,
       tabId: 'tab-portail-consultation',
       panelId: 'tab-content-portail-consultation'
     })

--- a/src/custom/simplifions/components/SimplifionsTags.vue
+++ b/src/custom/simplifions/components/SimplifionsTags.vue
@@ -22,32 +22,10 @@
         <HumanReadableList :items="orderedFournisseursDeService" />
       </p>
     </div>
-    <!-- Tags indiquant le type de simplification et de budget -->
-    <div
-      v-if="!props.hideSimplification && groupedTags['types-de-simplification']"
-      class="simplification-group fr-mt-2w"
-    >
-      <ul class="fr-badges-group">
-        <li v-for="t in groupedTags['types-de-simplification']" :key="t.id">
-          <TagComponent :tag="t" />
-        </li>
-      </ul>
-    </div>
-    <div
-      v-if="showCategorieDeSolution && groupedTags['categorie-de-solution']"
-      class="categorie-de-solution-group"
-    >
-      <ul class="fr-badges-group">
-        <li v-for="t in groupedTags['categorie-de-solution']" :key="t.id">
-          <TagComponent :tag="t" />
-        </li>
-      </ul>
-    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import TagComponent from '@/components/TagComponent.vue'
 import { useTagsByRef } from '@/utils/tags'
 import type { TopicCasUsage, TopicSolution } from '../model/topics'
 import HumanReadableList from './HumanReadableList.vue'
@@ -56,13 +34,10 @@ const props = withDefaults(
   defineProps<{
     topic: TopicCasUsage | TopicSolution
     pageKey: string
-    showCategorieDeSolution?: boolean
-    hideSimplification?: boolean
     showTargetUsers?: boolean
     showFournisseurs?: boolean
   }>(),
   {
-    showCategorieDeSolution: true,
     showTargetUsers: true,
     showFournisseurs: true
   }

--- a/src/custom/simplifions/components/article/SimplifionsArticleRelatedTopics.vue
+++ b/src/custom/simplifions/components/article/SimplifionsArticleRelatedTopics.vue
@@ -20,7 +20,6 @@
             :show-description="false"
             :show-image="true"
             :show-fournisseurs="false"
-            :show-simplification-tags="false"
           />
           <SimplifionsCasDusageCard
             v-else
@@ -28,7 +27,6 @@
             :page-key="entry.pageKey"
             :show-description="false"
             :show-fournisseurs="false"
-            :show-simplification-tags="false"
           />
         </li>
       </CarouselTrack>

--- a/src/custom/simplifions/components/article/SimplifionsArticleTopicSpotlight.vue
+++ b/src/custom/simplifions/components/article/SimplifionsArticleTopicSpotlight.vue
@@ -21,8 +21,6 @@
           :show-operateur-tag="showOperateurTag"
           :show-target-users="showTargetUsers"
           :show-fournisseurs="showFournisseurs"
-          :show-simplification-tags="showSimplificationTags"
-          :show-categorie-de-solution="showCategorieDeSolution"
           :show-arrow="showArrow"
         />
         <SimplifionsCasDusageCard
@@ -33,8 +31,6 @@
           :show-description="showDescription"
           :show-target-users="showTargetUsers"
           :show-fournisseurs="showFournisseurs"
-          :show-simplification-tags="showSimplificationTags"
-          :show-categorie-de-solution="showCategorieDeSolution"
           :show-arrow="showArrow"
         />
       </template>
@@ -59,8 +55,6 @@ const props = withDefaults(
     showOperateurTag?: boolean
     showTargetUsers?: boolean
     showFournisseurs?: boolean
-    showSimplificationTags?: boolean
-    showCategorieDeSolution?: boolean
     showArrow?: boolean
   }>(),
   {
@@ -69,8 +63,6 @@ const props = withDefaults(
     showOperateurTag: true,
     showTargetUsers: false,
     showFournisseurs: false,
-    showSimplificationTags: false,
-    showCategorieDeSolution: false,
     showArrow: false
   }
 )

--- a/src/custom/simplifions/model/grist.ts
+++ b/src/custom/simplifions/model/grist.ts
@@ -13,7 +13,6 @@ export type CasUsage = {
   Nom_complet: string
   Pour_simplifier_les_demarches_de: number[]
   Recommandations: number[]
-  Types_de_simplification: number[]
   Visible_sur_simplifions: boolean
 }
 export type CasUsageRecord = GristRecord & {
@@ -110,7 +109,6 @@ export type Solution = {
   Prix: string
   Public_ou_prive: string
   Site_internet: string
-  Types_de_simplification: number[]
   Visible_sur_simplifions: boolean
   Recommande_pour_les_cas_d_usages: number[] | null
   Type_de_solution: string[]

--- a/src/custom/simplifions/views/articles/ArticleGuideBasePetitesCollectivites.vue
+++ b/src/custom/simplifions/views/articles/ArticleGuideBasePetitesCollectivites.vue
@@ -243,7 +243,7 @@
           class="fr-btn fr-btn--secondary fr-icon-arrow-right-line fr-btn--icon-right"
           to="/solutions?categorie-de-solution=portail-consultation"
         >
-          Tous les portails de consultation référencés
+          Tous les sites de consultation référencés
         </router-link>
       </div>
     </ArticleSection>

--- a/src/custom/simplifions/views/articles/ArticleQuestCeQuUneAPI.vue
+++ b/src/custom/simplifions/views/articles/ArticleQuestCeQuUneAPI.vue
@@ -307,7 +307,6 @@
         page-key="solutions"
         :show-image="false"
         :show-operateur-tag="true"
-        :show-categorie-de-solution="true"
         :show-target-users="true"
         :show-arrow="true"
       >
@@ -329,7 +328,6 @@
         page-key="solutions"
         :show-image="false"
         :show-operateur-tag="true"
-        :show-categorie-de-solution="true"
         :show-target-users="true"
         :show-arrow="true"
       >
@@ -351,7 +349,6 @@
         page-key="solutions"
         :show-image="false"
         :show-operateur-tag="true"
-        :show-categorie-de-solution="true"
         :show-target-users="true"
         :show-arrow="true"
       >

--- a/src/custom/simplifions/views/articles/ArticleVosInterlocuteursSelonTypeAPI.vue
+++ b/src/custom/simplifions/views/articles/ArticleVosInterlocuteursSelonTypeAPI.vue
@@ -59,7 +59,6 @@
             :slugs="['bouquet-api-entreprise', 'bouquet-api-particulier']"
             page-key="solutions"
             :show-operateur-tag="true"
-            :show-categorie-de-solution="true"
             :show-target-users="true"
             :show-arrow="true"
           >
@@ -97,7 +96,6 @@
         :slugs="['api-impot-particulier']"
         page-key="solutions"
         :show-operateur-tag="true"
-        :show-categorie-de-solution="true"
         :show-target-users="true"
         :show-arrow="true"
       >


### PR DESCRIPTION
### Cartes cas d'usages et solutions

Retire les badges catégorie de solution et niveau de simplification pour alléger les cartes et suite retour utilisateurs : 

<img width="965" height="258" alt="image" src="https://github.com/user-attachments/assets/116e4fa7-c240-40df-bc38-d6c25cd1905e" />


### Filtres 

- Retire les pictos 💠
- Raccourcit les labels
- Modifie le label brique technique (gardé tel quel dans Grist) par "API, base de données et brique logicielle"
- Modifie le label Portail de consultation par site de consultation

<img width="385" height="226" alt="image" src="https://github.com/user-attachments/assets/58a24d54-26b1-4f59-8c9d-a6dfb1b36afb" />
<img width="345" height="247" alt="image" src="https://github.com/user-attachments/assets/da3f69c2-2951-4dad-bbc1-576cb04b8b5d" />
