### PR TITLE
[Simplifions] Indexations des pages articles

### DIFF
--- a/configs/simplifions/config.yaml
+++ b/configs/simplifions/config.yaml
@@ -132,6 +132,36 @@ website:
         id: 'terms'
         route: '/terms'
         url: '/static/simplifions/pages/terms.md'
+      # Entrées articles : ces routes sont déjà servies par des composants custom (src/custom/simplifions/routes.ts),
+      # elles ne sont déclarées ici que pour que udata-front-kit-seo les inclue dans sitemap.xml.
+      - title: 'Articles'
+        id: 'sitemap-articles'
+        route: '/articles'
+        url: ''
+      - title: "Qu'est-ce qu'une API ?"
+        id: 'sitemap-articles-qu-est-ce-qu-une-api'
+        route: '/articles/qu-est-ce-qu-une-api'
+        url: ''
+      - title: 'Les API FranceConnectées'
+        id: 'sitemap-articles-apis-franceconnectees'
+        route: '/articles/apis-franceconnectees'
+        url: ''
+      - title: 'Guide de base pour les petites collectivités'
+        id: 'sitemap-articles-guide-base-petites-collectivites'
+        route: '/articles/guide-base-petites-collectivites'
+        url: ''
+      - title: "Prérequis et étapes d'intégration d'une API"
+        id: 'sitemap-articles-prerequis-et-etapes-integration-api'
+        route: '/articles/prerequis-et-etapes-integration-api'
+        url: ''
+      - title: "Vos interlocuteurs selon le type d'API"
+        id: 'sitemap-articles-vos-interlocuteurs-selon-le-type-d-api'
+        route: '/articles/vos-interlocuteurs-selon-le-type-d-api'
+        url: ''
+      - title: "Anticiper le parcours usager avant d'intégrer vos API"
+        id: 'sitemap-articles-anticiper-le-parcours-usager-avant-d-integrer-vos-api'
+        route: '/articles/anticiper-le-parcours-usager-avant-d-integrer-vos-api'
+        url: ''
   show_quality_component: true
   oauth_option: true
   # debounce high enough for accessibility (screen readers will announce results)

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -96,6 +96,7 @@ const routerPromise = siteRoutesPromise.then((siteRoutes) => {
   siteRoutes.forEach((route) => {
     routesMap.set(route.path, route)
   })
+  // FIXME: remove me when simplifions is out of front-kit (SEO/sitemap hack)
   // static pages never override an already registered route (default or site-specific)
   pages.forEach((route) => {
     if (!routesMap.has(route.path)) {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -28,7 +28,7 @@ const defaultRoutes: RouteRecordRaw[] = [
 ]
 
 // static pages
-const pages = (config.website.router.static_pages ?? []).map(
+const pages: RouteRecordRaw[] = (config.website.router.static_pages ?? []).map(
   (item: StaticPageConfig) => {
     return {
       path: item.route,
@@ -96,8 +96,13 @@ const routerPromise = siteRoutesPromise.then((siteRoutes) => {
   siteRoutes.forEach((route) => {
     routesMap.set(route.path, route)
   })
+  // static pages never override an already registered route (default or site-specific)
+  pages.forEach((route) => {
+    if (!routesMap.has(route.path)) {
+      routesMap.set(route.path, route)
+    }
+  })
   const routes = Array.from(routesMap.values())
-  routes.push(...pages)
   // catch all 404 (keep at the end of the list)
   routes.push({
     path: '/:pathMatch(.*)',


### PR DESCRIPTION
### Contexte

Les pages articles https://simplifions.data.gouv.fr/articles ne sont pas du tout indexées. C'est un problème car un de leur objectif est justement d'augmenter la découvrabilité du site.

