### PR TITLE
[Simplifions] Mise en valeur du type d'accès pour les API et jeux de données

### DIFF
--- a/configs/simplifions/config.yaml
+++ b/configs/simplifions/config.yaml
@@ -251,7 +251,7 @@ shared_filter_values:
 
   categorie_de_solution: &categorie_de_solution_values
     - id: brique-technique
-      name: API, base de donnée ou brique logicielle
+      name: API, jeu de données ou brique logicielle
     - id: logiciel-metier
       name: Logiciel métier "clé en main"
     - id: portail-consultation

--- a/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
+++ b/cypress/e2e/custom/simplifions/cas_d_usage_detail.cy.ts
@@ -8,6 +8,7 @@ import {
   mockSolution,
   mockSolutionRecommandation
 } from '../../../support/factories/custom/simplifions/simplifions_mocks'
+import { dataserviceFactory } from '../../../support/factories/dataservices_factory'
 
 import './support'
 
@@ -624,5 +625,114 @@ describe("Simplifions Cas d'usages Show page - accordions behaviour", () => {
       .eq(1)
       .find('button.fr-accordion__btn')
       .should('have.attr', 'aria-expanded', 'false')
+  })
+})
+
+describe("Simplifions Cas d'usages Show page for a solution published on data.gouv.fr", () => {
+  const DATASERVICE_SLUG = 'api-recommandee'
+
+  const setup = ({
+    recommandationFields = {},
+    solutionFields = {},
+    dataserviceFields = {}
+  } = {}) => {
+    cy.baseMocksForSimplifions()
+    cy.mockStaticDatagouv()
+
+    const dataservice = dataserviceFactory.one({
+      overrides: {
+        slug: DATASERVICE_SLUG,
+        title: 'API Recommandée',
+        ...dataserviceFields
+      }
+    })
+    cy.mockDatagouvObject('dataservices', dataservice.slug, dataservice)
+
+    const { gristRecommandation } = mockSolutionRecommandation(
+      {
+        API_et_datasets_utiles_fournis: [],
+        Descriptions_des_API_et_datasets_utiles_fournis: [],
+        Ces_logiciels_l_integrent_deja: [],
+        Type_de_recommandation: 'API',
+        ...recommandationFields
+      },
+      { UID_datagouv: DATASERVICE_SLUG, ...solutionFields }
+    )
+
+    const { topicCasUsage } = mockCasUsage({}, [gristRecommandation])
+    cy.visit(`/cas-d-usages/${topicCasUsage.slug}`)
+    cy.get('.reco-card button.fr-accordion__btn').first().click()
+
+    return { dataservice }
+  }
+
+  it('should display the data.gouv.fr card of the recommended solution', () => {
+    setup()
+
+    cy.get('.reco-card .api-or-dataset-card')
+      .should('have.length', 1)
+      .and('contain.text', 'API Recommandée')
+      .and(
+        'have.attr',
+        'href',
+        `https://www.data.gouv.fr/fr/dataservices/${DATASERVICE_SLUG}`
+      )
+  })
+
+  it('should badge an open API as "ouverte"', () => {
+    setup()
+
+    cy.get('.reco-card .api-or-dataset-card .fr-badge')
+      .should('contain.text', 'API ouverte')
+      .and('have.class', 'fr-badge--info')
+  })
+
+  it('should badge a restricted API that public actors can access under condition', () => {
+    setup({
+      dataserviceFields: {
+        access_type: 'restricted',
+        access_audiences: [
+          {
+            role: 'local_authority_and_administration',
+            condition: 'under_condition'
+          }
+        ]
+      }
+    })
+
+    cy.get('.reco-card .api-or-dataset-card .fr-badge')
+      .should('contain.text', 'accessible aux acteurs publics sous conditions')
+      .and('have.class', 'fr-badge--green-tilleul-verveine')
+  })
+
+  it('should badge a restricted API that public actors cannot access', () => {
+    setup({
+      dataserviceFields: {
+        access_type: 'restricted',
+        access_audiences: [
+          { role: 'local_authority_and_administration', condition: 'no' }
+        ]
+      }
+    })
+
+    cy.get('.reco-card .api-or-dataset-card .fr-badge')
+      .should('contain.text', 'API en accès restreint')
+      .and('have.class', 'fr-badge--orange-terre-battue')
+  })
+
+  it('should not display the card when the recommandation type is not set', () => {
+    setup({ recommandationFields: { Type_de_recommandation: null } })
+
+    // The solution link resolves through its own request, so reaching it means
+    // the card would have had time to appear had it been built.
+    cy.get('.reco-card .test__solution-link').should('exist')
+    cy.get('.reco-card .api-or-dataset-card').should('not.exist')
+  })
+
+  it('should not display the card when the solution has no data.gouv.fr UID', () => {
+    setup({ solutionFields: { UID_datagouv: '' } })
+
+    cy.get('.reco-card .test__solution-link').should('exist')
+    cy.get('.reco-card .api-or-dataset-card').should('not.exist')
   })
 })

