### PR TITLE
fix(ci): check formatting

### DIFF
--- a/.agent-vm.runtime.sh
+++ b/.agent-vm.runtime.sh
@@ -8,6 +8,9 @@ command -v pm2 || pnpm add --global pm2
 
 CI=true pnpm install --store-dir ~/.local/share/pnpm/store
 
+# makes sure pre-commit is enabled, even if removed in a previous session
+./node_modules/.bin/husky
+
 pm2 delete dev-server 2>/dev/null || true
 export CHOKIDAR_USEPOLLING=true
 pm2 start "pnpm run dev" --name dev-server

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       - run: pnpm install
       - run: pnpm run type-check
       - run: pnpm run lint
+      - run: pnpm run format:check
 
   unit-tests:
     name: Unit tests

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 **/*.d.ts
 eslintrc-auto-import.mjs
+pnpm-lock.yaml

--- a/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
+++ b/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
@@ -1,5 +1,5 @@
-import { apiOrDatasetFactory } from '../../../support/factories/custom/simplifions/grist_factory'
 import type { ApiOrDatasetRecord } from '@/custom/simplifions/model/grist'
+import { apiOrDatasetFactory } from '../../../support/factories/custom/simplifions/grist_factory'
 import {
   mockApidatasetRecommandations,
   mockApiOrDatasetUtiles,

--- a/cypress/e2e/custom/simplifions/cas_d_usages_list.cy.ts
+++ b/cypress/e2e/custom/simplifions/cas_d_usages_list.cy.ts
@@ -76,10 +76,7 @@ describe("Simplifions Cas d'usages Listing Page", () => {
   it('should be able to filter by target users ', () => {
     cy.expectActionToCallApi(
       () =>
-        cy.selectFilterValue(
-          'Démarches à destination des :',
-          'Particuliers'
-        ),
+        cy.selectFilterValue('Démarches à destination des :', 'Particuliers'),
       'topics',
       {
         tag: [

--- a/cypress/e2e/custom/simplifions/solutions_list.cy.ts
+++ b/cypress/e2e/custom/simplifions/solutions_list.cy.ts
@@ -64,10 +64,7 @@ describe('Simplifions Solutions Page', () => {
   it('should be able to filter by target users ', () => {
     cy.expectActionToCallApi(
       () =>
-        cy.selectFilterValue(
-          'Démarches à destination des :',
-          'Particuliers'
-        ),
+        cy.selectFilterValue('Démarches à destination des :', 'Particuliers'),
       'topics',
       {
         tag: [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "eslint . --max-warnings 0",
     "hint": "tsc --project tsconfig.vitest.json",
     "format": "prettier --write src/",
+    "format:check": "prettier --check \"**/*.{js,ts,mjs,mts,vue,yml,yaml,json,md,css}\"",
     "prepare": "husky",
     "generate-robots-txt": "node scripts/generate-robots-txt.mjs",
     "type-check": "pnpm run type-check:app && pnpm run type-check:cypress",

--- a/public/static/simplifions/pages/doctrine-referencement-cas-usages.md
+++ b/public/static/simplifions/pages/doctrine-referencement-cas-usages.md
@@ -20,10 +20,7 @@
 
 <h2 id="referencement-cas-usage" class="fr-h2 fr-my-0w" style="color: black; background-color: rgb(167, 212, 205); padding: 2px 4px; display: inline-block;">Règles de référencement d'un cas d'usage</h2>
 
-
-
 <p class="fr-text--lead">Lorsque l'équipe de Simplifions.data.gouv.fr identifie un cas d'usage susceptible d'être simplifié via l'utilisation de données, voici les questions qu'elle se pose pour identifier si ce cas d'usage peut être référencé sur Simplifions.data.gouv.fr. </p>
-
 
 <div class="fr-col-12 fr-col-lg-8 fr-ml-4w">
     <ol class="fr-text--lg">
@@ -63,4 +60,3 @@
         </li>
     </ol>
 </div>
