### PR TITLE
feat(ecologie): search/breadcrumb labels

### DIFF
--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -282,7 +282,7 @@ pages:
       topic: 65e9aa6cb5c809c30c70ee02
     filter_prefix:
     title: Toutes les données
-    breadcrumb_title: Données
+    breadcrumb_title: Toutes les données
     labels:
       singular: jeu de données
       plural: jeux de données
@@ -401,7 +401,7 @@ pages:
       organization: 67884b4da4fca9c97bbef479
     filter_prefix: ecospheres-indicateurs
     title: Indicateurs phares
-    breadcrumb_title: Indicateurs
+    breadcrumb_title: Indicateurs phares
     labels:
       singular: indicateur
       plural: indicateurs
@@ -587,7 +587,7 @@ pages:
       tag: univers-ecospheres
     filter_prefix: ecospheres
     title: Collections thématiques
-    breadcrumb_title: Collections
+    breadcrumb_title: Collections thématiques
     labels:
       singular: collection
       plural: collections thématiques

--- a/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
+++ b/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
@@ -42,7 +42,7 @@ const topicsLabels = useLabels(topicConf.labels)
 
 const links = computed(() => [
   { to: '/', text: 'Accueil' },
-  { to: '/indicators', text: 'Indicateurs' },
+  { to: '/indicators', text: indicatorConf.breadcrumb_title },
   { text: indicator.value?.title || '' }
 ])
 


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1167

Also changes the breadcrumb titles (for coherence and because it's what drives the search labels). Also changed collections to collections thématiques, for coherence again.

<img width="473" height="685" alt="Capture d’écran 2026-08-10 à 16 58 13" src="https://github.com/user-attachments/assets/17362872-365d-46d4-ba2a-57cd1bd325b0" />