--- a/cypress/e2e/custom/simplifions/solutions_integratices.cy.ts
+++ b/cypress/e2e/custom/simplifions/solutions_integratices.cy.ts
@@ -255,12 +255,12 @@ describe('Solutions intégratrices block', () => {
     cy.contains('button[role="tab"]', 'Logiciels métiers').should('exist')
     cy.contains(
       'button[role="tab"]',
-      'API, base de donnée ou brique logicielle'
+      'API, jeu de données ou brique logicielle'
     ).should('exist')
 
     cy.contains(
       'button[role="tab"]',
-      'API, base de donnée ou brique logicielle'
+      'API, jeu de données ou brique logicielle'
     ).click()
     cy.get('.fr-tabs__panel')
       .filter(':visible')
@@ -290,14 +290,14 @@ describe('Solutions intégratrices block', () => {
     // Navigate to the second tab
     cy.contains(
       'button[role="tab"]',
-      'API, base de donnée ou brique logicielle'
+      'API, jeu de données ou brique logicielle'
     ).click()
     cy.get('.integrateur-card').should('contain.text', 'Brique A')
 
     // Apply a filter that removes all solutions with fewer APIs, hiding Logiciel métier tab
     cy.get('#min-apis').select('Au moins 3')
 
-    // First (and only) tab should now be API, base de donnée ou brique logicielle
+    // First (and only) tab should now be API, jeu de données ou brique logicielle
     cy.contains('button[role="tab"]', 'Logiciels métiers').should('not.exist')
     cy.get('.fr-tabs__panel')
       .filter(':visible')

--- a/cypress/support/factories/custom/simplifions/grist_factory.ts
+++ b/cypress/support/factories/custom/simplifions/grist_factory.ts
@@ -1,6 +1,7 @@
 import type {
   ApiEtDatasetsIntegresRecord,
   ApiOrDatasetRecord,
+  ApiOrDatasetType,
   ApiOrDatasetUtilesRecord,
   CasUsageRecord,
   RecommandationRecord,
@@ -95,7 +96,8 @@ export const solutionFactory = build<SolutionRecord>({
       Type_de_solution: ['Éditeur'],
       URL_demande_d_acces: '',
       solutions_integratrices: null,
-      liste_categories_de_solution: ['Logiciel métier']
+      liste_categories_de_solution: ['Logiciel métier'],
+      UID_datagouv: ''
     }
   }
 })
@@ -123,7 +125,9 @@ export const apiOrDatasetFactory = build<ApiOrDatasetRecord>({
       Nom: sequence(
         (x) => ['API n°' + x, 'Jeu de données n°' + x][x % 2] as string
       ),
-      Type: sequence((x) => ['API', 'Jeu de données'][x % 2] as string),
+      Type: sequence(
+        (x) => ['API', 'Jeu de données'][x % 2] as ApiOrDatasetType
+      ),
       Fourni_par: 1,
       Integre_par: [1, 2],
       Visible_sur_simplifions: true,

--- a/cypress/support/factories/custom/simplifions/simplifions_mocks.ts
+++ b/cypress/support/factories/custom/simplifions/simplifions_mocks.ts
@@ -51,7 +51,10 @@ export const mockCasUsage = (
   return { gristCasUsage, topicCasUsage }
 }
 
-export const mockSolutionRecommandation = (recommandationFields = {}) => {
+export const mockSolutionRecommandation = (
+  recommandationFields = {},
+  solutionFields = {}
+) => {
   const gristRecommandation = gristRecommandationFactory.one({
     overrides: {
       fields: {
@@ -82,7 +85,8 @@ export const mockSolutionRecommandation = (recommandationFields = {}) => {
       Visible_sur_simplifions: true,
       API_ou_datasets_integres: null,
       APIs_ou_datasets_fournis: null,
-      solutions_integratrices: null
+      solutions_integratrices: null,
+      ...solutionFields
     }
   }
 
@@ -98,7 +102,11 @@ export const mockSolutionRecommandation = (recommandationFields = {}) => {
     [topicSolutionRecommandee]
   )
 
-  return { gristRecommandation, topicSolution: topicSolutionRecommandee }
+  return {
+    gristRecommandation,
+    gristSolution: gristSolutionRecommandee,
+    topicSolution: topicSolutionRecommandee
+  }
 }
 
 export const mockApidatasetRecommandations = (

--- a/src/custom/simplifions/components/SimplifionsDataApi.vue
+++ b/src/custom/simplifions/components/SimplifionsDataApi.vue
@@ -36,6 +36,8 @@
         :organization="datagouvResource!.organization"
         :owner="datagouvResource!.owner"
         :access-type="datagouvResource!.access_type"
+        :access-audiences="datagouvResource!.access_audiences"
+        :resource-label="cardResourceLabel"
         :link-label="cardLinkLabel"
         :title-tag="props.titleTag"
       />
@@ -48,11 +50,11 @@ import SimplifionsDatasetDataserviceCard from '@/custom/simplifions/components/S
 import DatagouvfrAPI from '@/services/api/DatagouvfrAPI'
 import type { Dataservice, DatasetV2 } from '@datagouv/components-next'
 import * as Sentry from '@sentry/vue'
-import type { ApiOrDataset } from '../model/grist'
+import type { ApiOrDatasetCardData } from '../model/grist'
 
 const props = withDefaults(
   defineProps<{
-    apiOrDataset: ApiOrDataset
+    apiOrDataset: ApiOrDatasetCardData
     titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
   }>(),
   {
@@ -83,6 +85,7 @@ const datagouvType = computed(() => {
     case 'API':
       return 'dataservices'
     case 'Jeu de données':
+    case 'Base de données':
       return 'datasets'
     default:
       throw new Error(`Unknown api or dataset type: ${props.apiOrDataset.Type}`)
@@ -91,6 +94,10 @@ const datagouvType = computed(() => {
 
 const cardClass = computed(() =>
   datagouvType.value == 'datasets' ? 'dataset-card' : 'dataservice-card'
+)
+
+const cardResourceLabel = computed(() =>
+  datagouvType.value == 'datasets' ? 'Base de données' : 'API'
 )
 
 const cardLinkLabel = computed(() =>
@@ -123,10 +130,7 @@ if (!hasEmptyUid.value) {
       url: `${api.url()}/${props.apiOrDataset.UID_datagouv}`,
       method: 'get',
       params: {
-        fields:
-          datagouvType.value == 'dataservices'
-            ? 'title,organization,access_type,owner'
-            : 'title,organization,owner'
+        fields: 'title,organization,owner,access_type,access_audiences'
       }
     })
     .then((data) => {

--- a/src/custom/simplifions/components/SimplifionsDataApi.vue
+++ b/src/custom/simplifions/components/SimplifionsDataApi.vue
@@ -85,7 +85,6 @@ const datagouvType = computed(() => {
     case 'API':
       return 'dataservices'
     case 'Jeu de données':
-    case 'Base de données':
       return 'datasets'
     default:
       throw new Error(`Unknown api or dataset type: ${props.apiOrDataset.Type}`)
@@ -97,7 +96,7 @@ const cardClass = computed(() =>
 )
 
 const cardResourceLabel = computed(() =>
-  datagouvType.value == 'datasets' ? 'Base de données' : 'API'
+  datagouvType.value == 'datasets' ? 'Jeu de données' : 'API'
 )
 
 const cardLinkLabel = computed(() =>

--- a/src/custom/simplifions/components/SimplifionsDatasetDataserviceCard.vue
+++ b/src/custom/simplifions/components/SimplifionsDatasetDataserviceCard.vue
@@ -94,7 +94,7 @@ interface Props {
   owner?: UserReference | null
   accessType?: AccessType
   accessAudiences?: Array<AccessAudience>
-  resourceLabel: 'API' | 'Base de données'
+  resourceLabel: 'API' | 'Jeu de données'
   linkLabel: string
   titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 }

--- a/src/custom/simplifions/components/SimplifionsDatasetDataserviceCard.vue
+++ b/src/custom/simplifions/components/SimplifionsDatasetDataserviceCard.vue
@@ -1,20 +1,23 @@
 <template>
   <div class="fr-my-2w fr-p-2w border border-default-grey relative">
     <div
-      v-if="accessType === 'restricted'"
-      class="absolute top-0 fr-grid-row fr-grid-row--middle fr-mt-n3v fr-ml-n1v"
+      v-if="accessTypeBadge"
+      class="badge-wrapper absolute top-0 fr-grid-row fr-grid-row--middle fr-ml-n1v"
     >
       <p
-        class="fr-badge fr-badge--sm fr-badge--info fr-badge--no-icon fr-mr-1w"
+        :class="`fr-badge fr-badge--sm ${accessTypeBadge.colorClass} fr-badge--no-icon fr-mr-1w`"
       >
         <span
-          class="fr-icon-lock-line fr-icon--xs fr-mr-1v"
+          :class="`${accessTypeBadge.icon} fr-icon--sm fr-mr-1v`"
           aria-hidden="true"
         ></span>
-        API restreinte
+        {{ accessTypeBadge.label }}
       </p>
     </div>
-    <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+    <div
+      class="fr-grid-row fr-grid-row--gutters fr-grid-row--top"
+      :class="{ 'fr-mt-2w': accessTypeBadge }"
+    >
       <div class="fr-col-auto">
         <div class="logo">
           <OrganizationLogo
@@ -78,15 +81,20 @@ import {
   OrganizationLogo,
   OrganizationNameWithCertificate,
   Placeholder,
+  type AccessAudience,
+  type AccessType,
   type OrganizationReference,
   type UserReference
 } from '@datagouv/components-next'
+import { getAccessTypeBadge } from '../utils/accessTypeBadge'
 
 interface Props {
   title: string
   organization?: OrganizationReference | null
   owner?: UserReference | null
-  accessType?: string
+  accessType?: AccessType
+  accessAudiences?: Array<AccessAudience>
+  resourceLabel: 'API' | 'Base de données'
   linkLabel: string
   titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 }
@@ -95,6 +103,7 @@ const props = withDefaults(defineProps<Props>(), {
   organization: undefined,
   owner: undefined,
   accessType: undefined,
+  accessAudiences: undefined,
   titleTag: 'h4'
 })
 
@@ -107,6 +116,14 @@ const ownerAvatarUrl = computed(() => {
   if (!props.owner) return null
   return getOwnerAvatar({ organization: null, owner: props.owner }, 40)
 })
+
+const accessTypeBadge = computed(() =>
+  getAccessTypeBadge(
+    props.accessType,
+    props.accessAudiences,
+    props.resourceLabel
+  )
+)
 </script>
 
 <style scoped>
@@ -140,5 +157,11 @@ const ownerAvatarUrl = computed(() => {
 
 .top-0 {
   top: 0;
+}
+
+/* Keeps the badge centered on the card's top border regardless of how many
+   lines it wraps to, instead of a fixed negative margin sized for one line. */
+.badge-wrapper {
+  transform: translateY(-50%);
 }
 </style>

--- a/src/custom/simplifions/components/SimplifionsDatasetDataserviceCard.vue
+++ b/src/custom/simplifions/components/SimplifionsDatasetDataserviceCard.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="fr-my-2w fr-p-2w border border-default-grey relative">
+  <div class="fr-my-2w fr-p-2w border border-default-grey">
     <div
       v-if="accessTypeBadge"
-      class="badge-wrapper absolute top-0 fr-grid-row fr-grid-row--middle fr-ml-n1v"
+      class="fr-grid-row fr-mt-n6v fr-mb-2w fr-ml-n1v"
     >
       <p
-        :class="`fr-badge fr-badge--sm ${accessTypeBadge.colorClass} fr-badge--no-icon fr-mr-1w`"
+        :class="`fr-badge fr-badge--sm ${accessTypeBadge.colorClass} fr-badge--no-icon`"
       >
         <span
           :class="`${accessTypeBadge.icon} fr-icon--sm fr-mr-1v`"
@@ -14,10 +14,7 @@
         {{ accessTypeBadge.label }}
       </p>
     </div>
-    <div
-      class="fr-grid-row fr-grid-row--gutters fr-grid-row--top"
-      :class="{ 'fr-mt-2w': accessTypeBadge }"
-    >
+    <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
       <div class="fr-col-auto">
         <div class="logo">
           <OrganizationLogo
@@ -149,19 +146,5 @@ const accessTypeBadge = computed(() =>
     white-space: normal !important;
     text-overflow: clip !important;
   }
-}
-
-.absolute {
-  position: absolute;
-}
-
-.top-0 {
-  top: 0;
-}
-
-/* Keeps the badge centered on the card's top border regardless of how many
-   lines it wraps to, instead of a fixed negative margin sized for one line. */
-.badge-wrapper {
-  transform: translateY(-50%);
 }
 </style>

--- a/src/custom/simplifions/components/SimplifionsReco.vue
+++ b/src/custom/simplifions/components/SimplifionsReco.vue
@@ -223,6 +223,7 @@ import type {
   ApiOrDataset,
   ApiOrDatasetCardData,
   ApiOrDatasetRecord,
+  ApiOrDatasetType,
   ApiOrDatasetUtiles,
   ApiOrDatasetUtilesRecord,
   Recommandation,
@@ -241,6 +242,18 @@ const props = defineProps<{
 const recommandation = props.recommandation
 const isSolution = !!recommandation.Solution_recommandee
 
+// "Type de recommandation" tells whether the recommended resource is an API or a
+// dataset. "Type de solution" describes the kind of offer instead (Éditeur,
+// Logiciel métier…), so it cannot be used to pick the data.gouv.fr endpoint.
+const isApiOrDatasetType = (type: string | null): type is ApiOrDatasetType =>
+  type === 'API' || type === 'Jeu de données'
+
+const recommandationType = isApiOrDatasetType(
+  recommandation.Type_de_recommandation
+)
+  ? recommandation.Type_de_recommandation
+  : undefined
+
 // === Solution-specific ===
 const topicSlug = ref<string | undefined>(undefined)
 const usefulDataApiFourniesParLaSolution = ref<
@@ -256,27 +269,26 @@ if (isSolution) {
     topicSlug.value = topic?.slug
   })
 
-  grist
-    .getRecord('Solutions', recommandation.Solution_recommandee)
-    .then((data) => {
-      const solution = data.fields as Solution
-      const type = solution.Type_de_solution?.includes('API')
-        ? 'API'
-        : solution.Type_de_solution?.includes('Jeu de données')
-          ? 'Jeu de données'
-          : undefined
+  // Only worth fetching when the recommandation designates an API or a dataset:
+  // otherwise no card can be built out of the solution record.
+  if (recommandationType) {
+    grist
+      .getRecord('Solutions', recommandation.Solution_recommandee)
+      .then((data) => {
+        const solution = data.fields as Solution
 
-      if (solution.UID_datagouv && type) {
-        solutionApiOrDataset.value = {
-          UID_datagouv: solution.UID_datagouv,
-          Nom: solution.Nom,
-          Type: type
+        if (solution.UID_datagouv) {
+          solutionApiOrDataset.value = {
+            UID_datagouv: solution.UID_datagouv,
+            Nom: solution.Nom,
+            Type: recommandationType
+          }
         }
-      }
-    })
-    .catch((error) => {
-      console.error('Failed to fetch solution:', error)
-    })
+      })
+      .catch((error) => {
+        console.error('Failed to fetch solution:', error)
+      })
+  }
 
   if (recommandation.API_et_datasets_utiles_fournis?.length) {
     grist

--- a/src/custom/simplifions/components/SimplifionsReco.vue
+++ b/src/custom/simplifions/components/SimplifionsReco.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="reco-card fr-p-2w fr-mb-4w">
     <h4 class="fr-h4 fr-mb-2w">
-      ➡️ {{ recommandation.Nom_de_la_recommandation }}
+      <span class="fr-text--alt"><em>Via «</em></span>
+      {{ recommandation.Nom_de_la_recommandation }}
+      <span class="fr-text--alt"><em>»</em></span>
     </h4>
 
     <div class="fr-grid-row fr-grid-row--top fr-mx-2w">
@@ -59,7 +61,7 @@
 
           <template v-if="isSolution">
             <div
-              class="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-mt-2w"
+              class="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-my-2w"
             >
               <router-link
                 v-if="topicSlug"
@@ -82,6 +84,12 @@
                 Demander un accès pour ce cas d'usage
               </a>
             </div>
+
+            <SimplifionsDataApi
+              v-if="solutionApiOrDataset"
+              :api-or-dataset="solutionApiOrDataset"
+              title-tag="h6"
+            />
 
             <SimplifionsRecoUsefulEndpointsTable
               :endpoints="usefulDataApiFourniesParLaSolution"
@@ -213,10 +221,12 @@ import type { Dataservice, DatasetV2 } from '@datagouv/components-next'
 import { grist } from '../grist.ts'
 import type {
   ApiOrDataset,
+  ApiOrDatasetCardData,
   ApiOrDatasetRecord,
   ApiOrDatasetUtiles,
   ApiOrDatasetUtilesRecord,
   Recommandation,
+  Solution,
   SolutionRecord
 } from '../model/grist'
 import TopicsAPI from '../simplifionsTopicsApi'
@@ -237,6 +247,7 @@ const usefulDataApiFourniesParLaSolution = ref<
   ApiOrDatasetRecord[] | undefined
 >(undefined)
 const customDescriptions = ref<Record<number, ApiOrDatasetUtiles>>({})
+const solutionApiOrDataset = ref<ApiOrDatasetCardData | undefined>(undefined)
 
 if (isSolution) {
   const topicsAPI = new TopicsAPI({ version: 2 })
@@ -244,6 +255,28 @@ if (isSolution) {
   topicsAPI.getTopicByTag(solutionTag).then((topic) => {
     topicSlug.value = topic?.slug
   })
+
+  grist
+    .getRecord('Solutions', recommandation.Solution_recommandee)
+    .then((data) => {
+      const solution = data.fields as Solution
+      const type = solution.Type_de_solution?.includes('API')
+        ? 'API'
+        : solution.Type_de_solution?.includes('Base de données')
+          ? 'Base de données'
+          : undefined
+
+      if (solution.UID_datagouv && type) {
+        solutionApiOrDataset.value = {
+          UID_datagouv: solution.UID_datagouv,
+          Nom: solution.Nom,
+          Type: type
+        }
+      }
+    })
+    .catch((error) => {
+      console.error('Failed to fetch solution:', error)
+    })
 
   if (recommandation.API_et_datasets_utiles_fournis?.length) {
     grist
@@ -418,6 +451,7 @@ const activeAccordion = ref(-1)
 <style scoped>
 .reco-card {
   background-color: var(--background-alt-beige-gris-galet);
+  border-left: 4px solid var(--border-action-high-grey);
 }
 
 .icon-green {

--- a/src/custom/simplifions/components/SimplifionsReco.vue
+++ b/src/custom/simplifions/components/SimplifionsReco.vue
@@ -262,8 +262,8 @@ if (isSolution) {
       const solution = data.fields as Solution
       const type = solution.Type_de_solution?.includes('API')
         ? 'API'
-        : solution.Type_de_solution?.includes('Base de données')
-          ? 'Base de données'
+        : solution.Type_de_solution?.includes('Jeu de données')
+          ? 'Jeu de données'
           : undefined
 
       if (solution.UID_datagouv && type) {

--- a/src/custom/simplifions/components/SimplifionsSolutionIntegrateursTabs.vue
+++ b/src/custom/simplifions/components/SimplifionsSolutionIntegrateursTabs.vue
@@ -135,7 +135,7 @@ const tabTitles = computed(() => {
   }
   if (filteredBriquesTechniques.value.length > 0) {
     titles.push({
-      title: `API, base de donnée ou brique logicielle (${filteredBriquesTechniques.value.length})`,
+      title: `API, jeu de données ou brique logicielle (${filteredBriquesTechniques.value.length})`,
       tabId: 'tab-brique-technique',
       panelId: 'tab-content-brique-technique'
     })

--- a/src/custom/simplifions/model/grist.ts
+++ b/src/custom/simplifions/model/grist.ts
@@ -72,9 +72,7 @@ export type ApiOrDatasetCardData = Pick<
   ApiOrDataset,
   'UID_datagouv' | 'Nom'
 > & {
-  // Le type peut aussi provenir de Solution.Type_de_solution ("Base de données"),
-  // qui n'a pas le même libellé que le champ Grist ApiOrDataset.Type ("Jeu de données")
-  Type: ApiOrDatasetType | 'Base de données'
+  Type: ApiOrDatasetType
 }
 
 export type ApiOrDatasetUtiles = {

--- a/src/custom/simplifions/model/grist.ts
+++ b/src/custom/simplifions/model/grist.ts
@@ -50,10 +50,12 @@ export type RecommandationRecord = GristRecord & {
   fields: Recommandation
 }
 
+export type ApiOrDatasetType = 'API' | 'Jeu de données'
+
 export type ApiOrDataset = {
   UID_datagouv: string
   Nom: string
-  Type: string
+  Type: ApiOrDatasetType
   Fourni_par: number
   Integre_par: number[]
   Visible_sur_simplifions: boolean
@@ -64,6 +66,15 @@ export type ApiOrDataset = {
 }
 export type ApiOrDatasetRecord = GristRecord & {
   fields: ApiOrDataset
+}
+
+export type ApiOrDatasetCardData = Pick<
+  ApiOrDataset,
+  'UID_datagouv' | 'Nom'
+> & {
+  // Le type peut aussi provenir de Solution.Type_de_solution ("Base de données"),
+  // qui n'a pas le même libellé que le champ Grist ApiOrDataset.Type ("Jeu de données")
+  Type: ApiOrDatasetType | 'Base de données'
 }
 
 export type ApiOrDatasetUtiles = {
@@ -115,6 +126,7 @@ export type Solution = {
   URL_demande_d_acces: string
   solutions_integratrices: number[] | null
   liste_categories_de_solution: string[]
+  UID_datagouv: string
 }
 export type SolutionRecord = GristRecord & {
   fields: Solution

--- a/src/custom/simplifions/utils/__tests__/accessTypeBadge.test.ts
+++ b/src/custom/simplifions/utils/__tests__/accessTypeBadge.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { getAccessTypeBadge } from '../accessTypeBadge'
+
+describe('getAccessTypeBadge', () => {
+  it('returns no badge when access type is undefined', () => {
+    expect(getAccessTypeBadge(undefined, undefined, 'API')).toBeNull()
+  })
+
+  it('returns an open badge for both resource labels', () => {
+    expect(getAccessTypeBadge('open', undefined, 'API')).toMatchObject({
+      colorClass: 'fr-badge--info'
+    })
+    expect(
+      getAccessTypeBadge('open', undefined, 'Base de données')
+    ).toMatchObject({
+      colorClass: 'fr-badge--info'
+    })
+  })
+
+  it('returns an open-with-account badge only for API', () => {
+    expect(
+      getAccessTypeBadge('open_with_account', undefined, 'API')
+    ).toMatchObject({
+      colorClass: 'fr-badge--info'
+    })
+    expect(
+      getAccessTypeBadge('open_with_account', undefined, 'Base de données')
+    ).toBeNull()
+  })
+
+  it('returns a success badge when restricted but open to public actors', () => {
+    const badge = getAccessTypeBadge(
+      'restricted',
+      [{ role: 'local_authority_and_administration', condition: 'yes' }],
+      'Base de données'
+    )
+    expect(badge).toMatchObject({ colorClass: 'fr-badge--success' })
+  })
+
+  it('returns a conditional badge when restricted access is conditional for public actors', () => {
+    const badge = getAccessTypeBadge(
+      'restricted',
+      [
+        {
+          role: 'local_authority_and_administration',
+          condition: 'under_condition'
+        }
+      ],
+      'API'
+    )
+    expect(badge).toMatchObject({
+      colorClass: 'fr-badge--green-tilleul-verveine'
+    })
+  })
+
+  it('returns a restricted badge when public actors have no access', () => {
+    const badge = getAccessTypeBadge(
+      'restricted',
+      [{ role: 'local_authority_and_administration', condition: 'no' }],
+      'API'
+    )
+    expect(badge).toMatchObject({ colorClass: 'fr-badge--orange-terre-battue' })
+  })
+
+  it('returns a restricted badge when no audience information is available', () => {
+    const badge = getAccessTypeBadge('restricted', undefined, 'API')
+    expect(badge).toMatchObject({ colorClass: 'fr-badge--orange-terre-battue' })
+  })
+})

--- a/src/custom/simplifions/utils/__tests__/accessTypeBadge.test.ts
+++ b/src/custom/simplifions/utils/__tests__/accessTypeBadge.test.ts
@@ -11,7 +11,7 @@ describe('getAccessTypeBadge', () => {
       colorClass: 'fr-badge--info'
     })
     expect(
-      getAccessTypeBadge('open', undefined, 'Base de données')
+      getAccessTypeBadge('open', undefined, 'Jeu de données')
     ).toMatchObject({
       colorClass: 'fr-badge--info'
     })
@@ -24,7 +24,7 @@ describe('getAccessTypeBadge', () => {
       colorClass: 'fr-badge--info'
     })
     expect(
-      getAccessTypeBadge('open_with_account', undefined, 'Base de données')
+      getAccessTypeBadge('open_with_account', undefined, 'Jeu de données')
     ).toBeNull()
   })
 
@@ -32,7 +32,7 @@ describe('getAccessTypeBadge', () => {
     const badge = getAccessTypeBadge(
       'restricted',
       [{ role: 'local_authority_and_administration', condition: 'yes' }],
-      'Base de données'
+      'Jeu de données'
     )
     expect(badge).toMatchObject({ colorClass: 'fr-badge--success' })
   })

--- a/src/custom/simplifions/utils/accessTypeBadge.ts
+++ b/src/custom/simplifions/utils/accessTypeBadge.ts
@@ -13,20 +13,23 @@ export type AccessTypeBadge = {
 export function getAccessTypeBadge(
   accessType: AccessType | undefined,
   accessAudiences: Array<AccessAudience> | undefined,
-  resourceLabel: 'API' | 'Base de données'
+  resourceLabel: 'API' | 'Jeu de données'
 ): AccessTypeBadge | null {
+  const ouvert = resourceLabel === 'API' ? 'ouverte' : 'ouvert'
+  const restreint = resourceLabel === 'API' ? 'restreinte' : 'restreint'
+
   switch (accessType) {
     case 'open':
       return {
-        label: `${resourceLabel} ouverte`,
+        label: `${resourceLabel} ${ouvert}`,
         icon: 'fr-icon-arrow-left-right-line',
         colorClass: 'fr-badge--info'
       }
     case 'open_with_account':
-      // Ce statut d'accès n'existe pas pour les bases de données, pas de badge dans ce cas
+      // Ce statut d'accès n'existe pas pour les jeux de données, pas de badge dans ce cas
       return resourceLabel === 'API'
         ? {
-            label: `${resourceLabel} ouverte avec compte`,
+            label: `${resourceLabel} ${ouvert} avec compte`,
             icon: 'fr-icon-user-line',
             colorClass: 'fr-badge--info'
           }
@@ -38,7 +41,7 @@ export function getAccessTypeBadge(
 
       if (publicActorsAccess === 'yes') {
         return {
-          label: `${resourceLabel} restreinte · accessible aux acteurs publics`,
+          label: `${resourceLabel} ${restreint} · accessible aux acteurs publics`,
           icon: 'fr-icon-lock-unlock-line',
           colorClass: 'fr-badge--success'
         }
@@ -46,7 +49,7 @@ export function getAccessTypeBadge(
 
       if (publicActorsAccess === 'under_condition') {
         return {
-          label: `${resourceLabel} restreinte · accessible aux acteurs publics sous conditions`,
+          label: `${resourceLabel} ${restreint} · accessible aux acteurs publics sous conditions`,
           icon: 'fr-icon-lock-line',
           colorClass: 'fr-badge--green-tilleul-verveine'
         }

--- a/src/custom/simplifions/utils/accessTypeBadge.ts
+++ b/src/custom/simplifions/utils/accessTypeBadge.ts
@@ -1,0 +1,64 @@
+import type { AccessAudience, AccessType } from '@datagouv/components-next'
+
+export type AccessTypeBadge = {
+  label: string
+  icon: string
+  colorClass:
+    | 'fr-badge--info'
+    | 'fr-badge--success'
+    | 'fr-badge--orange-terre-battue'
+    | 'fr-badge--green-tilleul-verveine'
+}
+
+export function getAccessTypeBadge(
+  accessType: AccessType | undefined,
+  accessAudiences: Array<AccessAudience> | undefined,
+  resourceLabel: 'API' | 'Base de données'
+): AccessTypeBadge | null {
+  switch (accessType) {
+    case 'open':
+      return {
+        label: `${resourceLabel} ouverte`,
+        icon: 'fr-icon-arrow-left-right-line',
+        colorClass: 'fr-badge--info'
+      }
+    case 'open_with_account':
+      // Ce statut d'accès n'existe pas pour les bases de données, pas de badge dans ce cas
+      return resourceLabel === 'API'
+        ? {
+            label: `${resourceLabel} ouverte avec compte`,
+            icon: 'fr-icon-user-line',
+            colorClass: 'fr-badge--info'
+          }
+        : null
+    case 'restricted': {
+      const publicActorsAccess = accessAudiences?.find(
+        (audience) => audience.role === 'local_authority_and_administration'
+      )?.condition
+
+      if (publicActorsAccess === 'yes') {
+        return {
+          label: `${resourceLabel} restreinte · accessible aux acteurs publics`,
+          icon: 'fr-icon-lock-unlock-line',
+          colorClass: 'fr-badge--success'
+        }
+      }
+
+      if (publicActorsAccess === 'under_condition') {
+        return {
+          label: `${resourceLabel} restreinte · accessible aux acteurs publics sous conditions`,
+          icon: 'fr-icon-lock-line',
+          colorClass: 'fr-badge--green-tilleul-verveine'
+        }
+      }
+
+      return {
+        label: `${resourceLabel} en accès restreint`,
+        icon: 'fr-icon-lock-line',
+        colorClass: 'fr-badge--orange-terre-battue'
+      }
+    }
+    default:
+      return null
+  }
+}


### PR DESCRIPTION
Plusieurs exemples visibles ici : https://deploy-preview-1331--simplifions.sandbox.data.developpement-durable.gouv.fr/cas-d-usages/marches-publics-depot-et-instruction-des-candidatures


- [x] Retravaille les badges existant pour, par exemple, prendre en compte le public cible et passer en vert une API restreinte mais accessibles aux acteurs publics (ce qui est la cible de simplifions)
- [x] Applique ces changements aux bases de données
- [x] Suite à l'ajout d'un champ dans Grist dans les solutions (`UID_datagouv`), récupération de la fiche API ou jeu de données des solutions concernées
- [x] Modification mineure de style avec ajout d'une bordure noire à gauche et remplacement de la flèche du titre de la reco par le mot "Via"  


### Nouveau badges adapté au public simplifions
<img width="1239" height="166" alt="image" src="https://github.com/user-attachments/assets/1230c3bb-b3b0-4c37-b7a8-e63d0ceac58d" />
<img width="1250" height="175" alt="image" src="https://github.com/user-attachments/assets/3912d36f-bd66-4679-aced-18b7129b5448" />
<img width="1228" height="159" alt="image" src="https://github.com/user-attachments/assets/8e6975a3-3af6-49f8-8ab8-21fb2ee79089" />
<img width="1239" height="165" alt="image" src="https://github.com/user-attachments/assets/7324a7cd-d1d4-4131-bc62-62869cf66eac" />


### Affichage du composant pour les solutions 

<img width="1299" height="660" alt="image" src="https://github.com/user-attachments/assets/48bf4b81-321e-49c3-a346-e886e3a393ba" />

### Modification mineure du style de la reco
Pour permettre de bien identifier toute la zone de la reco
<img width="1328" height="552" alt="image" src="https://github.com/user-attachments/assets/81785589-a4df-4ebd-aad1-481a7f89ca06" />