-

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -203,13 +203,13 @@ cmd_prepare() {
 
     # Merge source into merge branch
     info "Merging $source_branch into $merge_branch..."
-    if ! git merge "origin/$source_branch" --no-edit; then
+    if ! git merge "origin/$source_branch" --no-edit --no-verify; then
       error "Merge conflicts detected!
 
 Please resolve conflicts manually:
   1. Edit conflicted files
   2. Stage resolved files: git add <files>
-  3. Complete merge: git commit
+  3. Complete merge: git commit --no-verify
   4. Re-run: $0 prepare $site $env $version$source_arg
 
 Or abort: git merge --abort"

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -469,7 +469,12 @@ Related: https://github.com/opendatateam/udata-front-kit/pull/621#issuecomment-2
 
 :root {
   --simplifions-h2-highlight: rgb(167, 212, 205);
-  --simplifions-homebanner-gradient: linear-gradient(0.25turn, #f6f6f6, #e3e3fd, #bfdcb7);
+  --simplifions-homebanner-gradient: linear-gradient(
+    0.25turn,
+    #f6f6f6,
+    #e3e3fd,
+    #bfdcb7
+  );
 }
 
 /* ===== Accessibilite custom styles ===== */

--- a/src/custom/simplifions/components/CarouselTrack.vue
+++ b/src/custom/simplifions/components/CarouselTrack.vue
@@ -1,5 +1,9 @@
 <template>
-  <ul ref="track" class="carousel__track fr-m-0 fr-p-0" @scroll.passive="onScroll">
+  <ul
+    ref="track"
+    class="carousel__track fr-m-0 fr-p-0"
+    @scroll.passive="onScroll"
+  >
     <slot />
   </ul>
   <div

--- a/src/custom/simplifions/components/SimplifionsCasDusageDescription.vue
+++ b/src/custom/simplifions/components/SimplifionsCasDusageDescription.vue
@@ -133,7 +133,10 @@
         class="fr-mb-4w"
       >
         <SimplifionsReco
-          v-if="recommandation.Solution_recommandee || recommandation.API_ou_datasets_recommandes"
+          v-if="
+            recommandation.Solution_recommandee ||
+            recommandation.API_ou_datasets_recommandes
+          "
           :recommandation="recommandation"
         />
       </div>

--- a/src/custom/simplifions/components/SimplifionsReco.vue
+++ b/src/custom/simplifions/components/SimplifionsReco.vue
@@ -4,192 +4,205 @@
       ➡️ {{ recommandation.Nom_de_la_recommandation }}
     </h4>
 
-    <div
-      class="fr-grid-row  fr-grid-row--top fr-mx-2w"
-    >
+    <div class="fr-grid-row fr-grid-row--top fr-mx-2w">
       <div class="fr-mt-2w fr-mb-2w fr-col-12 fr-col-md-6">
-          <h5 class="fr-text--lg">
-            <span aria-hidden="true" class="fr-icon-success-fill icon-green"></span>
-            Données disponibles :
-          </h5>
-          <!-- eslint-disable vue/no-v-html -->
-          <div
-            v-if="recommandation.Donnees_utiles_disponibles"
-            class="fr-ml-3w"
-            v-html="fromMarkdown(recommandation.Donnees_utiles_disponibles).html"
-          ></div>
-          <!-- eslint-enable vue/no-v-html -->
-          <p v-else class="fr-ml-3w fr-text--sm fr-text--mention-grey">
-            <i>Information non renseignée.</i>
-          </p>
+        <h5 class="fr-text--lg">
+          <span
+            aria-hidden="true"
+            class="fr-icon-success-fill icon-green"
+          ></span>
+          Données disponibles :
+        </h5>
+        <!-- eslint-disable vue/no-v-html -->
+        <div
+          v-if="recommandation.Donnees_utiles_disponibles"
+          class="fr-ml-3w"
+          v-html="fromMarkdown(recommandation.Donnees_utiles_disponibles).html"
+        ></div>
+        <!-- eslint-enable vue/no-v-html -->
+        <p v-else class="fr-ml-3w fr-text--sm fr-text--mention-grey">
+          <i>Information non renseignée.</i>
+        </p>
       </div>
 
       <div class="fr-px-2w fr-mt-2w fr-mb-2w fr-col-12 fr-col-md-6">
-          <h5 class="fr-text--lg">
-            <span aria-hidden="true">✍️</span>
-            Informations à saisir pour récupérer la donnée :
-          </h5>
-          <!-- eslint-disable vue/no-v-html -->
-          <div
-            v-if="recommandation.Parametres_a_saisir_pour_recuperer_les_donnees"
-            class="fr-ml-3w"
-            v-html="
-              fromMarkdown(
-                recommandation.Parametres_a_saisir_pour_recuperer_les_donnees
-              ).html
-            "
-          ></div>
-          <!-- eslint-enable vue/no-v-html -->
-          <p v-else class="fr-ml-3w fr-text--sm fr-text--mention-grey">
-            <i>Information non renseignée.</i>
-          </p>
-        </div>
+        <h5 class="fr-text--lg">
+          <span aria-hidden="true">✍️</span>
+          Informations à saisir pour récupérer la donnée :
+        </h5>
+        <!-- eslint-disable vue/no-v-html -->
+        <div
+          v-if="recommandation.Parametres_a_saisir_pour_recuperer_les_donnees"
+          class="fr-ml-3w"
+          v-html="
+            fromMarkdown(
+              recommandation.Parametres_a_saisir_pour_recuperer_les_donnees
+            ).html
+          "
+        ></div>
+        <!-- eslint-enable vue/no-v-html -->
+        <p v-else class="fr-ml-3w fr-text--sm fr-text--mention-grey">
+          <i>Information non renseignée.</i>
+        </p>
+      </div>
     </div>
 
     <div class="fr-mt-2w fr-mx-2w">
-    <h5 class="fr-text--lg fr-mb-2w">
-      <span aria-hidden="true" class="fr-icon-arrow-right-circle-fill"></span>
-      Moyens d'accès à ces données :
-    </h5>
+      <h5 class="fr-text--lg fr-mb-2w">
+        <span aria-hidden="true" class="fr-icon-arrow-right-circle-fill"></span>
+        Moyens d'accès à ces données :
+      </h5>
 
-    <DsfrAccordionsGroup v-model="activeAccordion">
-      <DsfrAccordion title-tag="h6">
-        <template #title>{{ apiAccordionTitle }}</template>
+      <DsfrAccordionsGroup v-model="activeAccordion">
+        <DsfrAccordion title-tag="h6">
+          <template #title>{{ apiAccordionTitle }}</template>
 
-        <template v-if="isSolution">
-          <div class="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-mt-2w">
-            <router-link
-              v-if="topicSlug"
-              class="fr-btn fr-btn--secondary test__solution-link"
-              :to="{ name: 'solutions_detail', params: { item_id: topicSlug } }"
+          <template v-if="isSolution">
+            <div
+              class="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-mt-2w"
             >
-              Plus d'informations sur {{ recommandation.Nom_de_la_recommandation }}
-            </router-link>
-            <a
-              v-if="recommandation.access_link_with_fallback"
-              rel="noopener noreferrer"
-              :href="recommandation.access_link_with_fallback"
-              class="fr-btn test__access-link"
-              target="_blank"
-            >
-              Demander un accès pour ce cas d'usage
-            </a>
-          </div>
-
-          <SimplifionsRecoUsefulEndpointsTable
-            :endpoints="usefulDataApiFourniesParLaSolution"
-            :custom-descriptions="customDescriptions"
-            :case-usage-name="recommandation.Nom_complet_du_cas_d_usage"
-          />
-        </template>
-
-        <template v-else>
-          <div class="fr-grid-row fr-grid-row--right fr-mb-2w">
-            <a
-              v-if="access_url"
-              rel="noopener noreferrer"
-              :href="access_url"
-              class="fr-btn test__access-link"
-              target="_blank"
-            >
-              Demander un accès à {{ accessTypeLabel }} pour ce cas d'usage
-            </a>
-          </div>
-          <SimplifionsDataApi
-            v-if="apiOrDataset"
-            :api-or-dataset="apiOrDataset"
-            title-tag="h6"
-            @resource-fetched="handleResourceFetched"
-          />
-        </template>
-      </DsfrAccordion>
-
-      <SimplifionsRecoIntegratingSolutionsAccordion
-        title="Via une brique logicielle à intégrer"
-        solution-kind="brique"
-        :solutions="integratingSolutionsBriquesTechniques"
-        :integration-score-per-solution="integrationScorePerSolution"
-        :nom-fournisseur="recommandation.Nom_de_la_recommandation"
-        :type-label="typeLabel"
-      >
-        <p>
-          <strong>Briques techniques logicielles</strong> destinées à être
-          intégrées dans un système informatique existant et conçues pour le cas
-          d'usage «<i>&nbsp;{{ recommandation.Nom_complet_du_cas_d_usage }}&nbsp;</i>» :
-        </p>
-      </SimplifionsRecoIntegratingSolutionsAccordion>
-
-      <SimplifionsRecoIntegratingSolutionsAccordion
-        title="Via un logiciel métier « clé en main »"
-        solution-kind="logiciel"
-        :solutions="integratingSolutionsLogicielsMetiers"
-        :integration-score-per-solution="integrationScorePerSolution"
-        :nom-fournisseur="recommandation.Nom_de_la_recommandation"
-        :type-label="typeLabel"
-      >
-        <p>
-          <strong>Liste des logiciels métier, sur étagère</strong> conçus pour
-          le cas d'usage «<i>&nbsp;{{ recommandation.Nom_complet_du_cas_d_usage }}&nbsp;</i>» :
-        </p>
-
-        <template #demande-acces>
-          <div v-if="access_url" class="fr-mt-2w">
-            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-              <p class="fr-col fr-mb-0">
-                Vous êtes déjà client d'un de ces éditeurs ? Demandez un accès
-                à «&nbsp;{{ recommandation.Nom_de_la_recommandation }}&nbsp;»
-                pour votre logiciel :
-              </p>
+              <router-link
+                v-if="topicSlug"
+                class="fr-btn fr-btn--secondary test__solution-link"
+                :to="{
+                  name: 'solutions_detail',
+                  params: { item_id: topicSlug }
+                }"
+              >
+                Plus d'informations sur
+                {{ recommandation.Nom_de_la_recommandation }}
+              </router-link>
               <a
+                v-if="recommandation.access_link_with_fallback"
                 rel="noopener noreferrer"
-                :href="access_url"
-                class="fr-btn test__access-link-logiciel"
+                :href="recommandation.access_link_with_fallback"
+                class="fr-btn test__access-link"
                 target="_blank"
               >
-                Demander un accès
+                Demander un accès pour ce cas d'usage
               </a>
             </div>
-            <p class="fr-text--sm fr-mb-0 fr-mt-1w">
-              Si vous n'êtes pas déjà client, contactez d'abord l'éditeur avant
-              de demander un accès à
-              «&nbsp;{{ recommandation.Nom_de_la_recommandation }}&nbsp;».
+
+            <SimplifionsRecoUsefulEndpointsTable
+              :endpoints="usefulDataApiFourniesParLaSolution"
+              :custom-descriptions="customDescriptions"
+              :case-usage-name="recommandation.Nom_complet_du_cas_d_usage"
+            />
+          </template>
+
+          <template v-else>
+            <div class="fr-grid-row fr-grid-row--right fr-mb-2w">
+              <a
+                v-if="access_url"
+                rel="noopener noreferrer"
+                :href="access_url"
+                class="fr-btn test__access-link"
+                target="_blank"
+              >
+                Demander un accès à {{ accessTypeLabel }} pour ce cas d'usage
+              </a>
+            </div>
+            <SimplifionsDataApi
+              v-if="apiOrDataset"
+              :api-or-dataset="apiOrDataset"
+              title-tag="h6"
+              @resource-fetched="handleResourceFetched"
+            />
+          </template>
+        </DsfrAccordion>
+
+        <SimplifionsRecoIntegratingSolutionsAccordion
+          title="Via une brique logicielle à intégrer"
+          solution-kind="brique"
+          :solutions="integratingSolutionsBriquesTechniques"
+          :integration-score-per-solution="integrationScorePerSolution"
+          :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+          :type-label="typeLabel"
+        >
+          <p>
+            <strong>Briques techniques logicielles</strong> destinées à être
+            intégrées dans un système informatique existant et conçues pour le
+            cas d'usage «<i
+              >&nbsp;{{ recommandation.Nom_complet_du_cas_d_usage }}&nbsp;</i
+            >» :
+          </p>
+        </SimplifionsRecoIntegratingSolutionsAccordion>
+
+        <SimplifionsRecoIntegratingSolutionsAccordion
+          title="Via un logiciel métier « clé en main »"
+          solution-kind="logiciel"
+          :solutions="integratingSolutionsLogicielsMetiers"
+          :integration-score-per-solution="integrationScorePerSolution"
+          :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+          :type-label="typeLabel"
+        >
+          <p>
+            <strong>Liste des logiciels métier, sur étagère</strong> conçus pour
+            le cas d'usage «<i
+              >&nbsp;{{ recommandation.Nom_complet_du_cas_d_usage }}&nbsp;</i
+            >» :
+          </p>
+
+          <template #demande-acces>
+            <div v-if="access_url" class="fr-mt-2w">
+              <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+                <p class="fr-col fr-mb-0">
+                  Vous êtes déjà client d'un de ces éditeurs ? Demandez un accès
+                  à «&nbsp;{{ recommandation.Nom_de_la_recommandation }}&nbsp;»
+                  pour votre logiciel :
+                </p>
+                <a
+                  rel="noopener noreferrer"
+                  :href="access_url"
+                  class="fr-btn test__access-link-logiciel"
+                  target="_blank"
+                >
+                  Demander un accès
+                </a>
+              </div>
+              <p class="fr-text--sm fr-mb-0 fr-mt-1w">
+                Si vous n'êtes pas déjà client, contactez d'abord l'éditeur
+                avant de demander un accès à «&nbsp;{{
+                  recommandation.Nom_de_la_recommandation
+                }}&nbsp;».
+              </p>
+            </div>
+          </template>
+        </SimplifionsRecoIntegratingSolutionsAccordion>
+
+        <SimplifionsRecoIntegratingSolutionsAccordion
+          title="Via un portail de consultation"
+          solution-kind="portail"
+          :solutions="integratingSolutionsPortailsConsultation"
+          :integration-score-per-solution="integrationScorePerSolution"
+          :nom-fournisseur="recommandation.Nom_de_la_recommandation"
+          :type-label="typeLabel"
+        >
+          <p>
+            <b
+              >Ces sites vous permettent de consulter certaines des données
+              utiles pour ce cas d'usage :</b
+            >
+          </p>
+          <div class="fr-m-2w fr-highlight--orange-terre-battue fr-highlight">
+            <p class="fr-mb-0">
+              💡 Pour vraiment simplifier la vie des usagers, l'intégration
+              directe de cette API ou de jeu de données dans vos logiciels
+              métiers est à privilégier car elle permet de mettre en oeuvre le
+              <i>dites-le-nous une fois</i> et la proactivité !
             </p>
           </div>
-        </template>
-      </SimplifionsRecoIntegratingSolutionsAccordion>
+        </SimplifionsRecoIntegratingSolutionsAccordion>
+      </DsfrAccordionsGroup>
 
-      <SimplifionsRecoIntegratingSolutionsAccordion
-        title="Via un portail de consultation"
-        solution-kind="portail"
-        :solutions="integratingSolutionsPortailsConsultation"
-        :integration-score-per-solution="integrationScorePerSolution"
-        :nom-fournisseur="recommandation.Nom_de_la_recommandation"
-        :type-label="typeLabel"
-      >
-        <p>
-          <b
-            >Ces sites vous permettent de consulter certaines des données utiles
-            pour ce cas d'usage :</b
-          >
-        </p>
-        <div class="fr-m-2w fr-highlight--orange-terre-battue fr-highlight">
-          <p class="fr-mb-0">
-            💡 Pour vraiment simplifier la vie des usagers, l'intégration
-            directe de cette API ou de jeu de données dans vos logiciels métiers
-            est à privilégier car elle permet de mettre en oeuvre le
-            <i>dites-le-nous une fois</i> et la proactivité !
-          </p>
-        </div>
-      </SimplifionsRecoIntegratingSolutionsAccordion>
-    </DsfrAccordionsGroup>
-
-    <p class="fr-text--sm fr-mx-2w fr-mt-2w">
-      <i
-        >Une solution intégrant
-        «&nbsp;{{ recommandation.Nom_de_la_recommandation }}&nbsp;», n'est pas listée ?
-      </i>
-      <a href="#modification-contenu">✒️ Proposez-nous de l'ajouter</a>.
-    </p>
+      <p class="fr-text--sm fr-mx-2w fr-mt-2w">
+        <i
+          >Une solution intégrant «&nbsp;{{
+            recommandation.Nom_de_la_recommandation
+          }}&nbsp;», n'est pas listée ?
+        </i>
+        <a href="#modification-contenu">✒️ Proposez-nous de l'ajouter</a>.
+      </p>
     </div>
   </div>
 </template>
@@ -220,7 +233,9 @@ const isSolution = !!recommandation.Solution_recommandee
 
 // === Solution-specific ===
 const topicSlug = ref<string | undefined>(undefined)
-const usefulDataApiFourniesParLaSolution = ref<ApiOrDatasetRecord[] | undefined>(undefined)
+const usefulDataApiFourniesParLaSolution = ref<
+  ApiOrDatasetRecord[] | undefined
+>(undefined)
 const customDescriptions = ref<Record<number, ApiOrDatasetUtiles>>({})
 
 if (isSolution) {
@@ -232,13 +247,18 @@ if (isSolution) {
 
   if (recommandation.API_et_datasets_utiles_fournis?.length) {
     grist
-      .getRecordsByIds('APIs_et_datasets', recommandation.API_et_datasets_utiles_fournis)
+      .getRecordsByIds(
+        'APIs_et_datasets',
+        recommandation.API_et_datasets_utiles_fournis
+      )
       .then((data) => {
-        usefulDataApiFourniesParLaSolution.value = (data as ApiOrDatasetRecord[]).filter(
-          (record) => record.fields.Visible_sur_simplifions
-        )
+        usefulDataApiFourniesParLaSolution.value = (
+          data as ApiOrDatasetRecord[]
+        ).filter((record) => record.fields.Visible_sur_simplifions)
 
-        if (recommandation.Descriptions_des_API_et_datasets_utiles_fournis?.length) {
+        if (
+          recommandation.Descriptions_des_API_et_datasets_utiles_fournis?.length
+        ) {
           grist
             .getRecordsByIds(
               'API_et_datasets_utiles',
@@ -276,8 +296,12 @@ const handleResourceFetched = (resource: DatasetV2 | Dataservice) => {
 }
 
 const access_url = computed(() => {
-  if (recommandation.access_link_with_fallback) return recommandation.access_link_with_fallback
-  if (fetchedResource.value && 'authorization_request_url' in fetchedResource.value) {
+  if (recommandation.access_link_with_fallback)
+    return recommandation.access_link_with_fallback
+  if (
+    fetchedResource.value &&
+    'authorization_request_url' in fetchedResource.value
+  ) {
     return (fetchedResource.value as Dataservice).authorization_request_url
   }
   return undefined
@@ -326,7 +350,9 @@ if (recommandation.Solutions_integratrices_categorie_logiciel_metier?.length) {
   })
 }
 
-if (recommandation.Solutions_integratrices_categorie_briques_techniques?.length) {
+if (
+  recommandation.Solutions_integratrices_categorie_briques_techniques?.length
+) {
   fetchSolutionsForCategory(
     recommandation.Solutions_integratrices_categorie_briques_techniques
   ).then((solutions) => {
@@ -334,7 +360,10 @@ if (recommandation.Solutions_integratrices_categorie_briques_techniques?.length)
   })
 }
 
-if (recommandation.Solutions_integratrices_categorie_portail_de_consultation?.length) {
+if (
+  recommandation.Solutions_integratrices_categorie_portail_de_consultation
+    ?.length
+) {
   fetchSolutionsForCategory(
     recommandation.Solutions_integratrices_categorie_portail_de_consultation
   ).then((solutions) => {
@@ -342,7 +371,9 @@ if (recommandation.Solutions_integratrices_categorie_portail_de_consultation?.le
   })
 }
 
-const usefulApiIds = new Set(recommandation.API_et_datasets_utiles_fournis ?? [])
+const usefulApiIds = new Set(
+  recommandation.API_et_datasets_utiles_fournis ?? []
+)
 
 const integrationScorePerSolution = computed(() => {
   const allSolutions = [
@@ -356,9 +387,9 @@ const integrationScorePerSolution = computed(() => {
       allSolutions.map((solution) => [
         solution.id,
         {
-          integratedCount: (solution.fields.API_ou_datasets_integres ?? []).filter((id) =>
-            usefulApiIds.has(id)
-          ).length,
+          integratedCount: (
+            solution.fields.API_ou_datasets_integres ?? []
+          ).filter((id) => usefulApiIds.has(id)).length,
           totalCount
         }
       ])
@@ -369,7 +400,9 @@ const integrationScorePerSolution = computed(() => {
       allSolutions.map((solution) => [
         solution.id,
         {
-          integratedCount: (solution.fields.API_ou_datasets_integres ?? []).includes(usefulApiId)
+          integratedCount: (
+            solution.fields.API_ou_datasets_integres ?? []
+          ).includes(usefulApiId)
             ? 1
             : 0,
           totalCount: 1
@@ -383,7 +416,6 @@ const activeAccordion = ref(-1)
 </script>
 
 <style scoped>
-
 .reco-card {
   background-color: var(--background-alt-beige-gris-galet);
 }

--- a/src/custom/simplifions/components/SimplifionsRecoUsefulEndpointsTable.vue
+++ b/src/custom/simplifions/components/SimplifionsRecoUsefulEndpointsTable.vue
@@ -1,9 +1,16 @@
 <template>
-  <div v-if="endpoints === undefined">
-    Chargement des données en cours...
-  </div>
+  <div v-if="endpoints === undefined">Chargement des données en cours...</div>
   <div v-else-if="sortedEndpoints?.length">
-    <p class="fr-mt-4w"><b><span title="Un endpoint est une sous-partie d'une API, un point d'accès spécifique à l'intérieur de l'API." style="text-decoration: underline dotted; text-underline-offset: 3px;">Endpoints</span> de l'API utiles pour ce cas d'usage :</b></p>
+    <p class="fr-mt-4w">
+      <b
+        ><span
+          title="Un endpoint est une sous-partie d'une API, un point d'accès spécifique à l'intérieur de l'API."
+          style="text-decoration: underline dotted; text-underline-offset: 3px"
+          >Endpoints</span
+        >
+        de l'API utiles pour ce cas d'usage :</b
+      >
+    </p>
     <div class="fr-table fr-table--multiline fr-table--no-caption fr-table--sm">
       <div class="fr-table__header">
         <div class="fr-search-bar" role="search">
@@ -24,13 +31,21 @@
             <table>
               <thead>
                 <tr class="">
-                  <th class="fr-col--md fr-py-2w" scope="col">Endpoints utiles de l'API</th>
-                  <th class="fr-col--lg fr-py-2w" scope="col">Description de l'utilité pour le cas d'usage «&nbsp;{{ caseUsageName }}&nbsp;»</th>
+                  <th class="fr-col--md fr-py-2w" scope="col">
+                    Endpoints utiles de l'API
+                  </th>
+                  <th class="fr-col--lg fr-py-2w" scope="col">
+                    Description de l'utilité pour le cas d'usage «&nbsp;{{
+                      caseUsageName
+                    }}&nbsp;»
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 <tr v-if="!filteredEndpoints.length">
-                  <td colspan="2"><i>Aucun endpoint ne correspond à votre recherche.</i></td>
+                  <td colspan="2">
+                    <i>Aucun endpoint ne correspond à votre recherche.</i>
+                  </td>
                 </tr>
                 <template v-else>
                   <tr
@@ -39,22 +54,35 @@
                     class="test__api-or-dataset-utile"
                   >
                     <td>
-                      <b>{{ record.fields.Nom }}</b><br />
+                      <b>{{ record.fields.Nom }}</b
+                      ><br />
                       <a
                         :href="`https://www.data.gouv.fr/fr/${datagouvUrlType(record.fields)}/${record.fields.UID_datagouv}`"
                         target="_blank"
                         class="fr-link fr-link--xs"
-                      >Documentation</a>
+                        >Documentation</a
+                      >
                     </td>
                     <!-- eslint-disable vue/no-v-html -->
                     <td
-                      v-if="customDescriptions[record.id]?.En_quoi_cette_API_ou_dataset_est_utile_pour_ce_cas_d_usage"
+                      v-if="
+                        customDescriptions[record.id]
+                          ?.En_quoi_cette_API_ou_dataset_est_utile_pour_ce_cas_d_usage
+                      "
                       class="fr-text--sm fr-py-1w test__api-or-dataset-utile-description"
-                      v-html="fromMarkdown(customDescriptions[record.id].En_quoi_cette_API_ou_dataset_est_utile_pour_ce_cas_d_usage).html"
+                      v-html="
+                        fromMarkdown(
+                          customDescriptions[record.id]
+                            .En_quoi_cette_API_ou_dataset_est_utile_pour_ce_cas_d_usage
+                        ).html
+                      "
                     ></td>
                     <!-- eslint-enable vue/no-v-html -->
                     <td v-else>
-                      <i class="fr-text--xs">Cet endpoint est identifié comme utile pour ce cas d'usage.</i>
+                      <i class="fr-text--xs"
+                        >Cet endpoint est identifié comme utile pour ce cas
+                        d'usage.</i
+                      >
                     </td>
                   </tr>
                 </template>
@@ -65,7 +93,11 @@
       </div>
       <div v-if="paginationPages.length > 1" class="fr-table__footer">
         <div class="fr-table__footer--start">
-          <p class="fr-table__detail">{{ filteredEndpoints.length }} endpoint{{ filteredEndpoints.length > 1 ? 's' : '' }}</p>
+          <p class="fr-table__detail">
+            {{ filteredEndpoints.length }} endpoint{{
+              filteredEndpoints.length > 1 ? 's' : ''
+            }}
+          </p>
         </div>
         <div class="fr-table__footer--middle">
           <DsfrPagination
@@ -81,7 +113,11 @@
 
 <script setup lang="ts">
 import { fromMarkdown } from '@/utils'
-import type { ApiOrDataset, ApiOrDatasetRecord, ApiOrDatasetUtiles } from '../model/grist'
+import type {
+  ApiOrDataset,
+  ApiOrDatasetRecord,
+  ApiOrDatasetUtiles
+} from '../model/grist'
 
 const props = defineProps<{
   endpoints: ApiOrDatasetRecord[] | undefined
@@ -97,9 +133,12 @@ const currentPage = ref(0)
 
 const datagouvUrlType = (apiOrDataset: ApiOrDataset) => {
   switch (apiOrDataset.Type) {
-    case 'API': return 'dataservices'
-    case 'Jeu de données': return 'datasets'
-    default: throw new Error(`Unknown type: ${apiOrDataset.Type}`)
+    case 'API':
+      return 'dataservices'
+    case 'Jeu de données':
+      return 'datasets'
+    default:
+      throw new Error(`Unknown type: ${apiOrDataset.Type}`)
   }
 }
 
@@ -109,18 +148,24 @@ const sortedEndpoints = computed(() => {
     const bCustomDescription = props.customDescriptions[b.id]
 
     const aOrdre =
-      typeof aCustomDescription?.Ordre === 'number' ? aCustomDescription.Ordre : Infinity
+      typeof aCustomDescription?.Ordre === 'number'
+        ? aCustomDescription.Ordre
+        : Infinity
     const bOrdre =
-      typeof bCustomDescription?.Ordre === 'number' ? bCustomDescription.Ordre : Infinity
+      typeof bCustomDescription?.Ordre === 'number'
+        ? bCustomDescription.Ordre
+        : Infinity
 
     if (aOrdre !== bOrdre) return aOrdre - bOrdre
 
     const aDescriptionLength =
       aCustomDescription
-        ?.En_quoi_cette_API_ou_dataset_est_utile_pour_ce_cas_d_usage?.length || 0
+        ?.En_quoi_cette_API_ou_dataset_est_utile_pour_ce_cas_d_usage?.length ||
+      0
     const bDescriptionLength =
       bCustomDescription
-        ?.En_quoi_cette_API_ou_dataset_est_utile_pour_ce_cas_d_usage?.length || 0
+        ?.En_quoi_cette_API_ou_dataset_est_utile_pour_ce_cas_d_usage?.length ||
+      0
     const lengthDiff = bDescriptionLength - aDescriptionLength
     if (lengthDiff !== 0) return lengthDiff
 
@@ -132,7 +177,9 @@ const filteredEndpoints = computed(() => {
   const q = searchQuery.value.trim().toLowerCase()
   if (!q) return sortedEndpoints.value ?? []
   return (sortedEndpoints.value ?? []).filter((record) => {
-    const description = props.customDescriptions[record.id]?.En_quoi_cette_API_ou_dataset_est_utile_pour_ce_cas_d_usage ?? ''
+    const description =
+      props.customDescriptions[record.id]
+        ?.En_quoi_cette_API_ou_dataset_est_utile_pour_ce_cas_d_usage ?? ''
     return (
       record.fields.Nom.toLowerCase().includes(q) ||
       description.toLowerCase().includes(q)
@@ -146,7 +193,9 @@ const paginatedEndpoints = computed(() => {
 })
 
 const paginationPages = computed(() => {
-  const pageCount = Math.ceil(filteredEndpoints.value.length / ENDPOINTS_PER_PAGE)
+  const pageCount = Math.ceil(
+    filteredEndpoints.value.length / ENDPOINTS_PER_PAGE
+  )
   return Array.from({ length: pageCount }, (_, i) => ({
     label: String(i + 1),
     title: `Page ${i + 1}`,

--- a/src/custom/simplifions/components/article/ArticleCard.vue
+++ b/src/custom/simplifions/components/article/ArticleCard.vue
@@ -2,16 +2,24 @@
   <div class="fr-card fr-enlarge-link fr-card--shadow">
     <div class="fr-card__body">
       <div class="fr-card__content fr-px-2w fr-pt-3w">
-        <div v-if="groupedKeywords.audienceKeywords.length" class="fr-card__start">
+        <div
+          v-if="groupedKeywords.audienceKeywords.length"
+          class="fr-card__start"
+        >
           <p class="fr-card__detail fr-icon-user-line">{{ audienceDetail }}</p>
         </div>
         <h3 class="fr-card__title fr-text--lead fr-mb-0">
-          <router-link :to="`/articles/${article.slug}`">{{ article.h1 }}</router-link>
+          <router-link :to="`/articles/${article.slug}`">{{
+            article.h1
+          }}</router-link>
         </h3>
         <p class="fr-card__desc fr-text--md">{{ article.description }}</p>
         <div class="fr-card__end">
           <ul class="fr-tags-group">
-            <li v-for="keyword in groupedKeywords.otherKeywords" :key="keyword.label">
+            <li
+              v-for="keyword in groupedKeywords.otherKeywords"
+              :key="keyword.label"
+            >
               <p class="fr-tag fr-tag--sm">{{ keyword.label }}</p>
             </li>
           </ul>
@@ -33,7 +41,10 @@
         ></div>
       </div>
       <div
-        v-if="groupedKeywords.articleTypeKeywords.length || groupedKeywords.dataTypeKeywords.length"
+        v-if="
+          groupedKeywords.articleTypeKeywords.length ||
+          groupedKeywords.dataTypeKeywords.length
+        "
         class="fr-badges-group"
       >
         <p
@@ -44,7 +55,10 @@
           {{ keyword.label }}
         </p>
         <span
-          v-if="groupedKeywords.articleTypeKeywords.length && groupedKeywords.dataTypeKeywords.length"
+          v-if="
+            groupedKeywords.articleTypeKeywords.length &&
+            groupedKeywords.dataTypeKeywords.length
+          "
           class="badge-group-break"
           aria-hidden="true"
         ></span>
@@ -61,12 +75,20 @@
 </template>
 
 <script setup lang="ts">
-import { groupArticleKeywords, joinKeywordLabels, type ArticleMeta } from '../../model/articles'
+import {
+  groupArticleKeywords,
+  joinKeywordLabels,
+  type ArticleMeta
+} from '../../model/articles'
 
 const props = defineProps<{ article: ArticleMeta }>()
 
-const groupedKeywords = computed(() => groupArticleKeywords(props.article.articleKeywords))
-const audienceDetail = computed(() => joinKeywordLabels(groupedKeywords.value.audienceKeywords))
+const groupedKeywords = computed(() =>
+  groupArticleKeywords(props.article.articleKeywords)
+)
+const audienceDetail = computed(() =>
+  joinKeywordLabels(groupedKeywords.value.audienceKeywords)
+)
 </script>
 
 <style scoped>

--- a/src/custom/simplifions/components/article/SimplifionsArticleLayout.vue
+++ b/src/custom/simplifions/components/article/SimplifionsArticleLayout.vue
@@ -27,13 +27,22 @@
         >
           <div v-if="hasMeta" class="article-hero__meta fr-mb-3v fr-mb-md-4v">
             <ul
-              v-if="groupedKeywords.articleTypeKeywords.length || groupedKeywords.dataTypeKeywords.length"
+              v-if="
+                groupedKeywords.articleTypeKeywords.length ||
+                groupedKeywords.dataTypeKeywords.length
+              "
               class="article-hero__badge-list fr-p-0 fr-m-0"
             >
-              <li v-for="keyword in groupedKeywords.articleTypeKeywords" :key="keyword.label">
+              <li
+                v-for="keyword in groupedKeywords.articleTypeKeywords"
+                :key="keyword.label"
+              >
                 <p class="fr-badge fr-badge--sm fr-m-0">{{ keyword.label }}</p>
               </li>
-              <li v-for="keyword in groupedKeywords.dataTypeKeywords" :key="keyword.label">
+              <li
+                v-for="keyword in groupedKeywords.dataTypeKeywords"
+                :key="keyword.label"
+              >
                 <p class="fr-badge fr-badge--sm fr-badge--blue-ecume fr-m-0">
                   {{ keyword.label }}
                 </p>
@@ -44,7 +53,10 @@
               v-if="groupedKeywords.otherKeywords.length"
               class="article-hero__tag-list fr-p-0 fr-m-0"
             >
-              <li v-for="keyword in groupedKeywords.otherKeywords" :key="keyword.label">
+              <li
+                v-for="keyword in groupedKeywords.otherKeywords"
+                :key="keyword.label"
+              >
                 <p class="fr-tag fr-tag--sm fr-m-0">{{ keyword.label }}</p>
               </li>
             </ul>
@@ -142,7 +154,11 @@ import type { BreadcrumbItem } from '@/model/breadcrumb'
 import { useCanonicalUrl, useMeta } from '@/utils/seo'
 import { provide } from 'vue'
 import { provideArticleTopicsRegistry } from '../../composables/useArticleTopicsRegistry'
-import { groupArticleKeywords, joinKeywordLabels, type ArticleKeyword } from '../../model/articles'
+import {
+  groupArticleKeywords,
+  joinKeywordLabels,
+  type ArticleKeyword
+} from '../../model/articles'
 import { articleSectionKey } from './articleSectionKey'
 import SimplifionsArticleRelatedTopics from './SimplifionsArticleRelatedTopics.vue'
 
@@ -173,7 +189,8 @@ const props = withDefaults(
     kicker: '',
     heroImageSrc: '',
     articleKeywords: () => [],
-    heroBackdropGradient: 'linear-gradient(135deg, var(--background-action-low-blue-ecume) 0%, var(--background-contrast-blue-ecume) 100%)',
+    heroBackdropGradient:
+      'linear-gradient(135deg, var(--background-action-low-blue-ecume) 0%, var(--background-contrast-blue-ecume) 100%)',
     heroPanelBackground: 'var(--background-alt-beige-gris-galet)',
     breadcrumbLinks: () => []
   }
@@ -181,8 +198,12 @@ const props = withDefaults(
 
 const metaTitle = computed(() => props.title ?? props.h1)
 
-const groupedKeywords = computed(() => groupArticleKeywords([...props.articleKeywords]))
-const audienceDetail = computed(() => joinKeywordLabels(groupedKeywords.value.audienceKeywords))
+const groupedKeywords = computed(() =>
+  groupArticleKeywords([...props.articleKeywords])
+)
+const audienceDetail = computed(() =>
+  joinKeywordLabels(groupedKeywords.value.audienceKeywords)
+)
 
 useMeta({
   title: metaTitle,

--- a/src/custom/simplifions/components/article/SimplifionsArticleReadMore.vue
+++ b/src/custom/simplifions/components/article/SimplifionsArticleReadMore.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="fr-callout fr-callout--beige-gris-galet fr-my-4w fr-p-2w">
-  
     <p v-if="description" class="fr-callout__text fr-text--sm">
       <strong>Lire plus</strong> • {{ description }}
     </p>

--- a/src/custom/simplifions/components/article/SimplifionsArticleTopicSpotlight.vue
+++ b/src/custom/simplifions/components/article/SimplifionsArticleTopicSpotlight.vue
@@ -106,7 +106,12 @@ onMounted(async () => {
   if (cancelled) return
   results
     .filter((r) => r.status === 'rejected')
-    .forEach((r) => console.warn('SimplifionsArticleTopicSpotlight: failed to load topic', (r as PromiseRejectedResult).reason))
+    .forEach((r) =>
+      console.warn(
+        'SimplifionsArticleTopicSpotlight: failed to load topic',
+        (r as PromiseRejectedResult).reason
+      )
+    )
   topics.value = results
     .filter((r): r is PromiseFulfilledResult<Topic> => r.status === 'fulfilled')
     .map((r) => r.value)

--- a/src/custom/simplifions/model/articles.ts
+++ b/src/custom/simplifions/model/articles.ts
@@ -40,12 +40,21 @@ export const ARTICLE_KEYWORDS = {
   definition: { label: 'Définition', category: "Type d'article" },
   api: { label: 'API', category: 'Type de données' },
   jeuxDeDonnees: { label: 'Jeux de données', category: 'Type de données' },
-  petiteCollectivite: { label: 'Petite collectivité', category: 'Vous êtes ...' },
+  petiteCollectivite: {
+    label: 'Petite collectivité',
+    category: 'Vous êtes ...'
+  },
   dsi: { label: 'DSI', category: 'Vous êtes ...' },
   moa: { label: 'MOA', category: 'Vous êtes ...' },
-  editeurDeLogiciels: { label: 'Éditeur de logiciels', category: 'Vous êtes ...' },
+  editeurDeLogiciels: {
+    label: 'Éditeur de logiciels',
+    category: 'Vous êtes ...'
+  },
   parcoursUsager: { label: 'Parcours usager', category: 'Thématique' },
-  integrationTechnique: { label: 'Intégration technique', category: 'Thématique' },
+  integrationTechnique: {
+    label: 'Intégration technique',
+    category: 'Thématique'
+  },
   apiFranceConnectees: { label: 'API FranceConnectées', category: 'Thématique' }
 } satisfies Record<string, ArticleKeyword>
 
@@ -66,7 +75,12 @@ export const articleQuestCeQuUneAPI: ArticleMeta = {
   title: "Qu'est-ce qu'une API ? Explication simple pour les non-techniciens",
   description:
     "Comprendre ce qu'est une API sans vocabulaire technique : comment ces outils permettent aux administrations d'échanger des données pour simplifier les démarches des entreprises, associations et particuliers.",
-  articleKeywords: [ARTICLE_KEYWORDS.api, ARTICLE_KEYWORDS.definition, ARTICLE_KEYWORDS.petiteCollectivite, ARTICLE_KEYWORDS.moa],
+  articleKeywords: [
+    ARTICLE_KEYWORDS.api,
+    ARTICLE_KEYWORDS.definition,
+    ARTICLE_KEYWORDS.petiteCollectivite,
+    ARTICLE_KEYWORDS.moa
+  ],
   heroBackdropGradient: 'linear-gradient(135deg, #decdbd 0%, #d2e2f6 100%)',
   heroPanelBackground: 'var(--background-alt-beige-gris-galet)'
 }
@@ -76,7 +90,15 @@ export const articleApisFranceConnectees: ArticleMeta = {
   h1: 'Les API FranceConnectées',
   title: `Administrations, pré-remplissez les démarches FranceConnectées`,
   description: `Les API FranceConnectées donnent accès à diverses données administratives des particuliers en proposant FranceConnect comme modalité d'appel. Elles permettent de simplifier les démarches d'un particulier utilisant FranceConnect en récupérant automatiquement d'autres informations administratives le concernant.`,
-  articleKeywords: [ARTICLE_KEYWORDS.api, ARTICLE_KEYWORDS.guideMetier, ARTICLE_KEYWORDS.apiFranceConnectees, ARTICLE_KEYWORDS.dsi, ARTICLE_KEYWORDS.moa, ARTICLE_KEYWORDS.editeurDeLogiciels, ARTICLE_KEYWORDS.definition],
+  articleKeywords: [
+    ARTICLE_KEYWORDS.api,
+    ARTICLE_KEYWORDS.guideMetier,
+    ARTICLE_KEYWORDS.apiFranceConnectees,
+    ARTICLE_KEYWORDS.dsi,
+    ARTICLE_KEYWORDS.moa,
+    ARTICLE_KEYWORDS.editeurDeLogiciels,
+    ARTICLE_KEYWORDS.definition
+  ],
   heroBackdropGradient: 'linear-gradient(135deg, #a19237 0%, #fddede 100%)',
   heroPanelBackground: 'var(--background-alt-beige-gris-galet)'
 }
@@ -89,7 +111,10 @@ export const articleGuideBasePetitesCollectivites: ArticleMeta = {
     "Petites collectivités, simplifiez vos démarches administratives sans développement : portails publics gratuits et logiciels éditeurs déjà raccordés aux données vous permettent d'éviter de les redemander aux usagers.",
   imageSrc:
     '/static/simplifions/assets/image-guide-de-base-collectivites-guichet-mairie-2.jpg',
-  articleKeywords: [ARTICLE_KEYWORDS.guideDeBase, ARTICLE_KEYWORDS.petiteCollectivite],
+  articleKeywords: [
+    ARTICLE_KEYWORDS.guideDeBase,
+    ARTICLE_KEYWORDS.petiteCollectivite
+  ],
   heroBackdropGradient: 'linear-gradient(135deg, #34BAB5 0%, #d2e2f6 100%)',
   heroPanelBackground: 'var(--background-alt-beige-gris-galet)'
 }
@@ -104,7 +129,10 @@ export const articlePrerequisEtapesIntegrationAPI: ArticleMeta = {
     ARTICLE_KEYWORDS.api,
     ARTICLE_KEYWORDS.guideTechnique,
     ARTICLE_KEYWORDS.guideMetier,
-    ARTICLE_KEYWORDS.integrationTechnique, ARTICLE_KEYWORDS.dsi, ARTICLE_KEYWORDS.moa, ARTICLE_KEYWORDS.editeurDeLogiciels
+    ARTICLE_KEYWORDS.integrationTechnique,
+    ARTICLE_KEYWORDS.dsi,
+    ARTICLE_KEYWORDS.moa,
+    ARTICLE_KEYWORDS.editeurDeLogiciels
   ],
   heroBackdropGradient: 'linear-gradient(135deg, #decdbd 0%, #a3afce 100%)',
   heroPanelBackground: 'var(--background-alt-beige-gris-galet)'
@@ -116,7 +144,13 @@ export const articleVosInterlocuteursSelonTypeAPI: ArticleMeta = {
   title: "Vos interlocuteurs selon le type d'API",
   description:
     "Identifiez votre interlocuteur selon le type d'API que vous intégrez et selon votre situation.",
-  articleKeywords: [ARTICLE_KEYWORDS.api, ARTICLE_KEYWORDS.guideMetier, ARTICLE_KEYWORDS.dsi, ARTICLE_KEYWORDS.moa, ARTICLE_KEYWORDS.editeurDeLogiciels],
+  articleKeywords: [
+    ARTICLE_KEYWORDS.api,
+    ARTICLE_KEYWORDS.guideMetier,
+    ARTICLE_KEYWORDS.dsi,
+    ARTICLE_KEYWORDS.moa,
+    ARTICLE_KEYWORDS.editeurDeLogiciels
+  ],
   heroBackdropGradient: 'linear-gradient(135deg, #decdbd 0%, #e3e3fd 100%)',
   heroPanelBackground: 'var(--background-alt-beige-gris-galet)'
 }
@@ -127,7 +161,14 @@ export const articleAnticiperParcoursUsager: ArticleMeta = {
   title: "Anticiper le parcours usager avant d'intégrer vos API",
   description:
     'API délivrant des données publiques ou protégées : ce guide détaille les parcours usager possibles pour intégrer une API.',
-  articleKeywords: [ARTICLE_KEYWORDS.api, ARTICLE_KEYWORDS.parcoursUsager, ARTICLE_KEYWORDS.guideMetier, ARTICLE_KEYWORDS.dsi, ARTICLE_KEYWORDS.moa, ARTICLE_KEYWORDS.editeurDeLogiciels],
+  articleKeywords: [
+    ARTICLE_KEYWORDS.api,
+    ARTICLE_KEYWORDS.parcoursUsager,
+    ARTICLE_KEYWORDS.guideMetier,
+    ARTICLE_KEYWORDS.dsi,
+    ARTICLE_KEYWORDS.moa,
+    ARTICLE_KEYWORDS.editeurDeLogiciels
+  ],
   heroBackdropGradient: 'linear-gradient(135deg, #decdbd 0%, #cfe0ef 100%)',
   heroPanelBackground: 'var(--background-alt-beige-gris-galet)'
 }

--- a/src/custom/simplifions/views/articles/ApiSireneDemo.vue
+++ b/src/custom/simplifions/views/articles/ApiSireneDemo.vue
@@ -27,13 +27,19 @@
       />
     </form>
 
-    <div v-if="loading" class="fr-mt-3w sirene-demo__loading" aria-live="polite">
+    <div
+      v-if="loading"
+      class="fr-mt-3w sirene-demo__loading"
+      aria-live="polite"
+    >
       <div class="sirene-demo__spinner" aria-hidden="true" />
       <p class="fr-text--sm fr-mb-0">Interrogation de l'API en cours…</p>
     </div>
 
     <div v-if="result" class="fr-mt-3w fr-p-5v sirene-demo__result">
-      <p class="fr-text--bold fr-text--lg fr-mb-1v sirene-demo__company-name">{{ denomination }}</p>
+      <p class="fr-text--bold fr-text--lg fr-mb-1v sirene-demo__company-name">
+        {{ denomination }}
+      </p>
       <p class="fr-text--sm fr-mb-2w sirene-demo__siret-display">
         SIRET : {{ formatSiret(result.siege?.siret ?? siretInput) }}
       </p>
@@ -45,7 +51,10 @@
             <dd>{{ adresse }}</dd>
           </div>
         </div>
-        <div v-if="result.siege?.activite_principale" class="fr-col-12 fr-col-sm-6">
+        <div
+          v-if="result.siege?.activite_principale"
+          class="fr-col-12 fr-col-sm-6"
+        >
           <div class="sirene-demo__field fr-p-3v">
             <dt class="fr-mb-1v fr-text--xs">Activité principale (Code NAF)</dt>
             <dd>{{ result.siege.activite_principale }}</dd>
@@ -72,9 +81,11 @@
         </div>
       </dl>
 
-      <p class="fr-text--xs fr-mt-2w fr-pt-3v fr-mb-0 ">
-        <i>Ces données ont été récupérées en temps réel auprès de l'API SIRENE,
-        sans que vous ayez eu à les saisir manuellement.</i>
+      <p class="fr-text--xs fr-mt-2w fr-pt-3v fr-mb-0">
+        <i
+          >Ces données ont été récupérées en temps réel auprès de l'API SIRENE,
+          sans que vous ayez eu à les saisir manuellement.</i
+        >
       </p>
     </div>
   </div>
@@ -129,20 +140,24 @@ const search = async () => {
     }
     result.value = data.results[0]
   } catch {
-    error.value = 'Une erreur est survenue lors de la requête. Vérifiez le numéro et réessayez.'
+    error.value =
+      'Une erreur est survenue lors de la requête. Vérifiez le numéro et réessayez.'
   } finally {
     loading.value = false
   }
 }
 
-const denomination = computed(() =>
-  result.value?.nom_complet || result.value?.nom_raison_sociale || '—'
+const denomination = computed(
+  () => result.value?.nom_complet || result.value?.nom_raison_sociale || '—'
 )
 
 const adresse = computed(() => result.value?.siege?.adresse ?? '')
 
 const categorieJuridique = computed(
-  () => result.value?.siege?.libelle_nature_juridique ?? result.value?.nature_juridique ?? ''
+  () =>
+    result.value?.siege?.libelle_nature_juridique ??
+    result.value?.nature_juridique ??
+    ''
 )
 
 const estActif = computed(() => result.value?.etat_administratif === 'A')
@@ -205,8 +220,4 @@ const formatSiret = (s: string) =>
   height: 100%;
   box-sizing: border-box;
 }
-
-
-
-
 </style>

--- a/src/custom/simplifions/views/articles/ArticleAnticiperParcoursUsager.vue
+++ b/src/custom/simplifions/views/articles/ArticleAnticiperParcoursUsager.vue
@@ -10,11 +10,9 @@
   >
     <p class="fr-text--lg">
       Avant d'intégrer une API, il faut décider à quel endroit et comment vous
-      allez récupérer le
-      paramètre d'appel et afficher les données transmises par l'API.
-      C'est un choix déterminant pour la
-      qualité de l'expérience usager — d'autant plus lorsque l'API délivre des
-      données protégées.
+      allez récupérer le paramètre d'appel et afficher les données transmises
+      par l'API. C'est un choix déterminant pour la qualité de l'expérience
+      usager — d'autant plus lorsque l'API délivre des données protégées.
     </p>
 
     <SimplifionsArticleReadMore
@@ -26,10 +24,10 @@
       id="parcours-donnees-publiques"
       label="Parcours avec données publiques"
     >
-          <template #heading>Parcours usager avec des données publiques</template>
+      <template #heading>Parcours usager avec des données publiques</template>
       <p class="fr-text--lg">
-        Lorsque la donnée délivrée par l'API est publique, une simple saisie
-        du paramètre d'appel suffit à déclencher la récupération automatique.
+        Lorsque la donnée délivrée par l'API est publique, une simple saisie du
+        paramètre d'appel suffit à déclencher la récupération automatique.
       </p>
 
       <ol class="fr-mb-3w">
@@ -37,51 +35,55 @@
           L'usager débute sa démarche. Il n'a pas eu besoin de s'authentifier ni
           même de se connecter.
         </li>
-        <li>Au début du parcours, il saisit le ou les paramètres d'appel requis.</li>
+        <li>
+          Au début du parcours, il saisit le ou les paramètres d'appel requis.
+        </li>
         <li>
           Les données publiques transmises par l'API pré-remplissent les champs
-          connus. Si l'usager identifie une erreur ou souhaite apporter une modification, un parcours dédié lui permet de le faire directement ou bien d'en faire la demande.
+          connus. Si l'usager identifie une erreur ou souhaite apporter une
+          modification, un parcours dédié lui permet de le faire directement ou
+          bien d'en faire la demande.
         </li>
       </ol>
 
-         <div class="user-example fr-p-2w">
-        <p class="fr-mb-0">  💬
+      <div class="user-example fr-p-2w">
+        <p class="fr-mb-0">
+          💬
           <b
-            >Exemple avec Gilles, bénévole d'une association, souhaitant réserver
-            la salle communale</b
-          ></p>
-        <p class="fr-text--alt fr-text--lg">
-        
-          <i
-            >Gilles se rend sur le site de la mairie, ouvre le
-            formulaire dédié à cette démarche, saisit le numéro RNA de son
-            association. Le nom, le régime, l'adresse et les activités
-            principales de l'association sont automatiquement saisies dans le
-            formulaire. S'il s'aperçoit qu'une donnée n'est pas à jour, il peut
-            modifier le champ pré-rempli.</i
+            >Exemple avec Gilles, bénévole d'une association, souhaitant
+            réserver la salle communale</b
           >
         </p>
-    
-
-      <blockquote class="fr-highlight fr-highlight--grey-border">
-        <p>
-          ⚙️ <strong>Que s'est-il passé techniquement ?</strong> Le formulaire
-          de la mairie intègre l'API Association du Ministère des Sports ou bien
-          l'API données association en open data de l'API Entreprise. Le numéro
-          RNA est le paramètre d'appel de cette API. Au moment où il est saisi
-          par l'usager, un appel se déclenche.
+        <p class="fr-text--alt fr-text--lg">
+          <i
+            >Gilles se rend sur le site de la mairie, ouvre le formulaire dédié
+            à cette démarche, saisit le numéro RNA de son association. Le nom,
+            le régime, l'adresse et les activités principales de l'association
+            sont automatiquement saisies dans le formulaire. S'il s'aperçoit
+            qu'une donnée n'est pas à jour, il peut modifier le champ
+            pré-rempli.</i
+          >
         </p>
-      </blockquote>
+
+        <blockquote class="fr-highlight fr-highlight--grey-border">
+          <p>
+            ⚙️ <strong>Que s'est-il passé techniquement ?</strong> Le formulaire
+            de la mairie intègre l'API Association du Ministère des Sports ou
+            bien l'API données association en open data de l'API Entreprise. Le
+            numéro RNA est le paramètre d'appel de cette API. Au moment où il
+            est saisi par l'usager, un appel se déclenche.
+          </p>
+        </blockquote>
       </div>
 
       <p class="fr-mt-3w">
-        <b>Ce parcours est le plus rapide à mettre en œuvre</b>, car il ne nécessite
-        aucune brique d'authentification. En revanche, il ne s'applique qu'aux
-        données non protégées (ex. la dénomination d'une entreprise) car rien
-        n'empêche techniquement un tiers de saisir le même identifiant pour
-        récupérer la donnée, voire faire des appels en masse pour récupérer
-        toutes les données de l'API. Aucune donnée sensible ne doit être exposée
-        par ce biais.
+        <b>Ce parcours est le plus rapide à mettre en œuvre</b>, car il ne
+        nécessite aucune brique d'authentification. En revanche, il ne
+        s'applique qu'aux données non protégées (ex. la dénomination d'une
+        entreprise) car rien n'empêche techniquement un tiers de saisir le même
+        identifiant pour récupérer la donnée, voire faire des appels en masse
+        pour récupérer toutes les données de l'API. Aucune donnée sensible ne
+        doit être exposée par ce biais.
       </p>
     </ArticleSection>
 
@@ -89,11 +91,11 @@
       id="parcours-donnees-protegees"
       label="Parcours avec données protégées"
     >
-           <template #heading>Parcours usager avec des données protégées</template>
+      <template #heading>Parcours usager avec des données protégées</template>
       <p class="fr-text--lg">
-        Lorsque la donnée délivrée par l'API est protégée, quatre parcours
-        sont possibles selon le niveau de confiance disponible sur l'identité
-        de l'usager.
+        Lorsque la donnée délivrée par l'API est protégée, quatre parcours sont
+        possibles selon le niveau de confiance disponible sur l'identité de
+        l'usager.
       </p>
 
       <h3>
@@ -103,7 +105,10 @@
 
       <ol class="fr-mb-3w">
         <li>L'usager débute sa démarche, sans s'authentifier.</li>
-        <li>Il saisit les informations le concernant qui permettent l'appel à l'API.</li>
+        <li>
+          Il saisit les informations le concernant qui permettent l'appel à
+          l'API.
+        </li>
         <li>
           <strong>Du côté de l'usager :</strong> Un message indique alors à
           l'usager le nombre de justificatifs ou données requis qui ont pu être
@@ -112,25 +117,31 @@
           justificatif qui a été transmis. Si un justificatif n'a pas pu être
           récupéré, l'usager peut le déposer par lui-même.
           <br />
-          <br/>
+          <br />
           <strong>Du côté de l'agent habilité :</strong> Les justificatifs et
           données protégés ont été mis à disposition dans le dossier de
           l'usager. L'agent est informé si les pièces ont été récupérées par API
           (donc directement à la source) ou si elles ont été déposées par
           l'usager.
-          <br/>
-            <blockquote class="fr-highlight fr-mt-2v">💡 Selon ce que l'agent est autorisé de consulter, vous pouvez adapter les informations que vous lui montrez. Par exemple, plutôt que de donner l'information précise telle que le quotient familial, vous pouvez plutôt indiquer la tranche de quotient familial.</blockquote>
+          <br />
+          <blockquote class="fr-highlight fr-mt-2v">
+            💡 Selon ce que l'agent est autorisé de consulter, vous pouvez
+            adapter les informations que vous lui montrez. Par exemple, plutôt
+            que de donner l'information précise telle que le quotient familial,
+            vous pouvez plutôt indiquer la tranche de quotient familial.
+          </blockquote>
         </li>
       </ol>
 
       <div class="user-example fr-p-2w">
-        <p class="fr-mb-0">  💬
+        <p class="fr-mb-0">
+          💬
           <b
             >Exemple avec Camille, agricultrice, et Nicolas, agent
             territorial</b
-          ></p>
+          >
+        </p>
         <p class="fr-text--alt fr-text--lg">
-        
           <br />
           <i
             >Camille a besoin d'un emplacement sur le marché de sa commune pour
@@ -151,31 +162,33 @@
           <i
             >Nicolas, agent instructeur habilité, reçoit la demande. Depuis la
             fiche entreprise de Camille, il voit en un coup d'œil que toutes les
-            pièces sont réunies : quatre sont récupérées à la source via
-            API, une a été déposée manuellement. Il concentre son contrôle sur ce dernier
-            document et valide la demande.</i
+            pièces sont réunies : quatre sont récupérées à la source via API,
+            une a été déposée manuellement. Il concentre son contrôle sur ce
+            dernier document et valide la demande.</i
           >
         </p>
 
-
-      <blockquote class="fr-highlight fr-highlight--grey-border">
-        <p>
-          ⚙️ <strong>Que s'est-il passé techniquement ?</strong> Le portail de
-          la commune intègre plusieurs API. Le SIRET saisi par Camille sert de
-          paramètre d'appel. Les documents récupérés sont stockés côté
-          back-office et associés au dossier de Camille, sans lui être
-          directement exposés.
-        </p>
-      </blockquote>
+        <blockquote class="fr-highlight fr-highlight--grey-border">
+          <p>
+            ⚙️ <strong>Que s'est-il passé techniquement ?</strong> Le portail de
+            la commune intègre plusieurs API. Le SIRET saisi par Camille sert de
+            paramètre d'appel. Les documents récupérés sont stockés côté
+            back-office et associés au dossier de Camille, sans lui être
+            directement exposés.
+          </p>
+        </blockquote>
       </div>
 
       <p class="fr-mt-3w">
-        <b>Ce parcours est le parcours à privilégier lorsqu'il n'est pas possible
-        de s'assurer de l'identité réelle d'un individu</b> s'étant créé un compte
-        dans vos systèmes d'information. Il présente l'avantage de rendre la
-        démarche plus découvrable car aucune authentification n'est requise. En
-        revanche, l'usager ne voit pas les pièces justificatives qu'il transmet,
-        ce qui peut être délicat dans certaines situations.
+        <b
+          >Ce parcours est le parcours à privilégier lorsqu'il n'est pas
+          possible de s'assurer de l'identité réelle d'un individu</b
+        >
+        s'étant créé un compte dans vos systèmes d'information. Il présente
+        l'avantage de rendre la démarche plus découvrable car aucune
+        authentification n'est requise. En revanche, l'usager ne voit pas les
+        pièces justificatives qu'il transmet, ce qui peut être délicat dans
+        certaines situations.
       </p>
 
       <h3>
@@ -200,31 +213,36 @@
       </ol>
 
       <div class="user-example fr-p-2w fr-mb-4w">
-        <p class="fr-mb-0">  💬
-          <b
-            >Exemple avec Élisabeth, allocataire, et Karim, agent en
-            CCAS</b
-          >
+        <p class="fr-mb-0">
+          💬
+          <b>Exemple avec Élisabeth, allocataire, et Karim, agent en CCAS</b>
         </p>
         <p class="fr-text--alt fr-text--lg">
-            <i
+          <i
             >Élisabeth se présente au guichet de son centre communal d'action
-            sociale. Karim, agent habilité, ouvre le dossier de Élisabeth et lui demande ses informations d'état civil. Élisabeth épelle son nom, son prénom et indique sa date et son lieu de naissance. Karim saisit ces informations dans le logiciel du CCAS pour récupérer la composition familiale, l'adresse et le quotient familial de Élisabeth.</i
+            sociale. Karim, agent habilité, ouvre le dossier de Élisabeth et lui
+            demande ses informations d'état civil. Élisabeth épelle son nom, son
+            prénom et indique sa date et son lieu de naissance. Karim saisit ces
+            informations dans le logiciel du CCAS pour récupérer la composition
+            familiale, l'adresse et le quotient familial de Élisabeth.</i
           >
           <br />
           <i
-            >Les données de Élisabeth s'affichent instantanément : Karim
-            peut poursuivre l'instruction sans lui demander d'attestation de quotient familial, ni de justificatif d'adresse, ni de livret de famille.</i
+            >Les données de Élisabeth s'affichent instantanément : Karim peut
+            poursuivre l'instruction sans lui demander d'attestation de quotient
+            familial, ni de justificatif d'adresse, ni de livret de famille.</i
           >
         </p>
 
-
-      <blockquote class="fr-highlight fr-highlight--grey-border">
-        <p>
-          ⚙️ <strong>Que s'est-il passé techniquement ?</strong> Le logiciel
-          métier du CCAS intègre l'API quotient familial du bouquet API Particulier. En saisissant les informations d'état civil d'Élisabeth, Karim renseigne en réalité les paramètres d'appel de l'API ce qui déclenche la requête.
-        </p>
-      </blockquote>
+        <blockquote class="fr-highlight fr-highlight--grey-border">
+          <p>
+            ⚙️ <strong>Que s'est-il passé techniquement ?</strong> Le logiciel
+            métier du CCAS intègre l'API quotient familial du bouquet API
+            Particulier. En saisissant les informations d'état civil
+            d'Élisabeth, Karim renseigne en réalité les paramètres d'appel de
+            l'API ce qui déclenche la requête.
+          </p>
+        </blockquote>
       </div>
 
       <h3>
@@ -233,27 +251,37 @@
 
       <ol class="fr-mb-3w">
         <li>
-          L'usager se connecte à son compte. Son identité a été vérifiée par l'administration en charge du service : elle sait que ce compte appartient bien à la bonne personne.
+          L'usager se connecte à son compte. Son identité a été vérifiée par
+          l'administration en charge du service : elle sait que ce compte
+          appartient bien à la bonne personne.
         </li>
         <li>
-          L'usager saisit le ou les paramètres d'appel nécessaires, à moins que ceux-ci ne
-          soient déjà disponibles dans son compte. Dans ce dernier cas, les informations déjà connues dans le compte ne sont pas redemandées (par exemple son prénom et son
-          nom).
+          L'usager saisit le ou les paramètres d'appel nécessaires, à moins que
+          ceux-ci ne soient déjà disponibles dans son compte. Dans ce dernier
+          cas, les informations déjà connues dans le compte ne sont pas
+          redemandées (par exemple son prénom et son nom).
         </li>
         <li>
           La donnée protégée est récupérée et affichée directement dans son
           espace usager.
         </li>
-        <li>Si l'usager identifie une erreur dans les données ou souhaite apporter une modification, l'interface lui permet.  <router-link to="#parcours-alternatifs"
-          >Plus d'informations sur parcours altenratifs</router-link
-        >.</li>
+        <li>
+          Si l'usager identifie une erreur dans les données ou souhaite apporter
+          une modification, l'interface lui permet.
+          <router-link to="#parcours-alternatifs"
+            >Plus d'informations sur parcours altenratifs</router-link
+          >.
+        </li>
       </ol>
 
       <div class="user-example fr-p-2w fr-mb-4w">
-        <p class="fr-mb-0">  💬
+        <p class="fr-mb-0">
+          💬
           <b
-            >Exemple avec Léa, étudiante, ayant besoin d'une carte de transport</b
-          ></p>
+            >Exemple avec Léa, étudiante, ayant besoin d'une carte de
+            transport</b
+          >
+        </p>
         <p class="fr-text--alt fr-text--lg">
           <i
             >Léa souhaite renouveler son abonnement annuel de transport pour sa
@@ -275,55 +303,54 @@
           >
         </p>
 
+        <blockquote class="fr-highlight fr-highlight--grey-border">
+          <p>
+            ⚙️ <strong>Que s'est-il passé techniquement ?</strong> Le portail de
+            l'opérateur de transport dans sa ville intègre les API statut
+            étudiant et statut étudiant boursier. Le numéro INE, un des
+            paramètres d'appel de ces API, est déjà connu car saisi par Léa dans
+            son compte l'année précédente. En confirmant son INE, Léa déclenche
+            la requête auprès des API qui retournent son statut.
+          </p>
+        </blockquote>
 
-      <blockquote class="fr-highlight fr-highlight--grey-border">
-        <p>
-          ⚙️ <strong>Que s'est-il passé techniquement ?</strong> Le portail de
-          l'opérateur de transport dans sa ville intègre les API statut étudiant
-          et statut étudiant boursier. Le numéro INE, un des paramètres d'appel de ces
-          API, est déjà connu car saisi par Léa dans son compte l'année
-          précédente. En confirmant son INE, Léa déclenche la requête auprès des
-          API qui retournent son statut.
+        <p class="fr-text--alt fr-text--lg fr-mt-3v">
+          <i
+            >Imaginons que la récupération automatique d'un des justificatifs
+            n'ait pas fonctionné. Le statut boursier de Léa n'a pas pu être
+            récupéré. Il lui est alors proposé de pouvoir déposer son document
+            (qui sera traité par un agent) et même de pouvoir s'abonner sans
+            bénéficier du tarif. L'important est de laisser un maximum de
+            liberté à Léa et de ne pas la bloquer si la récupération automatique
+            par API échoue.</i
+          >
         </p>
-      </blockquote>
-
-      <p class="fr-text--alt fr-text--lg fr-mt-3v">
-        <i
-          >Imaginons que la récupération automatique d'un des justificatifs
-          n'ait pas fonctionné. Le statut boursier de Léa n'a pas pu être
-          récupéré. Il lui est alors proposé de pouvoir déposer son document
-          (qui sera traité par un agent) et même de pouvoir s'abonner sans
-          bénéficier du tarif. L'important est de laisser un maximum de liberté
-          à Léa et de ne pas la bloquer si la récupération automatique par API
-          échoue.</i
-        >
-      </p>
       </div>
 
-        <div class="user-example fr-p-2w fr-mb-4w">
+      <div class="user-example fr-p-2w fr-mb-4w">
         <b>D'autres exemples avec le démonstrateur de l'API Particulier :</b>
-    
-          <ul class="fr-mb-0">
-            <li>
-              Démonstration avec Juliette, étudiante — Tarification transport :
-              <a
-                href="https://demonstrateur.particulier.api.gouv.fr/transport/souscription?user=2"
-                target="_blank"
-                rel="noopener noreferrer"
-                >demonstrateur.particulier.api.gouv.fr</a
-              >
-            </li>
-            <li>
-              Démonstration avec Kevin — Tarification cantine pour ses enfants :
-              <a
-                href="https://demonstrateur.particulier.api.gouv.fr/cantine/souscription?user=4"
-                target="_blank"
-                rel="noopener noreferrer"
-                >demonstrateur.particulier.api.gouv.fr</a
-              >
-            </li>
-          </ul>
-        </div>
+
+        <ul class="fr-mb-0">
+          <li>
+            Démonstration avec Juliette, étudiante — Tarification transport :
+            <a
+              href="https://demonstrateur.particulier.api.gouv.fr/transport/souscription?user=2"
+              target="_blank"
+              rel="noopener noreferrer"
+              >demonstrateur.particulier.api.gouv.fr</a
+            >
+          </li>
+          <li>
+            Démonstration avec Kevin — Tarification cantine pour ses enfants :
+            <a
+              href="https://demonstrateur.particulier.api.gouv.fr/cantine/souscription?user=4"
+              target="_blank"
+              rel="noopener noreferrer"
+              >demonstrateur.particulier.api.gouv.fr</a
+            >
+          </li>
+        </ul>
+      </div>
 
       <p>
         <b>Ce parcours implique de disposer d'un système d'authentification</b>
@@ -333,9 +360,6 @@
         l'API, évitez de les redemander à l'usager lors du parcours,
         permettez-lui simplement de les confirmer !
       </p>
-
-    
-    
 
       <h3>D. Via FranceConnect</h3>
 
@@ -348,19 +372,22 @@
           concernant vont être transmises à ce site. L'usager valide.
         </li>
         <li>
-          L'usager est alors connecté au compte du service en question. Les données protégées sont
-          pré-remplies dans sa démarche.
+          L'usager est alors connecté au compte du service en question. Les
+          données protégées sont pré-remplies dans sa démarche.
         </li>
-        <li>Si l'usager identifie une erreur dans les données ou souhaite apporter une modification, l'interface lui permet.  <router-link to="#parcours-alternatifs"
-          >Plus d'informations sur parcours altenratifs</router-link
-        >.</li>
+        <li>
+          Si l'usager identifie une erreur dans les données ou souhaite apporter
+          une modification, l'interface lui permet.
+          <router-link to="#parcours-alternatifs"
+            >Plus d'informations sur parcours altenratifs</router-link
+          >.
+        </li>
       </ol>
 
-         <div class="user-example fr-p-2w fr-mb-4w">
-        <p class="fr-mb-0">  💬
-          <b
-            >Exemple avec Malik, inscrivant ses enfants à la cantine</b
-          ></p>
+      <div class="user-example fr-p-2w fr-mb-4w">
+        <p class="fr-mb-0">
+          💬 <b>Exemple avec Malik, inscrivant ses enfants à la cantine</b>
+        </p>
         <p class="fr-text--alt fr-text--lg">
           <i
             >Malik souhaite inscrire ses enfants à la cantine municipale. Sur le
@@ -377,91 +404,88 @@
           <i
             >Une fois FranceConnecté, il n'a rien de plus à saisir : son
             quotient familial, la liste de ses enfants, et son revenu fiscal de
-            référence ont été automatiquement récupérés, il peut les consulter avant d'envoyer son dossier. S'il identifie une erreur, Malik peut proposer une autre information et déposer un justificatif.</i
+            référence ont été automatiquement récupérés, il peut les consulter
+            avant d'envoyer son dossier. S'il identifie une erreur, Malik peut
+            proposer une autre information et déposer un justificatif.</i
           >
         </p>
 
-
-      <blockquote class="fr-highlight fr-highlight--grey-border">
-        <p>
-          ⚙️ <strong>Que s'est-il passé techniquement ?</strong> Le portail de
-          la commune intègre FranceConnect et les API FranceConnectées Quotient
-          familial CAF &amp; MSA du bouquet API Particulier et l'API Impôt
-          Particulier de la DGFIP. Les paramètres d'appel de ces API n'ont pas à
-          être saisis par Malik : en effet l'appel est déclenché avec l'identité
-          pivot (son état civil) connue de FranceConnect, au moment de la
-          FranceConnexion. Au moment où Malik confirme la liste des données
-          transmises au site, il permet à la fois sa connexion et l'appel aux
-          API.
-        </p>
-      </blockquote>
+        <blockquote class="fr-highlight fr-highlight--grey-border">
+          <p>
+            ⚙️ <strong>Que s'est-il passé techniquement ?</strong> Le portail de
+            la commune intègre FranceConnect et les API FranceConnectées
+            Quotient familial CAF &amp; MSA du bouquet API Particulier et l'API
+            Impôt Particulier de la DGFIP. Les paramètres d'appel de ces API
+            n'ont pas à être saisis par Malik : en effet l'appel est déclenché
+            avec l'identité pivot (son état civil) connue de FranceConnect, au
+            moment de la FranceConnexion. Au moment où Malik confirme la liste
+            des données transmises au site, il permet à la fois sa connexion et
+            l'appel aux API.
+          </p>
+        </blockquote>
       </div>
 
-      
-
-        <div class="user-example fr-p-2w fr-mb-4w">
+      <div class="user-example fr-p-2w fr-mb-4w">
         <b>D'autres exemples avec le démonstrateur de l'API Particulier :</b>
-          <ul class="fr-mb-0">
-            <li>
-              Démonstration avec Nicolas, demandeur d'emploi — Tarification
-              transport :
-              <a
-                href="https://demonstrateur.particulier.api.gouv.fr/fr/transport/souscription?user=1"
-                target="_blank"
-                rel="noopener noreferrer"
-                >demonstrateur.particulier.api.gouv.fr</a
-              >
-            </li>
-            <li>
-              Démonstration avec Camille — Tarification cantine pour ses enfants
-              :
-              <a
-                href="https://demonstrateur.particulier.api.gouv.fr/fr/cantine/souscription?user=3"
-                target="_blank"
-                rel="noopener noreferrer"
-                >demonstrateur.particulier.api.gouv.fr</a
-              >
-            </li>
-          </ul>
-        </div>
+        <ul class="fr-mb-0">
+          <li>
+            Démonstration avec Nicolas, demandeur d'emploi — Tarification
+            transport :
+            <a
+              href="https://demonstrateur.particulier.api.gouv.fr/fr/transport/souscription?user=1"
+              target="_blank"
+              rel="noopener noreferrer"
+              >demonstrateur.particulier.api.gouv.fr</a
+            >
+          </li>
+          <li>
+            Démonstration avec Camille — Tarification cantine pour ses enfants :
+            <a
+              href="https://demonstrateur.particulier.api.gouv.fr/fr/cantine/souscription?user=3"
+              target="_blank"
+              rel="noopener noreferrer"
+              >demonstrateur.particulier.api.gouv.fr</a
+            >
+          </li>
+        </ul>
+      </div>
 
       <p class="fr-mt-3w">
-        <b>Ce parcours bénéficie de la sécurité apportée par FranceConnect</b>. Avec
-        FranceConnect, vous êtes sûr que le compte d'une personne est bien celui de cette personne. Pour l'usager c'est aussi bien plus simple, la récupération des
-        données protégées se fait sans besoin de ressaisir des paramètres.
+        <b>Ce parcours bénéficie de la sécurité apportée par FranceConnect</b>.
+        Avec FranceConnect, vous êtes sûr que le compte d'une personne est bien
+        celui de cette personne. Pour l'usager c'est aussi bien plus simple, la
+        récupération des données protégées se fait sans besoin de ressaisir des
+        paramètres.
         <br />
         Toutefois, comme tous les usagers n'utilisent pas FranceConnect, cette
-        modalité doit au moins être combinée aux parcours A ou C pour couvrir l'ensemble
-        des usagers.
+        modalité doit au moins être combinée aux parcours A ou C pour couvrir
+        l'ensemble des usagers.
       </p>
-
     </ArticleSection>
 
     <ArticleSection id="parcours-alternatifs" label="Parcours alternatifs">
       <template #heading>Parcours alternatifs</template>
 
       <p class="fr-text--lg">
-        
         <strong
           >Quel que soit le parcours retenu, prévoyez toujours des parcours
           alternatifs.</strong
         >
-        Aucune API n'est fiable à 100% : en cas de panne,
-        de donnée manquante ou erronnée, l'usager doit pouvoir saisir l'information
-        manuellement ou déposer le document lui-même, sans que sa démarche
-        soit bloquée.
+        Aucune API n'est fiable à 100% : en cas de panne, de donnée manquante ou
+        erronnée, l'usager doit pouvoir saisir l'information manuellement ou
+        déposer le document lui-même, sans que sa démarche soit bloquée.
       </p>
 
-    <SimplifionsArticleReadMore
-      to="/articles/prerequis-et-etapes-integration-api#limites"
-      description="En savoir plus sur les limites des API :"
-      section-title="Les limites des API"
-    />
+      <SimplifionsArticleReadMore
+        to="/articles/prerequis-et-etapes-integration-api#limites"
+        description="En savoir plus sur les limites des API :"
+        section-title="Les limites des API"
+      />
 
       <h3>Pallier une panne ou une indisponibilité de l'API</h3>
       <p>
-        Une API peut être indisponible, retourner une erreur, ou ne pas avoir
-        la donnée recherchée. Le parcours doit alors permettre à l'usager de
+        Une API peut être indisponible, retourner une erreur, ou ne pas avoir la
+        donnée recherchée. Le parcours doit alors permettre à l'usager de
         continuer sa démarche autrement : saisie manuelle de l'information, ou
         dépôt du justificatif par ses soins. Un incident technique ne doit
         jamais bloquer l'usager.
@@ -469,25 +493,30 @@
       <h3 class="fr-mt-3w">Pallier une erreur de donnée</h3>
       <p>
         Un usager peut aussi constater que la donnée récupérée par API est
-        erronée ou périmée. Le parcours alternatif à proposer dépend alors de
-        la fiabilité de l'API :
+        erronée ou périmée. Le parcours alternatif à proposer dépend alors de la
+        fiabilité de l'API :
       </p>
       <p>
         <strong
-          >Pour les API dont la fraîcheur ou la qualité de la donnée n'est
-          pas garantie</strong
+          >Pour les API dont la fraîcheur ou la qualité de la donnée n'est pas
+          garantie</strong
         >, il peut être utile de permettre à l'usager de saisir directement
-        l'information. 
+        l'information.
       </p>
       <p>
         <strong
           >Pour les API très fiables en termes de qualité et de fraîcheur de
           données</strong
-        >, il est préférable de ne pas proposer à l'usager de "corriger" la donnée récupérée par API, mais plutôt de lui proposer un
-        parcours alternatif dans lequel il peut
-        suggérer sa correction, en déposant un élément qui justifie sa demande de correction.
+        >, il est préférable de ne pas proposer à l'usager de "corriger" la
+        donnée récupérée par API, mais plutôt de lui proposer un parcours
+        alternatif dans lequel il peut suggérer sa correction, en déposant un
+        élément qui justifie sa demande de correction.
       </p>
-      <p>Dans les deux situations, assurez-vous de toujours indiquer à l'agent d'où provient l'information : est-elle récupérée par API ou indiquée par l'usager ? Pour lui permettre d'arbitrer, fournissez-lui les deux informations.
+      <p>
+        Dans les deux situations, assurez-vous de toujours indiquer à l'agent
+        d'où provient l'information : est-elle récupérée par API ou indiquée par
+        l'usager ? Pour lui permettre d'arbitrer, fournissez-lui les deux
+        informations.
       </p>
     </ArticleSection>
 
@@ -495,20 +524,28 @@
       <SimplifionsArticleChecklist>
         <li>
           <strong
-            >Le choix du parcours dépend de l'ouverture de la donnée transmise par API.</strong
+            >Le choix du parcours dépend de l'ouverture de la donnée transmise
+            par API.</strong
           >
-          Lorsque la donnée est plubique, le parcours est facile car la réponse de l'API peut être affichée. En revanche lorsque la donnée est protégée, les parcours possibles sont construits de façon à s'assurer que la donnée protégée sera
-          visible uniquement par les bonnes personnes.
+          Lorsque la donnée est plubique, le parcours est facile car la réponse
+          de l'API peut être affichée. En revanche lorsque la donnée est
+          protégée, les parcours possibles sont construits de façon à s'assurer
+          que la donnée protégée sera visible uniquement par les bonnes
+          personnes.
         </li>
         <li>
-          <strong>Quatre parcours possibles pour les données protégées :</strong>
+          <strong
+            >Quatre parcours possibles pour les données protégées :</strong
+          >
           Transmission directe aux instructeurs sans montrer la donnée à
           l'usager si son identité n'est pas vérifiée, consultation par un agent
           en guichet, affichage à l'usager après vérification de son identité
           via son compte usager ou FranceConnect.
         </li>
         <li>
-          <strong>Prévoyez toujours un parcours alternatif.</strong> En cas de panne, de donnée obsolète ou erronnée, l'usager doit pouvoir saisir l'information et déposer un justificatif.
+          <strong>Prévoyez toujours un parcours alternatif.</strong> En cas de
+          panne, de donnée obsolète ou erronnée, l'usager doit pouvoir saisir
+          l'information et déposer un justificatif.
         </li>
       </SimplifionsArticleChecklist>
     </ArticleSection>

--- a/src/custom/simplifions/views/articles/ArticleApisFranceConnectees.vue
+++ b/src/custom/simplifions/views/articles/ArticleApisFranceConnectees.vue
@@ -329,11 +329,11 @@ import ArticleSection from '../../components/article/SimplifionsArticleSection.v
 import SimplifionsArticleTopicSpotlight from '../../components/article/SimplifionsArticleTopicSpotlight.vue'
 import SimplifionsDataApi from '../../components/SimplifionsDataApi.vue'
 import { grist } from '../../grist'
-import type { ApiOrDataset } from '../../model/grist'
 import {
   articleApisFranceConnectees as articleMeta,
   getArticleBreadcrumbLinks
 } from '../../model/articles'
+import type { ApiOrDataset } from '../../model/grist'
 
 const breadcrumbLinks = getArticleBreadcrumbLinks(articleMeta.h1)
 

--- a/src/custom/simplifions/views/articles/ArticlePrerequisEtapesIntegrationAPI.vue
+++ b/src/custom/simplifions/views/articles/ArticlePrerequisEtapesIntegrationAPI.vue
@@ -15,24 +15,28 @@
         qui demande une réduction de transport&nbsp;? C'est possible grâce aux
         API référencées dans le catalogue de Simplifions.data</em
       >. Néanmoins, entre le moment où vous prenez connaissance de l'existence
-      d'une API et le moment où elle est utilisée en
-      production dans votre service, plusieurs étapes se succèdent. 
+      d'une API et le moment où elle est utilisée en production dans votre
+      service, plusieurs étapes se succèdent.
     </p>
     <p class="fr-text-lg">
-      <b>Ce
-      guide s'adresse aux acteurs publics souhaitant intégrer des API</b> et donne une vision détaillée des
-      étapes et prérequis nécessaires à l'intégration de toute API conçue pour
-      simplifier des démarches via la récupération des données de l'usager —
+      <b>Ce guide s'adresse aux acteurs publics souhaitant intégrer des API</b>
+      et donne une vision détaillée des étapes et prérequis nécessaires à
+      l'intégration de toute API conçue pour simplifier des démarches via la
+      récupération des données de l'usager —
       <em>principe du «&nbsp;Dites-le-nous une fois&nbsp;»</em>.
     </p>
 
     <div class="fr-highlight fr-highlight--green-menthe fr-my-4w">
       <p>
-      <b>💡 Les informations de cet article s'appliquent si vous intégrez
-      vous-même une API.</b> Si vous passez par un éditeur de logiciel métier, la
-      charge est bien plus légère&nbsp;: il s'agit d'identifier vos
-      cas d'usages, les données utiles et de prendre connaissance des logiciels éditeurs les ayant intégrées.
-    </p>
+        <b
+          >💡 Les informations de cet article s'appliquent si vous intégrez
+          vous-même une API.</b
+        >
+        Si vous passez par un éditeur de logiciel métier, la charge est bien
+        plus légère&nbsp;: il s'agit d'identifier vos cas d'usages, les données
+        utiles et de prendre connaissance des logiciels éditeurs les ayant
+        intégrées.
+      </p>
     </div>
 
     <SimplifionsArticleReadMore
@@ -40,12 +44,11 @@
       description="Comprendre ce qu'est une API sans vocabulaire technique."
     />
 
-
-
     <ArticleSection id="prerequis" label="Prérequis">
-       <template #heading>Les prérequis avant de démarrer</template>
+      <template #heading>Les prérequis avant de démarrer</template>
       <p class="fr-text--lg">
-        Voici quatre familles de prérequis que vous pouvez vérifier bien avant d'intégrer une API pour gagner du temps :
+        Voici quatre familles de prérequis que vous pouvez vérifier bien avant
+        d'intégrer une API pour gagner du temps :
       </p>
 
       <h3>1. Un prérequis de conception : penser au parcours de vos usagers</h3>
@@ -53,11 +56,11 @@
       <h4>Vérifier que l'API délivre les données dont vous avez besoin</h4>
 
       <p>
-        Avant de demander l'accès à une API ou de vous y raccorder, prenez le temps
-        de consulter la documentation technique de l'API (souvent un <i>swagger</i> ou
-        une spécification <i>OpenAPI</i>) pour vérifier que les données renvoyées
-        correspondent réellement à votre besoin. Trois points de vigilance
-        reviennent régulièrement :
+        Avant de demander l'accès à une API ou de vous y raccorder, prenez le
+        temps de consulter la documentation technique de l'API (souvent un
+        <i>swagger</i> ou une spécification <i>OpenAPI</i>) pour vérifier que
+        les données renvoyées correspondent réellement à votre besoin. Trois
+        points de vigilance reviennent régulièrement :
       </p>
 
       <ul class="fr-mb-3w">
@@ -96,18 +99,19 @@
       </h4>
 
       <p>
-        Pour appeler une API, il faut lui
-        fournir un ou plusieurs <strong>paramètres d'appel</strong> qui permettent d'identifier
-        l'entité dont on souhaite récupérer/pré-remplir les données. Selon
-        l'API, ces paramètres peuvent être un numéro de SIRET/SIREN pour
-        une association ou une entreprise, un numéro fiscal ou les données d'état civil pour
-        un particulier.
+        Pour appeler une API, il faut lui fournir un ou plusieurs
+        <strong>paramètres d'appel</strong> qui permettent d'identifier l'entité
+        dont on souhaite récupérer/pré-remplir les données. Selon l'API, ces
+        paramètres peuvent être un numéro de SIRET/SIREN pour une association ou
+        une entreprise, un numéro fiscal ou les données d'état civil pour un
+        particulier.
       </p>
 
       <p>
         Avant d'intégrer une API, il faut donc décider à quel endroit et comment
         vous allez pouvoir obtenir ce paramètre auprès de l'usager ou de
-        l'agent. C'est un choix de conception produit à part entière qui est déterminant pour la qualité de l'expérience usager.
+        l'agent. C'est un choix de conception produit à part entière qui est
+        déterminant pour la qualité de l'expérience usager.
       </p>
 
       <h4>Maquetter ou prototyper avant de développer</h4>
@@ -116,14 +120,14 @@
         Il n'est pas nécessaire d'attendre l'accès aux API pour valider vos
         parcours. Au contraire, les anticiper en lisant les spécifications des
         API vous permettra de vous assurer que l'API correspond à votre besoin.
-        Certaines API délivrant de la donnée protégée mettent à disposition des environnements de tests qui
-        permettent même de concevoir tout votre produit avec de la donnée
-        fictive en attendant d'obtenir l'accès.
+        Certaines API délivrant de la donnée protégée mettent à disposition des
+        environnements de tests qui permettent même de concevoir tout votre
+        produit avec de la donnée fictive en attendant d'obtenir l'accès.
       </p>
 
       <SimplifionsArticleReadMore
-      to="/articles/anticiper-le-parcours-usager-avant-d-integrer-vos-api"
-      description="Découvrez comment utiliser les API au sein du parcours usager, selon que la donnée est publique ou protégée :"
+        to="/articles/anticiper-le-parcours-usager-avant-d-integrer-vos-api"
+        description="Découvrez comment utiliser les API au sein du parcours usager, selon que la donnée est publique ou protégée :"
       />
 
       <h3>
@@ -140,8 +144,8 @@
         Chaque demande d'accès doit être justifiée par un
         <strong>cadre juridique précis</strong> : texte de loi ou règlementaire
         spécifiant que votre administration est habilitée à demander ces
-        informations pour traiter une démarche usager. Pour les collectivités, une
-        <strong>délibération</strong> décrivant précisément les données
+        informations pour traiter une démarche usager. Pour les collectivités,
+        une <strong>délibération</strong> décrivant précisément les données
         nécessaires,
         <em
           >par exemple le barème tarifaire lié au quotient familial pour une
@@ -163,8 +167,9 @@
 
       <h4>Contacts</h4>
       <p class="fr-mt-3w">
-        Une demande d'habilitation mobilise généralement plusieurs contacts au sein de votre administrtation (qui
-        peuvent parfois être la même personne) :
+        Une demande d'habilitation mobilise généralement plusieurs contacts au
+        sein de votre administrtation (qui peuvent parfois être la même
+        personne) :
       </p>
 
       <div class="fr-table">
@@ -180,7 +185,11 @@
               <td><strong>Contact technique</strong></td>
               <td>
                 Responsable de l'intégration technique et de la maintenance de
-                l'API dans votre système d'information. C'est lui qui pourra récupérer les « clés d'accès techniques », en aura la gestion et devra s'assurer de leur validité. Il devra également s'informer des opérations de maintenance et des incidents. Certains services l'abonneront par défaut à ces informations.
+                l'API dans votre système d'information. C'est lui qui pourra
+                récupérer les « clés d'accès techniques », en aura la gestion et
+                devra s'assurer de leur validité. Il devra également s'informer
+                des opérations de maintenance et des incidents. Certains
+                services l'abonneront par défaut à ces informations.
               </td>
             </tr>
             <tr>
@@ -202,9 +211,10 @@
                 S'assure que l'organisation protège correctement les données
                 personnelles conformément à la réglementation. Cette personne
                 doit pouvoir exercer en toute indépendance en étant à l'abri des
-                conflits d'intérêt, elle ne peut donc pas être ni le contact technique, ni le contact métier. C'est le point de contact de la
-                CNIL en cas de problème. Dans les collectivités, le DPD est souvent mutualisé avec
-                d'autres collectivités.
+                conflits d'intérêt, elle ne peut donc pas être ni le contact
+                technique, ni le contact métier. C'est le point de contact de la
+                CNIL en cas de problème. Dans les collectivités, le DPD est
+                souvent mutualisé avec d'autres collectivités.
               </td>
             </tr>
             <tr>
@@ -259,13 +269,14 @@
           votre système d'information (questionnaire ou homologation de
           sécurité) ;
         </li>
-        <li>
-          gérer le renouvellement des jetons d'accès à l'API.
-        </li>
+        <li>gérer le renouvellement des jetons d'accès à l'API.</li>
       </ul>
 
-      <p><b>Que ce soit pour les API en accès libre ou restreint
-</b>, il est indispensable de prévoir de la maintenance dans la durée pour gérer les montées de version des API, suivre les accidents, etc...</p>
+      <p>
+        <b>Que ce soit pour les API en accès libre ou restreint </b>, il est
+        indispensable de prévoir de la maintenance dans la durée pour gérer les
+        montées de version des API, suivre les accidents, etc...
+      </p>
 
       <h3>4. Un prérequis budgétaire</h3>
 
@@ -278,18 +289,12 @@
       </p>
     </ArticleSection>
 
-
-
-    <ArticleSection
-      id="etapes-integration"
-      label="Étapes d'intégration"
-    >
-       <template #heading>Les étapes d'intégration d'une API</template>
+    <ArticleSection id="etapes-integration" label="Étapes d'intégration">
+      <template #heading>Les étapes d'intégration d'une API</template>
       <p class="fr-text--lg">
         Les étapes d'intégration d'une API dépendent de l'ouverture de l'API :
-        une API en accès libre est appelable sans habilitation
-        ni clé d'accès, tandis qu'une API en
-        accès restreint (délivrant des données protégées)
+        une API en accès libre est appelable sans habilitation ni clé d'accès,
+        tandis qu'une API en accès restreint (délivrant des données protégées)
         requiert plus d'étapes pour être utilisable dans vos systèmes
         d'information.
       </p>
@@ -298,7 +303,8 @@
 
       <p>
         Après avoir
-        <router-link to="/articles/anticiper-le-parcours-usager-avant-d-integrer-vos-api"
+        <router-link
+          to="/articles/anticiper-le-parcours-usager-avant-d-integrer-vos-api"
           >réfléchi aux parcours de vos usagers</router-link
         >, il est utile de vérifier que l'API correspond bien à votre besoin en
         consultant ses spécifications via sa documentation et son
@@ -315,27 +321,36 @@
         </li>
         <li>
           <strong>Pour une API à accès restreint</strong>, la plupart proposent
-          un environnement de test (bac à sable)
-          avec des données fictives, ce qui permet à votre équipe technique de
-          se familiariser avec les types de données renvoyés et les différentes
-          situations d'usage possibles. Si les exemples proposés ne répondent pas à tous les cas de figure possibles de votre cas d'usage, certains opérateurs proposent une option permettant de contribuer à l'environnement de bac à sable afin de l'enrichir.
+          un environnement de test (bac à sable) avec des données fictives, ce
+          qui permet à votre équipe technique de se familiariser avec les types
+          de données renvoyés et les différentes situations d'usage possibles.
+          Si les exemples proposés ne répondent pas à tous les cas de figure
+          possibles de votre cas d'usage, certains opérateurs proposent une
+          option permettant de contribuer à l'environnement de bac à sable afin
+          de l'enrichir.
         </li>
       </ul>
 
-       <div class="fr-highlight fr-highlight--green-menthe fr-mb-4w">
-        <p>          
-          Toutes les API référencées sur Simplifions.data sont aussi <b>cataloguées dans Data.gouv.fr</b> où elles ont leur propre page d'information. Cette page recense les éléments essentiels pour vous permettre d'intégrer l'API.
-          <br/>
-          <br/>
-          Cette page data.gouv.fr est toujours mise en lien sur simplifions.data lorsqu'une API ou un jeu de donnée est référencé.
+      <div class="fr-highlight fr-highlight--green-menthe fr-mb-4w">
+        <p>
+          Toutes les API référencées sur Simplifions.data sont aussi
+          <b>cataloguées dans Data.gouv.fr</b> où elles ont leur propre page
+          d'information. Cette page recense les éléments essentiels pour vous
+          permettre d'intégrer l'API.
+          <br />
+          <br />
+          Cette page data.gouv.fr est toujours mise en lien sur simplifions.data
+          lorsqu'une API ou un jeu de donnée est référencé.
         </p>
       </div>
 
       <h3>Étape 2 — Récupérer et, le cas échéant, sécuriser vos accès</h3>
 
       <p>
-        <strong>Pour une API en libre accès</strong>, cette étape est généralement superflue : aucune clé n'est nécessaire, l'API est appelable directement depuis une page web, sans avoir à sécuriser l'appel.
-
+        <strong>Pour une API en libre accès</strong>, cette étape est
+        généralement superflue : aucune clé n'est nécessaire, l'API est
+        appelable directement depuis une page web, sans avoir à sécuriser
+        l'appel.
       </p>
 
       <p>
@@ -362,7 +377,8 @@
       <p>
         L'équipe technique développe l'appel à l'API dans votre service, en
         implémentant le
-        <router-link to="/articles/anticiper-le-parcours-usager-avant-d-integrer-vos-api"
+        <router-link
+          to="/articles/anticiper-le-parcours-usager-avant-d-integrer-vos-api"
           >parcours décidé en amont</router-link
         >
         : développement du formulaire ou du service et interconnexion des champs
@@ -373,38 +389,59 @@
       </p>
 
       <p>
-        <strong>Pour une API en accès libre</strong>, l'intégration reste simple : il suffit de gérer les appels HTTPS, le traitement du JSON reçu, et les codes d'erreur HTTP standards — notamment le 429 (limite de débit dépassée) ou un timeout en cas de lenteur du service. Pas de logique de jeton ni de traçabilité particulière à mettre en œuvre.
-
+        <strong>Pour une API en accès libre</strong>, l'intégration reste simple
+        : il suffit de gérer les appels HTTPS, le traitement du JSON reçu, et
+        les codes d'erreur HTTP standards — notamment le 429 (limite de débit
+        dépassée) ou un timeout en cas de lenteur du service. Pas de logique de
+        jeton ni de traçabilité particulière à mettre en œuvre.
       </p>
 
       <p>
-        <strong>Pour une API à accès restreint</strong>, aux erreurs HTTP standards s'ajoutent des codes propres à l'authentification (401 en cas de jeton invalide ou expiré, 403 en cas d'accès à une donnée hors du périmètre habilité) et le respect des limites de volumétrie propres à votre habilitation — au-delà, un bannissement temporaire peut intervenir. Il est également souvent requis de renseigner, dans chaque appel, des paramètres de traçabilité permettant d'identifier l'origine de la requête.
+        <strong>Pour une API à accès restreint</strong>, aux erreurs HTTP
+        standards s'ajoutent des codes propres à l'authentification (401 en cas
+        de jeton invalide ou expiré, 403 en cas d'accès à une donnée hors du
+        périmètre habilité) et le respect des limites de volumétrie propres à
+        votre habilitation — au-delà, un bannissement temporaire peut
+        intervenir. Il est également souvent requis de renseigner, dans chaque
+        appel, des paramètres de traçabilité permettant d'identifier l'origine
+        de la requête.
       </p>
 
-
-        <p><b>Aucune API n'est fiable à 100 %. Or votre service doit continuer à fonctionner en
-          cas de panne :</b>
+      <p>
+        <b
+          >Aucune API n'est fiable à 100 %. Or votre service doit continuer à
+          fonctionner en cas de panne :</b
+        >
+      </p>
+      <ul>
+        <li>
+          si l'API sert à <strong>pré-remplir un formulaire</strong>, prévoyez
+          une saisie manuelle de secours ;
+        </li>
+        <li>
+          si l'API sert à <strong>récupérer un justificatif</strong>, prévoyez
+          que l'usager puisse encore le déposer lui-même.
+        </li>
+      </ul>
+      <div class="fr-highlight fr-highlight--green-menthe fr-mb-4w">
+        <p>
+          ⚠️ Le «&nbsp;Dites-le-nous une fois&nbsp;» ne doit jamais devenir un
+          obstacle. Un usager préférera souvent ressaisir une information plutôt
+          que de ne pas pouvoir finaliser sa démarche.
         </p>
-        <ul><li>si l'API sert à <strong>pré-remplir un formulaire</strong>,
-          prévoyez une saisie manuelle de secours ;</li><li>si l'API sert à
-          <strong>récupérer un justificatif</strong>, prévoyez que l'usager
-          puisse encore le déposer lui-même.</li></ul>
-        <div class="fr-highlight fr-highlight--green-menthe fr-mb-4w">
-          <p>⚠️ Le «&nbsp;Dites-le-nous
-          une fois&nbsp;» ne doit jamais devenir un obstacle. Un usager
-          préférera souvent ressaisir une information plutôt que de ne pas
-          pouvoir finaliser sa démarche.</p>
       </div>
 
       <SimplifionsArticleReadMore
-      to="/articles/anticiper-le-parcours-usager-avant-d-integrer-vos-api"
-      description="Découvrez comment utiliser les API au sein du parcours usager, selon que la donnée est publique ou protégée :"
+        to="/articles/anticiper-le-parcours-usager-avant-d-integrer-vos-api"
+        description="Découvrez comment utiliser les API au sein du parcours usager, selon que la donnée est publique ou protégée :"
       />
 
       <h3>Étape 4 — Mettre en production, surveiller, faire évoluer</h3>
 
       <p>
-       Après des tests concluants, l'accès en production peut démarrer. Quelques bonnes pratiques à mettre en place dès le lancement lorqu'elles sont rendues possibles par l'opérateur de l'API :
+        Après des tests concluants, l'accès en production peut démarrer.
+        Quelques bonnes pratiques à mettre en place dès le lancement lorqu'elles
+        sont rendues possibles par l'opérateur de l'API :
       </p>
 
       <ul class="fr-mb-3w">
@@ -413,23 +450,26 @@
           s'abonner aux <b>pages de statut / notifications d'incidents</b> ;
         </li>
         <li>
-          s'abonner aux actualités de l'API indiquant les <b>nouveautés, les montées en version et le changelog</b> ;
+          s'abonner aux actualités de l'API indiquant les
+          <b>nouveautés, les montées en version et le changelog</b> ;
         </li>
         <li>
-          utiliser les <b>routes de monitoring dédiées</b> ("ping"), plutôt que d'appeler les vraies routes de données, pour surveiller la disponibilité.
+          utiliser les <b>routes de monitoring dédiées</b> ("ping"), plutôt que
+          d'appeler les vraies routes de données, pour surveiller la
+          disponibilité.
         </li>
       </ul>
 
-    <SimplifionsArticleReadMore
-      to="/articles/vos-interlocuteurs-selon-le-type-d-api"
-      description="Durant l'intégration et l'usage d'une API, identifiez les acteurs pour savoir qui sont vos interlocuteurs :"
-    />
+      <SimplifionsArticleReadMore
+        to="/articles/vos-interlocuteurs-selon-le-type-d-api"
+        description="Durant l'intégration et l'usage d'une API, identifiez les acteurs pour savoir qui sont vos interlocuteurs :"
+      />
     </ArticleSection>
 
     <ArticleSection id="limites" label="Limites des API">
       <template #heading>Les limites des API</template>
       <p class="fr-text--lg">
-       Comprendre les limites des API vous permet d'anticiper les solutions à
+        Comprendre les limites des API vous permet d'anticiper les solutions à
         mettre en œuvre pour contrebalancer leurs manques.
       </p>
 
@@ -468,13 +508,14 @@
             <tr>
               <td><strong>Qualité de la donnée</strong></td>
               <td>
-                La donnée renvoyée par l'API peut elle-même être erronée ou 
-                incomplète. L'API ne fait que refléter la
-                qualité de la donnée détenue par l'administration qui la
-                fournit.
+                La donnée renvoyée par l'API peut elle-même être erronée ou
+                incomplète. L'API ne fait que refléter la qualité de la donnée
+                détenue par l'administration qui la fournit.
               </td>
               <td>
-                Cas d'une donnée déclarative : Une adresse postale contient une erreur car cette donnée a été saisie par l'usager qui a fait une faute de frappe.
+                Cas d'une donnée déclarative : Une adresse postale contient une
+                erreur car cette donnée a été saisie par l'usager qui a fait une
+                faute de frappe.
               </td>
             </tr>
             <tr>
@@ -553,25 +594,24 @@
       <p class="fr-mt-3w">
         Dans tous les cas,
         <strong>gardez toujours un chemin de secours pour l'usager</strong>
-        (ressaisie, dépôt manuel du justificatif). 
+        (ressaisie, dépôt manuel du justificatif).
       </p>
 
-    <SimplifionsArticleReadMore
-      to="/articles/anticiper-le-parcours-usager-avant-d-integrer-vos-api#parcours-alternatifs"
-      description="En savoir plus sur les parcours alternatifs à proposer :"
-    />
-
+      <SimplifionsArticleReadMore
+        to="/articles/anticiper-le-parcours-usager-avant-d-integrer-vos-api#parcours-alternatifs"
+        description="En savoir plus sur les parcours alternatifs à proposer :"
+      />
     </ArticleSection>
 
     <ArticleSection id="recapitulatif" label="Pour résumer">
       <SimplifionsArticleChecklist>
         <li>
           <strong
-            >Quatre prérequis avant de lancer un chantier d'intégration
-            d'API :</strong
+            >Quatre prérequis avant de lancer un chantier d'intégration d'API
+            :</strong
           >
-        conception, technique, budget — et juridique si
-          l'API délivre des données protégées.
+          conception, technique, budget — et juridique si l'API délivre des
+          données protégées.
         </li>
         <li>
           <strong>Quatre étapes pour intégrer les API.</strong> Explorer et

--- a/src/custom/simplifions/views/articles/ArticleQuestCeQuUneAPI.vue
+++ b/src/custom/simplifions/views/articles/ArticleQuestCeQuUneAPI.vue
@@ -10,42 +10,54 @@
   >
     <ArticleSection id="definition" label="Qu'est-ce qu'une API ?">
       <p class="fr-text--lead">
-        API est un acronyme anglais — <em>Application Programming Interface</em> — qui
-        désigne un mécanisme permettant à deux systèmes informatiques de
-        communiquer entre eux. Derrière ce terme technique se cache une idée
-        simple : deux ordinateurs qui s'échangent des informations, automatiquement,
-        par internet.
+        API est un acronyme anglais —
+        <em>Application Programming Interface</em> — qui désigne un mécanisme
+        permettant à deux systèmes informatiques de communiquer entre eux.
+        Derrière ce terme technique se cache une idée simple : deux ordinateurs
+        qui s'échangent des informations, automatiquement, par internet.
       </p>
 
       <h3>Une analogie : le serveur au restaurant</h3>
 
       <p>
-        Imaginez un restaurant. Vous êtes assis à table, la cuisine est
-        en arrière-salle. Vous ne pouvez pas y entrer directement. Le serveur
-        joue le <strong>rôle d'intermédiaire</strong> : vous lui donnez votre commande, il la
-        transmet à la cuisine, et revient avec votre plat.
+        Imaginez un restaurant. Vous êtes assis à table, la cuisine est en
+        arrière-salle. Vous ne pouvez pas y entrer directement. Le serveur joue
+        le <strong>rôle d'intermédiaire</strong> : vous lui donnez votre
+        commande, il la transmet à la cuisine, et revient avec votre plat.
       </p>
 
       <p>
         <em>
-          Une <strong>API</strong>, c'est <strong>ce serveur</strong> — mais entre deux ordinateurs.
-          Elle transmet une demande d'un système à un autre, récupère la réponse,
-          et la renvoie, sans que les deux systèmes aient besoin de se connaître
-          directement.
+          Une <strong>API</strong>, c'est <strong>ce serveur</strong> — mais
+          entre deux ordinateurs. Elle transmet une demande d'un système à un
+          autre, récupère la réponse, et la renvoie, sans que les deux systèmes
+          aient besoin de se connaître directement.
         </em>
       </p>
 
       <h3>Un exemple concret</h3>
 
       <p>
-        Lorsque vous utilisez une application météo sur votre téléphone, ce dernier ne dispose pas de capteurs pour mesurer la météo extérieure. Que fait l'application ? Elle envoie une demande, via une API, à un
-        serveur météorologique, qui lui renvoie les données du moment. L'application
-        affiche ensuite ces données — <i>sans que vous ayez eu à les chercher vous-même</i> —. Ce mécanisme de requête et d'affichage de données distantes est au cœur du fonctionnement de la majorité des applications connectées que vous utilisez au quotidien.
+        Lorsque vous utilisez une application météo sur votre téléphone, ce
+        dernier ne dispose pas de capteurs pour mesurer la météo extérieure. Que
+        fait l'application ? Elle envoie une demande, via une API, à un serveur
+        météorologique, qui lui renvoie les données du moment. L'application
+        affiche ensuite ces données —
+        <i>sans que vous ayez eu à les chercher vous-même</i> —. Ce mécanisme de
+        requête et d'affichage de données distantes est au cœur du
+        fonctionnement de la majorité des applications connectées que vous
+        utilisez au quotidien.
       </p>
 
       <div class="fr-my-4w fr-highlight fr-highlight--green-menthe">
         <p class="fr-mb-0 fr-text--lg">
-          <b>C'est exactement ce qui peut se passer pour les démarches administratives</b> : par exemple, un formulaire en ligne peut être pré-rempli en interrogeant, via une API, un autre système informatique de l'État pour récupérer des informations, sans les demander à l'usager.
+          <b
+            >C'est exactement ce qui peut se passer pour les démarches
+            administratives</b
+          >
+          : par exemple, un formulaire en ligne peut être pré-rempli en
+          interrogeant, via une API, un autre système informatique de l'État
+          pour récupérer des informations, sans les demander à l'usager.
         </p>
       </div>
     </ArticleSection>
@@ -54,17 +66,20 @@
       <template #heading>Les API du Dîtes-le nous une fois</template>
 
       <p class="fr-text--lg">
-        L'administration française utilise de nombreuses données administratives : revenus fiscaux, quotient familial, statut d'une entreprise,
+        L'administration française utilise de nombreuses données administratives
+        : revenus fiscaux, quotient familial, statut d'une entreprise,
         attestations sociales… Ces données sont hébergées dans les systèmes
         informatiques des différentes administrations publiques.
       </p>
 
       <p>
-        Dans le cas d'une démarche qui n'est pas simplifiée par l'utilisation d'API, lorsqu'un usager effectue la démarche, il lui est
-        demandé de <strong>fournir lui-même</strong> ces informations sous forme de
-        pièces justificatives : <i>avis d'imposition, certificat de scolarité,
-        extrait Kbis…</i>
-        <br />C'est sur lui que repose la charge de faire transiter ces données pourtant connues de l'administration.
+        Dans le cas d'une démarche qui n'est pas simplifiée par l'utilisation
+        d'API, lorsqu'un usager effectue la démarche, il lui est demandé de
+        <strong>fournir lui-même</strong> ces informations sous forme de pièces
+        justificatives :
+        <i>avis d'imposition, certificat de scolarité, extrait Kbis…</i>
+        <br />C'est sur lui que repose la charge de faire transiter ces données
+        pourtant connues de l'administration.
       </p>
 
       <div class="fr-my-4w fr-highlight fr-highlight--green-menthe">
@@ -72,114 +87,171 @@
           <strong>Le principe du Dîtes-le nous une fois</strong>
           <br />
           La loi interdit désormais à une administration de demander à un usager
-          une information qu'elle détient déjà ou qu'une autre administration peut
-          lui communiquer. Les API sont le principal outil technique qui permet
-          de mettre ce principe en pratique.
+          une information qu'elle détient déjà ou qu'une autre administration
+          peut lui communiquer. Les API sont le principal outil technique qui
+          permet de mettre ce principe en pratique.
         </p>
       </div>
 
       <h3>Comment cela se concrétise pour les usagers et les agents ?</h3>
 
       <p>
-        Lorsqu'une démarche requiert une information sur un particulier, une entreprise ou une association, le formulaire en ligne ou le logiciel de l'agent peut
-        interroger directement le système de l'administration détentrice de cette
-        donnée, via une API. La réponse arrive en quelques secondes, et peut pré-remplir le formulaire pour l'usager et/ou afficher les informations dans le logiciel de l'agent.
+        Lorsqu'une démarche requiert une information sur un particulier, une
+        entreprise ou une association, le formulaire en ligne ou le logiciel de
+        l'agent peut interroger directement le système de l'administration
+        détentrice de cette donnée, via une API. La réponse arrive en quelques
+        secondes, et peut pré-remplir le formulaire pour l'usager et/ou afficher
+        les informations dans le logiciel de l'agent.
       </p>
 
       Par exemple :
       <ul class="fr-mb-3w">
         <li>
-          Une commune qui traite une demande de tarification sociale peut récupérer le quotient familial directement auprès de la CAF, sans demander d'attestation à la famille. Elle n'est plus contrainte à une mise à jour annuelle — souvent liée à la difficulté de collecter les justificatifs — et peut choisir de recalculer la tarification aussi souvent qu'elle le souhaite, en s'appuyant sur un quotient familial toujours à jour.
+          Une commune qui traite une demande de tarification sociale peut
+          récupérer le quotient familial directement auprès de la CAF, sans
+          demander d'attestation à la famille. Elle n'est plus contrainte à une
+          mise à jour annuelle — souvent liée à la difficulté de collecter les
+          justificatifs — et peut choisir de recalculer la tarification aussi
+          souvent qu'elle le souhaite, en s'appuyant sur un quotient familial
+          toujours à jour.
         </li>
         <li>
-          Une entreprise qui candidate à un marché public n'a plus besoin de saisir les informations générales de sa société — dénomination, adresse, code NAF, etc. Ces données sont pré-remplies automatiquement via une API qui interroge le répertoire Sirene de l'Insee. Cet exemple est justement illustré par le <a href="#demonstrateur">démonstrateur ci-dessous</a>.
+          Une entreprise qui candidate à un marché public n'a plus besoin de
+          saisir les informations générales de sa société — dénomination,
+          adresse, code NAF, etc. Ces données sont pré-remplies automatiquement
+          via une API qui interroge le répertoire Sirene de l'Insee. Cet exemple
+          est justement illustré par le
+          <a href="#demonstrateur">démonstrateur ci-dessous</a>.
         </li>
       </ul>
     </ArticleSection>
 
     <ArticleSection id="demonstrateur" label="Démonstrateur">
       <p>
-        Pour ce démonstrateur, votre ordinateur utilise internet pour demander à un autre ordinateur des informations à propos des entreprises françaises.
-        Pour cela, il utilise l'<a href="https://www.data.gouv.fr/dataservices/api-sirene-open-data">API Sirene de l'Insee</a> qui expose les données du répertoire Sirene.
+        Pour ce démonstrateur, votre ordinateur utilise internet pour demander à
+        un autre ordinateur des informations à propos des entreprises
+        françaises. Pour cela, il utilise l'<a
+          href="https://www.data.gouv.fr/dataservices/api-sirene-open-data"
+          >API Sirene de l'Insee</a
+        >
+        qui expose les données du répertoire Sirene.
       </p>
-      <strong>Testez le fonctionnement de l'API en entrant le numéro de SIRET d'une entreprise ci-dessous :</strong>
+      <strong
+        >Testez le fonctionnement de l'API en entrant le numéro de SIRET d'une
+        entreprise ci-dessous :</strong
+      >
       <p class="fr-text--sm">
-        Par exemple, utilisez ce SIRET d'un établissement de La Poste : <strong>35600000000048</strong>
+        Par exemple, utilisez ce SIRET d'un établissement de La Poste :
+        <strong>35600000000048</strong>
       </p>
 
       <ApiSireneDemo />
 
       <p>
-        Ce mécanisme — une requête automatique vers une source de données distante,
-        un affichage instantané du résultat — est exactement ce qui se passe lorsqu'une
-        démarche administrative est simplifiée par une API.
+        Ce mécanisme — une requête automatique vers une source de données
+        distante, un affichage instantané du résultat — est exactement ce qui se
+        passe lorsqu'une démarche administrative est simplifiée par une API.
       </p>
     </ArticleSection>
 
-    <ArticleSection id="donnees-utilisees-par-l-api" label="Données utilisées par l'API">
+    <ArticleSection
+      id="donnees-utilisees-par-l-api"
+      label="Données utilisées par l'API"
+    >
       <template #heading>Données utilisées par l'API</template>
 
       <p class="fr-text--lg">
-        Toute API utile pour simplifier une démarche repose sur un échange en deux temps :
-        des <strong>données d'appel</strong> permettent d'identifier la personne ou l'entité concernée par la démarche,
-        et des <strong>données de réponse</strong> la concernant sont renvoyées en retour.
+        Toute API utile pour simplifier une démarche repose sur un échange en
+        deux temps : des <strong>données d'appel</strong> permettent
+        d'identifier la personne ou l'entité concernée par la démarche, et des
+        <strong>données de réponse</strong> la concernant sont renvoyées en
+        retour.
       </p>
 
       <ul class="fr-mb-3w">
         <li>
-          <strong>Données d'appel</strong> — informations transmises à l'API pour identifier
-          la personne ou l'entité concernée.
+          <strong>Données d'appel</strong> — informations transmises à l'API
+          pour identifier la personne ou l'entité concernée.
           <SimplifionsArticleFigure
             src="/static/simplifions/assets/article-qu-est-ce-qu-une-api-donnees-appel.png"
             alt="Capture d'écran de la partie du démonstrateur d'API qui montre la donnée d'appel"
           >
-            Exemple avec le <a href="#demonstrateur">démonstrateur</a> : le numéro SIRET de l'établissement est la donnée d'appel.
+            Exemple avec le <a href="#demonstrateur">démonstrateur</a> : le
+            numéro SIRET de l'établissement est la donnée d'appel.
           </SimplifionsArticleFigure>
         </li>
         <li>
-          <strong>Données de réponse</strong> — données renvoyées par l'API concernant l'entité ou la personne renseignée en appel. Ces données sont celles attendues dans la démarche usager et que l'on souhaite éviter de demander au particulier, à l'entreprise ou à l'association.
+          <strong>Données de réponse</strong> — données renvoyées par l'API
+          concernant l'entité ou la personne renseignée en appel. Ces données
+          sont celles attendues dans la démarche usager et que l'on souhaite
+          éviter de demander au particulier, à l'entreprise ou à l'association.
           <SimplifionsArticleFigure
             src="/static/simplifions/assets/article-qu-est-ce-qu-une-api-donnees-reponse.png"
             alt="Capture d'écran de la partie du démonstrateur d'API qui montre les données de réponse"
           >
-            Exemple avec le <a href="#demonstrateur">démonstrateur</a> : adresse, code NAF, forme juridique, état administratif sont les données de réponse de l'API.
+            Exemple avec le <a href="#demonstrateur">démonstrateur</a> :
+            adresse, code NAF, forme juridique, état administratif sont les
+            données de réponse de l'API.
           </SimplifionsArticleFigure>
         </li>
       </ul>
 
       <h3>D'où proviennent les données d'appel ?</h3>
 
-      <p>Pour interroger une API, il faut disposer d'au moins une information permettant d'identifier l'entité concernée. Cette information peut provenir de deux sources :</p>
+      <p>
+        Pour interroger une API, il faut disposer d'au moins une information
+        permettant d'identifier l'entité concernée. Cette information peut
+        provenir de deux sources :
+      </p>
 
       <ul class="fr-mb-3w">
         <li>
-          <strong>L'usager lui-même</strong> — par exemple, en saisissant son SIRET, en s'authentifiant
-          via FranceConnect, ou en communiquant son numéro fiscal lors de sa démarche.
+          <strong>L'usager lui-même</strong> — par exemple, en saisissant son
+          SIRET, en s'authentifiant via FranceConnect, ou en communiquant son
+          numéro fiscal lors de sa démarche.
         </li>
         <li>
-          <strong>L'agent en charge du dossier</strong> — via le système informatique
-          de son administration (dossier existant, base de bénéficiaires…) ou, en guichet,
-          via les informations transmises directement par l'usager.
+          <strong>L'agent en charge du dossier</strong> — via le système
+          informatique de son administration (dossier existant, base de
+          bénéficiaires…) ou, en guichet, via les informations transmises
+          directement par l'usager.
         </li>
       </ul>
 
       <h3>Les données d'appel et de réponse visibles sur Simplifions.data</h3>
 
       <p>
-        Sur chaque API référencée par Simplifions comme étant utile pour une démarche, vous retrouverez
-        ces deux types d'informations sous des libellés spécifiques :
+        Sur chaque API référencée par Simplifions comme étant utile pour une
+        démarche, vous retrouverez ces deux types d'informations sous des
+        libellés spécifiques :
       </p>
 
       <ul class="fr-mb-3w">
-        <li><strong>«<span aria-hidden="true">✍️</span> Informations à saisir pour récupérer la donnée »</strong> correspond aux données d'appel ;</li>
-        <li><strong>«<span aria-hidden="true" class="fr-icon-success-fill icon-green"></span> Données disponibles »</strong> correspond aux données de réponse.</li>
+        <li>
+          <strong
+            >«<span aria-hidden="true">✍️</span> Informations à saisir pour
+            récupérer la donnée »</strong
+          >
+          correspond aux données d'appel ;
+        </li>
+        <li>
+          <strong
+            >«<span
+              aria-hidden="true"
+              class="fr-icon-success-fill icon-green"
+            ></span>
+            Données disponibles »</strong
+          >
+          correspond aux données de réponse.
+        </li>
       </ul>
 
       <SimplifionsArticleFigure
         src="/static/simplifions/assets/article-qu-est-ce-qu-une-api-donnees-transmises-donnees-renvoyees-composant-api.png"
         alt="Capture d'écran d'un composant Simplifions montrant les données transmises à l'API et les données renvoyées"
       >
-        Sur Simplifions, les données d'appel et de réponse sont présentées pour chaque API référencée.
+        Sur Simplifions, les données d'appel et de réponse sont présentées pour
+        chaque API référencée.
       </SimplifionsArticleFigure>
 
       <br />
@@ -187,31 +259,47 @@
       <div class="fr-callout fr-callout--beige-gris-galet">
         <div class="fr-callout__text">
           <p class="fr-text--lead fr-text--bold">
-            En résumé, avant de rechercher une API, posez-vous ces deux questions :
+            En résumé, avant de rechercher une API, posez-vous ces deux
+            questions :
           </p>
           <ol class="fr-text--md fr-mt-2w">
             <li>
-              <strong>De quelles informations disposez-vous pour appeler l'API ?</strong><br />
-              Les données disponibles — côté agent ou côté usager — correspondent-elles
-              aux paramètres d'appel acceptés par l'API ?<br />
-              <i>Par exemple, si une API n'accepte que le numéro étudiant,
-              elle ne pourra pas être utilisée si vous ne disposez que de l'état civil.</i>
+              <strong
+                >De quelles informations disposez-vous pour appeler l'API
+                ?</strong
+              ><br />
+              Les données disponibles — côté agent ou côté usager —
+              correspondent-elles aux paramètres d'appel acceptés par l'API ?<br />
+              <i
+                >Par exemple, si une API n'accepte que le numéro étudiant, elle
+                ne pourra pas être utilisée si vous ne disposez que de l'état
+                civil.</i
+              >
             </li>
             <li>
-              <strong>Quelles informations souhaitez-vous obtenir en retour ?</strong><br />
-              Les données renvoyées par l'API couvrent-elles bien ce dont vous avez besoin
-              pour instruire la démarche ?
+              <strong
+                >Quelles informations souhaitez-vous obtenir en retour ?</strong
+              ><br />
+              Les données renvoyées par l'API couvrent-elles bien ce dont vous
+              avez besoin pour instruire la démarche ?
             </li>
           </ol>
         </div>
       </div>
     </ArticleSection>
 
-    <ArticleSection id="api-entreprise-particulier" label="Les API clés pour la simplification">
-      <template #heading>Les API clés pour la simplification des démarches</template>
+    <ArticleSection
+      id="api-entreprise-particulier"
+      label="Les API clés pour la simplification"
+    >
+      <template #heading
+        >Les API clés pour la simplification des démarches</template
+      >
 
       <p class="fr-text--lg">
-        La mise en œuvre du Dîtes-le nous une fois reposant en grande partie sur des échanges de données, différentes administrations mettent à disposition des API dédiées à cet objectif.
+        La mise en œuvre du Dîtes-le nous une fois reposant en grande partie sur
+        des échanges de données, différentes administrations mettent à
+        disposition des API dédiées à cet objectif.
       </p>
 
       <SimplifionsArticleTopicSpotlight
@@ -225,14 +313,19 @@
       >
         <p>
           Pour que les administrations n'aient pas à brancher des dizaines de
-          connexions différentes à chaque source de données, <b>la direction
-          interministérielle du numérique (DINUM) a créé deux API centralisatrices</b>,
-          chacune spécialisée dans un type d'usager.
+          connexions différentes à chaque source de données,
+          <b
+            >la direction interministérielle du numérique (DINUM) a créé deux
+            API centralisatrices</b
+          >, chacune spécialisée dans un type d'usager.
         </p>
       </SimplifionsArticleTopicSpotlight>
 
       <SimplifionsArticleTopicSpotlight
-        :slugs="['api-impot-particulier', 'api-service-finances-publiques-sfip']"
+        :slugs="[
+          'api-impot-particulier',
+          'api-service-finances-publiques-sfip'
+        ]"
         page-key="solutions"
         :show-image="false"
         :show-operateur-tag="true"
@@ -241,7 +334,15 @@
         :show-arrow="true"
       >
         <p>
-          <b>La direction générale des finances publiques a également mis en œuvre deux API dédiées à la simplification des démarches des particuliers</b>. Toutes deux délivrent les mêmes données en réponse, dont notamment le revenu fiscal de référence. C'est leurs données d'appel qui divergent : l'API Impôt particulier requiert le numéro fiscal ou une connexion via FranceConnect ; l'API SFIP requiert les données d'état civil du particulier.
+          <b
+            >La direction générale des finances publiques a également mis en
+            œuvre deux API dédiées à la simplification des démarches des
+            particuliers</b
+          >. Toutes deux délivrent les mêmes données en réponse, dont notamment
+          le revenu fiscal de référence. C'est leurs données d'appel qui
+          divergent : l'API Impôt particulier requiert le numéro fiscal ou une
+          connexion via FranceConnect ; l'API SFIP requiert les données d'état
+          civil du particulier.
         </p>
       </SimplifionsArticleTopicSpotlight>
 
@@ -255,7 +356,11 @@
         :show-arrow="true"
       >
         <p>
-          L'utilisation de l'<b>API FranceConnect permet d'utiliser en données d'appel une connexion de l'usager via FranceConnect</b>. Les API proposant ce paramètre d'appel sont prénommées des « API FranceConnectées ».
+          L'utilisation de l'<b
+            >API FranceConnect permet d'utiliser en données d'appel une
+            connexion de l'usager via FranceConnect</b
+          >. Les API proposant ce paramètre d'appel sont prénommées des « API
+          FranceConnectées ».
         </p>
 
         <router-link
@@ -269,24 +374,27 @@
       <h3>Qui peut utiliser ces API ?</h3>
 
       <p>
-        Ces API sont en <strong>accès restreint</strong> : seules les administrations
-        et les organismes chargés d'une mission de service public peuvent y accéder,
-        après habilitation. Cela garantit que les données personnelles et
-        confidentielles ne circulent qu'entre les entités qui ont un droit
-        légal de les consulter.
+        Ces API sont en <strong>accès restreint</strong> : seules les
+        administrations et les organismes chargés d'une mission de service
+        public peuvent y accéder, après habilitation. Cela garantit que les
+        données personnelles et confidentielles ne circulent qu'entre les
+        entités qui ont un droit légal de les consulter.
       </p>
 
       <p>
         En pratique, l'accès se fait souvent de façon transparente pour les
         agents : c'est le <strong>logiciel métier</strong> qu'ils utilisent au
-        quotidien qui est branché à ces API. Les agents bénéficient alors de l'accès à ces données sans même avoir connaissance de l'existence de ces API.
+        quotidien qui est branché à ces API. Les agents bénéficient alors de
+        l'accès à ces données sans même avoir connaissance de l'existence de ces
+        API.
       </p>
 
       <div class="fr-my-4w fr-highlight fr-highlight--green-menthe">
         <p class="fr-mb-0">
-          Simplifions.data.gouv.fr référence les logiciels métiers déjà raccordés
-          à l'API Entreprise et à l'API Particulier. Si votre logiciel est dans
-          la liste, vous bénéficiez peut-être déjà de ces données sans le savoir.
+          Simplifions.data.gouv.fr référence les logiciels métiers déjà
+          raccordés à l'API Entreprise et à l'API Particulier. Si votre logiciel
+          est dans la liste, vous bénéficiez peut-être déjà de ces données sans
+          le savoir.
         </p>
         <br />
         <router-link
@@ -312,28 +420,55 @@
     <ArticleSection id="recapitulatif" label="Récapitulatif">
       <SimplifionsArticleChecklist>
         <li>
-          Une <strong>API</strong> est un intermédiaire qui permet à deux systèmes
-          informatiques de s'échanger des données automatiquement, par internet.
+          Une <strong>API</strong> est un intermédiaire qui permet à deux
+          systèmes informatiques de s'échanger des données automatiquement, par
+          internet.
         </li>
         <li>
-          Les API sont un outil majeur pour appliquer le principe du <strong>Dîtes-le nous une fois</strong>.
+          Les API sont un outil majeur pour appliquer le principe du
+          <strong>Dîtes-le nous une fois</strong>.
         </li>
         <li>
-          Toute API repose sur des <strong>données d'appel</strong> (pour identifier le particulier, l'association ou l'entreprise recherchée)
-          et des <strong>données de réponse</strong> (les informations renvoyées).
+          Toute API repose sur des <strong>données d'appel</strong> (pour
+          identifier le particulier, l'association ou l'entreprise recherchée)
+          et des <strong>données de réponse</strong> (les informations
+          renvoyées).
         </li>
         <li>
-          Avant de chercher une API, <strong>vérifiez que vous disposez des données d'appel nécessaires</strong> et que
-          les données de réponse couvrent votre besoin.
+          Avant de chercher une API,
+          <strong
+            >vérifiez que vous disposez des données d'appel nécessaires</strong
+          >
+          et que les données de réponse couvrent votre besoin.
         </li>
         <li>
-          <router-link to="/solutions/bouquet-api-entreprise"><strong>L'API Entreprise</strong></router-link> et <router-link to="/solutions/bouquet-api-particulier"><strong>l'API Particulier</strong></router-link> (DINUM) centralisent de nombreuses données des entreprises,
+          <router-link to="/solutions/bouquet-api-entreprise"
+            ><strong>L'API Entreprise</strong></router-link
+          >
+          et
+          <router-link to="/solutions/bouquet-api-particulier"
+            ><strong>l'API Particulier</strong></router-link
+          >
+          (DINUM) centralisent de nombreuses données des entreprises,
           associations et particuliers auprès de multiples organismes.
         </li>
         <li>
-          D'autres API spécialisées existent : <router-link to="/solutions/api-impot-particulier"><strong>l'API Impôt Particulier</strong></router-link> et
-          <router-link to="/solutions/api-service-finances-publiques-sfip"><strong>l'API SFIP</strong></router-link> (DGFiP) pour les données fiscales,
-          <router-link to="/solutions/franceconnect-2"><strong>FranceConnect</strong></router-link> pour utiliser une connexion usager comme donnée d'appel et accéder aux <router-link to="/articles/apis-franceconnectees">API FranceConnectées</router-link>.
+          D'autres API spécialisées existent :
+          <router-link to="/solutions/api-impot-particulier"
+            ><strong>l'API Impôt Particulier</strong></router-link
+          >
+          et
+          <router-link to="/solutions/api-service-finances-publiques-sfip"
+            ><strong>l'API SFIP</strong></router-link
+          >
+          (DGFiP) pour les données fiscales,
+          <router-link to="/solutions/franceconnect-2"
+            ><strong>FranceConnect</strong></router-link
+          >
+          pour utiliser une connexion usager comme donnée d'appel et accéder aux
+          <router-link to="/articles/apis-franceconnectees"
+            >API FranceConnectées</router-link
+          >.
         </li>
       </SimplifionsArticleChecklist>
     </ArticleSection>
@@ -341,17 +476,17 @@
 </template>
 
 <script setup lang="ts">
-import SimplifionsArticleLayout from '../../components/article/SimplifionsArticleLayout.vue'
-import ArticleSection from '../../components/article/SimplifionsArticleSection.vue'
 import SimplifionsArticleChecklist from '../../components/article/SimplifionsArticleChecklist.vue'
-import SimplifionsArticleTopicSpotlight from '../../components/article/SimplifionsArticleTopicSpotlight.vue'
 import SimplifionsArticleFigure from '../../components/article/SimplifionsArticleFigure.vue'
+import SimplifionsArticleLayout from '../../components/article/SimplifionsArticleLayout.vue'
 import SimplifionsArticleReadMore from '../../components/article/SimplifionsArticleReadMore.vue'
-import ApiSireneDemo from './ApiSireneDemo.vue'
+import ArticleSection from '../../components/article/SimplifionsArticleSection.vue'
+import SimplifionsArticleTopicSpotlight from '../../components/article/SimplifionsArticleTopicSpotlight.vue'
 import {
   articleQuestCeQuUneAPI as articleMeta,
   getArticleBreadcrumbLinks
 } from '../../model/articles'
+import ApiSireneDemo from './ApiSireneDemo.vue'
 
 const breadcrumbLinks = getArticleBreadcrumbLinks(articleMeta.h1)
 </script>

--- a/src/custom/simplifions/views/articles/ArticleVosInterlocuteursSelonTypeAPI.vue
+++ b/src/custom/simplifions/views/articles/ArticleVosInterlocuteursSelonTypeAPI.vue
@@ -9,14 +9,17 @@
     :breadcrumb-links="breadcrumbLinks"
   >
     <p class="fr-text--lg">
-      Selon le type d'API que vous intégrez — <em>bouquet mono ou
-      multi-fournisseur, API à l'unité, API FranceConnectée</em> — votre
-      interlocuteur n'est pas toujours le même pour l'habilitation, l'intégration technique et le
-      support. Ce guide vous aide à identifier qui
+      Selon le type d'API que vous intégrez —
+      <em
+        >bouquet mono ou multi-fournisseur, API à l'unité, API
+        FranceConnectée</em
+      >
+      — votre interlocuteur n'est pas toujours le même pour l'habilitation,
+      l'intégration technique et le support. Ce guide vous aide à identifier qui
       contacter selon votre situation.
     </p>
 
-     <SimplifionsArticleReadMore
+    <SimplifionsArticleReadMore
       to="/articles/qu-est-ce-qu-une-api"
       description="Comprendre ce qu'est une API sans vocabulaire technique."
     />
@@ -24,33 +27,32 @@
     <ArticleSection id="types-api" label="Types d'API">
       <p class="fr-text--lg">
         Dans l'écosystème des API utiles pour mettre en place le
-        «&nbsp;Dites-le-nous une fois&nbsp;», il existe différents types pouvant se
-        superposer :
+        «&nbsp;Dites-le-nous une fois&nbsp;», il existe différents types pouvant
+        se superposer :
       </p>
 
       <h3>Les bouquets d'API</h3>
       <p>
-        Ces API regroupent, derrière un seul point d'entrée et un seul point
-        de contact, plusieurs API, généralement organisées autour d'un
-        secteur ou d'un usage commun. Ces «&nbsp;bouquets d'API&nbsp;»
-        permettent donc d'accéder à de nombreuses données à partir d'une même
-        API ayant plusieurs «&nbsp;branches&nbsp;», appelées
-        «&nbsp;endpoints&nbsp;». On distingue deux types de bouquets d'API,
-        ceux :
+        Ces API regroupent, derrière un seul point d'entrée et un seul point de
+        contact, plusieurs API, généralement organisées autour d'un secteur ou
+        d'un usage commun. Ces «&nbsp;bouquets d'API&nbsp;» permettent donc
+        d'accéder à de nombreuses données à partir d'une même API ayant
+        plusieurs «&nbsp;branches&nbsp;», appelées «&nbsp;endpoints&nbsp;». On
+        distingue deux types de bouquets d'API, ceux :
       </p>
       <ul>
         <li>
-          <strong>regroupant les API d'un même fournisseur</strong> : Il
-          s'agit d'un regroupement des API d'une même administration, comme
-          par exemple le bouquet des API de FranceTravail.
+          <strong>regroupant les API d'un même fournisseur</strong> : Il s'agit
+          d'un regroupement des API d'une même administration, comme par exemple
+          le bouquet des API de FranceTravail.
         </li>
         <li>
-          <strong>regroupant différents fournisseurs d'API</strong> : Il
-          s'agit d'un regroupement d'API issues de différentes
-          administrations fournisseurs d'API. Cette mise en commun permet
-          d'accélérer l'intégration d'API grâce notamment à une demande
-          d'habilitation unique et une cohérence technique (même
-          authentification, mêmes conventions de nommage et de réponse).
+          <strong>regroupant différents fournisseurs d'API</strong> : Il s'agit
+          d'un regroupement d'API issues de différentes administrations
+          fournisseurs d'API. Cette mise en commun permet d'accélérer
+          l'intégration d'API grâce notamment à une demande d'habilitation
+          unique et une cohérence technique (même authentification, mêmes
+          conventions de nommage et de réponse).
           <br />
           <br />
           <SimplifionsArticleTopicSpotlight
@@ -63,18 +65,20 @@
           >
             <p>
               <strong
-                >L'API Entreprise et l'API Particulier sont des bouquets
-                d'API multi-fournisseurs</strong
+                >L'API Entreprise et l'API Particulier sont des bouquets d'API
+                multi-fournisseurs</strong
               >
               conçus pour mettre en oeuvre le «&nbsp;Dites-le-nous une
               fois&nbsp;». L'API Entreprise donne accès aux données des
-              entreprises <em> - Insee, Inpi, DGFIP, URSSAF, caisses de retraite...-</em> ; l'API Particulier, aux données des particuliers
+              entreprises
+              <em> - Insee, Inpi, DGFIP, URSSAF, caisses de retraite...-</em> ;
+              l'API Particulier, aux données des particuliers
               <em
-                >- CAF/MSA, France Travail, ministères de l'éducation
-                nationale et de l'enseignement supérieur...-</em
+                >- CAF/MSA, France Travail, ministères de l'éducation nationale
+                et de l'enseignement supérieur...-</em
               >. Les intégrer permet aussi de bénéficier du travail métier
-              effectué pour proposer une offre en cohérence avec les
-              démarches à simplifier.
+              effectué pour proposer une offre en cohérence avec les démarches à
+              simplifier.
             </p>
           </SimplifionsArticleTopicSpotlight>
         </li>
@@ -82,11 +86,11 @@
 
       <h3>Les API classiques, «&nbsp;à l'unité&nbsp;»</h3>
       <p>
-        Ces API sont propres à un seul fournisseur de données, comme l'API
-        Impôt Particulier de la DGFiP ou l'API statut élève scolarisé et boursier du ministère de l'éducation nationale. Souvent très utiles et complémentaires
-        aux bouquets, elles ont chacune leur propre formulaire
-        d'habilitation, ainsi que leur propre gestion des accès et du
-        support.
+        Ces API sont propres à un seul fournisseur de données, comme l'API Impôt
+        Particulier de la DGFiP ou l'API statut élève scolarisé et boursier du
+        ministère de l'éducation nationale. Souvent très utiles et
+        complémentaires aux bouquets, elles ont chacune leur propre formulaire
+        d'habilitation, ainsi que leur propre gestion des accès et du support.
       </p>
 
       <SimplifionsArticleTopicSpotlight
@@ -99,16 +103,22 @@
       >
         <p>
           <strong>L'API Impôt Particulier de la DGFiP</strong> est un exemple
-          d'API «&nbsp;à l'unité&nbsp;» : elle est propre à un seul
-          fournisseur et dispose de sa propre demande d'habilitation,
-          distincte de celle des bouquets d'API.
+          d'API «&nbsp;à l'unité&nbsp;» : elle est propre à un seul fournisseur
+          et dispose de sa propre demande d'habilitation, distincte de celle des
+          bouquets d'API.
         </p>
       </SimplifionsArticleTopicSpotlight>
 
       <h3>Les API FranceConnectées</h3>
       <p>
-        Il s'agit d'une catégorie d'API qui ne concerne que les données des particuliers. Ces API se superposent aux deux catégories précédentes, elles peuvent être incluses dans des bouquets ou bien autonomes. Elles sont dites «&nbsp;FranceConnectées&nbsp;», car elles peuvent être appelées avec l'identité pivot FranceConnect plutôt qu'un simple identifiant. Ce niveau d'intégration supplémentaire simplifie le parcours de l'usager, sous conditions de quelques prérequis techniques spécifiques.
-
+        Il s'agit d'une catégorie d'API qui ne concerne que les données des
+        particuliers. Ces API se superposent aux deux catégories précédentes,
+        elles peuvent être incluses dans des bouquets ou bien autonomes. Elles
+        sont dites «&nbsp;FranceConnectées&nbsp;», car elles peuvent être
+        appelées avec l'identité pivot FranceConnect plutôt qu'un simple
+        identifiant. Ce niveau d'intégration supplémentaire simplifie le
+        parcours de l'usager, sous conditions de quelques prérequis techniques
+        spécifiques.
       </p>
 
       <SimplifionsArticleReadMore
@@ -136,42 +146,52 @@
             <tr>
               <td><strong>Le fournisseur de la donnée</strong></td>
               <td>
-                Détient et produit la donnée. C'est votre interlocuteur s'il
-                est également l'opérateur de l'API ou du bouquet, autrement ce n'est pas votre point de contact.
+                Détient et produit la donnée. C'est votre interlocuteur s'il est
+                également l'opérateur de l'API ou du bouquet, autrement ce n'est
+                pas votre point de contact.
               </td>
               <td>
-                <em>La DGFiP pour pour une attestation
-                fiscale, la CAF ou la MSA pour le quotient familial, le
-                Cnous pour le statut boursier.</em>
+                <em
+                  >La DGFiP pour pour une attestation fiscale, la CAF ou la MSA
+                  pour le quotient familial, le Cnous pour le statut
+                  boursier.</em
+                >
               </td>
             </tr>
             <tr>
               <td><strong>L'opérateur de l'API</strong></td>
               <td>
-               Gère l'API et la met à disposition. C'est
-                votre interlocuteur, sauf si vous utilisez son API via un
-                bouquet. Dans ce dernier cas, c'est alors l'opérateur du
-                bouquet qui est votre interlocuteur.
+                Gère l'API et la met à disposition. C'est votre interlocuteur,
+                sauf si vous utilisez son API via un bouquet. Dans ce dernier
+                cas, c'est alors l'opérateur du bouquet qui est votre
+                interlocuteur.
               </td>
-              <td><em>La Caisse nationale d'assurance vieillesse pour l'API quotient familial.</em></td>
+              <td>
+                <em
+                  >La Caisse nationale d'assurance vieillesse pour l'API
+                  quotient familial.</em
+                >
+              </td>
             </tr>
             <tr>
               <td><strong>L'opérateur du bouquet</strong></td>
               <td>
-              Gère le bouquet d'API et tous ses endpoints. Si vous utilisez un bouquet d'API regroupant des API de
-                plusieurs fournisseurs, il s'agit de votre interlocuteur
-                unique pour l'habilitation, l'intégration technique et le
-                support, pour toutes les API du bouquet.
+                Gère le bouquet d'API et tous ses endpoints. Si vous utilisez un
+                bouquet d'API regroupant des API de plusieurs fournisseurs, il
+                s'agit de votre interlocuteur unique pour l'habilitation,
+                l'intégration technique et le support, pour toutes les API du
+                bouquet.
               </td>
-              <td><em>La DINUM pour l'API Particulier et l'API Entreprise.</em></td>
+              <td>
+                <em>La DINUM pour l'API Particulier et l'API Entreprise.</em>
+              </td>
             </tr>
             <tr>
               <td><strong>FranceConnect</strong>, le cas échéant</td>
               <td>
-                Gère l'identité pivot utilisée comme paramètre d'appel des
-                API FranceConnectées. C'est votre interlocuteur uniquement
-                sur cet aspect, si vous intégrez la version FranceConnectée
-                d'une API.
+                Gère l'identité pivot utilisée comme paramètre d'appel des API
+                FranceConnectées. C'est votre interlocuteur uniquement sur cet
+                aspect, si vous intégrez la version FranceConnectée d'une API.
               </td>
               <td><em>FranceConnect, pour toute API FranceConnectée.</em></td>
             </tr>
@@ -184,11 +204,10 @@
                 Gère votre ou vos logiciels métiers et intègre les API à
                 l'intérieur. C'est votre interlocuteur privilégié. En cas de
                 difficulté concernant une API, c'est lui que vous devez
-                contacter en premier, notamment parce que le problème
-                rencontré peut provenir du logiciel et non de l'API. Si
-                l'éditeur constate que le problème provient bien de l'API,
-                c'est à lui de contacter l'opérateur de l'API ou du bouquet
-                d'API.
+                contacter en premier, notamment parce que le problème rencontré
+                peut provenir du logiciel et non de l'API. Si l'éditeur constate
+                que le problème provient bien de l'API, c'est à lui de contacter
+                l'opérateur de l'API ou du bouquet d'API.
               </td>
               <td>—</td>
             </tr>
@@ -196,20 +215,35 @@
         </table>
       </div>
 
-      <p class="">
-        <b>Par exemple, pour l'API Quotient familial CAF/MSA</b> : 
-      </p>
+      <p class=""><b>Par exemple, pour l'API Quotient familial CAF/MSA</b> :</p>
       <ul>
-        <li>Les
-          <b>fournisseurs de la donnée</b> sont la Caisse d'allocation familiale (CAF) et la Mutuelle sociale agricole (MSA) ;</li>
-        <li>L'<b>opérateur de
-          l'API</b> est la caisse nationale d'assurance vieillesse (CNAV) pour des
-          raisons internes aux systèmes d'informations de l'État ;</li>
-          <li>L'<b>opérateur du bouquet</b>
-          est la DINUM car l'API est
-          distribuée dans le bouquet API Particulier ; </li>
-          <li><em>Si vous utilisez la version FranceConnectée de l'API Quotient familial</em>, FranceConnect est votre interlocuteur sur cet aspect via son API FranceConnect ;</li>
-          <li><em>Si l'API Quotient familial CAF/MSA a été intégrée par votre éditeur</em>, cet éditeur reste votre interlocuteur privilégié à contacter en premier lieu en cas de difficulté.</li>
+        <li>
+          Les <b>fournisseurs de la donnée</b> sont la Caisse d'allocation
+          familiale (CAF) et la Mutuelle sociale agricole (MSA) ;
+        </li>
+        <li>
+          L'<b>opérateur de l'API</b> est la caisse nationale d'assurance
+          vieillesse (CNAV) pour des raisons internes aux systèmes
+          d'informations de l'État ;
+        </li>
+        <li>
+          L'<b>opérateur du bouquet</b> est la DINUM car l'API est distribuée
+          dans le bouquet API Particulier ;
+        </li>
+        <li>
+          <em
+            >Si vous utilisez la version FranceConnectée de l'API Quotient
+            familial</em
+          >, FranceConnect est votre interlocuteur sur cet aspect via son API
+          FranceConnect ;
+        </li>
+        <li>
+          <em
+            >Si l'API Quotient familial CAF/MSA a été intégrée par votre
+            éditeur</em
+          >, cet éditeur reste votre interlocuteur privilégié à contacter en
+          premier lieu en cas de difficulté.
+        </li>
       </ul>
     </ArticleSection>
 
@@ -217,14 +251,19 @@
       <SimplifionsArticleChecklist>
         <li>
           <strong>Trois familles d'API, à combiner selon vos besoins :</strong>
-          Bouquets mono ou
-          multi-fournisseurs, API à l'unité, ou API FranceConnectées.
+          Bouquets mono ou multi-fournisseurs, API à l'unité, ou API
+          FranceConnectées.
         </li>
         <li>
-          <strong>Identifiez vos interlocuteurs.</strong> Selon votre situation et le type d'API que vous utilisez, votre point de contact est différent.
+          <strong>Identifiez vos interlocuteurs.</strong> Selon votre situation
+          et le type d'API que vous utilisez, votre point de contact est
+          différent.
         </li>
         <li>
-          <strong>Votre éditeur est toujours votre premier point de contact,</strong> s'il est en charge de l'intégration de l'API.
+          <strong
+            >Votre éditeur est toujours votre premier point de contact,</strong
+          >
+          s'il est en charge de l'intégration de l'API.
         </li>
       </SimplifionsArticleChecklist>
     </ArticleSection>
@@ -232,11 +271,11 @@
 </template>
 
 <script setup lang="ts">
-import SimplifionsArticleLayout from '../../components/article/SimplifionsArticleLayout.vue'
-import ArticleSection from '../../components/article/SimplifionsArticleSection.vue'
 import SimplifionsArticleChecklist from '../../components/article/SimplifionsArticleChecklist.vue'
-import SimplifionsArticleTopicSpotlight from '../../components/article/SimplifionsArticleTopicSpotlight.vue'
+import SimplifionsArticleLayout from '../../components/article/SimplifionsArticleLayout.vue'
 import SimplifionsArticleReadMore from '../../components/article/SimplifionsArticleReadMore.vue'
+import ArticleSection from '../../components/article/SimplifionsArticleSection.vue'
+import SimplifionsArticleTopicSpotlight from '../../components/article/SimplifionsArticleTopicSpotlight.vue'
 import {
   articleVosInterlocuteursSelonTypeAPI as articleMeta,
   getArticleBreadcrumbLinks


### PR DESCRIPTION
Adds formatting check as a mandatory CI step. This is because some devs/tooling would bypass the precommit locally and another correctly configured environment would reformat the files and create discrepancies between branches (eg when deploying, deploy script on a correctly configured machine would reformat the deploy branch).

The deploy script and deploy instructions now refrain from running the precommit formatter, even though it shouldn't happen anymore.

`pnpm-lock.yaml` is ignored, it shouldn't be formatted.

The offending files on `main` are reformatted to comply with the check.

Example failing output: https://github.com/opendatateam/udata-front-kit/actions/runs/30650941687/job/91223737202?pr=1327

Thanks @streino for the detective work 🕵️ 