### PR TITLE
feat(topics): detect more datasets/topics/dataservices domains

### DIFF
--- a/src/components/forms/dataset/FactorEditModal.vue
+++ b/src/components/forms/dataset/FactorEditModal.vue
@@ -17,7 +17,7 @@ import { useTopicElementStore } from '@/store/TopicElementStore'
 import { useSiteId } from '@/utils/config'
 import { useForm, type AllowedInput } from '@/utils/form'
 import { useLabels } from '@/utils/labels'
-import { getDatasetIdFromUri } from '@/utils/topic'
+import { getSlugFromUri } from '@/utils/topic'
 import ErrorSummary from '../ErrorSummary.vue'
 import FactorFields from './FactorFields.vue'
 
@@ -159,7 +159,7 @@ const submit = async (modalData: DatasetModalData) => {
       siteExtras?.uri &&
       siteExtras?.availability === Availability.URL_AVAILABLE
     ) {
-      const datasetName = getDatasetIdFromUri(siteExtras.uri, [
+      const datasetName = getSlugFromUri(siteExtras.uri, 'datasets', [
         config.datagouvfr.base_url,
         config.website.seo?.canonical_url
       ])

--- a/src/components/forms/dataset/FactorEditModal.vue
+++ b/src/components/forms/dataset/FactorEditModal.vue
@@ -17,6 +17,7 @@ import { useTopicElementStore } from '@/store/TopicElementStore'
 import { useSiteId } from '@/utils/config'
 import { useForm, type AllowedInput } from '@/utils/form'
 import { useLabels } from '@/utils/labels'
+import { getDatasetIdFromUri } from '@/utils/topic'
 import ErrorSummary from '../ErrorSummary.vue'
 import FactorFields from './FactorFields.vue'
 
@@ -158,18 +159,15 @@ const submit = async (modalData: DatasetModalData) => {
       siteExtras?.uri &&
       siteExtras?.availability === Availability.URL_AVAILABLE
     ) {
-      const pattern = new RegExp(
-        `^${config.datagouvfr.base_url}(?:/.*)?/datasets/(?<datasetName>[a-zA-Z0-9_-]+)(?:/|#|$)`
-      )
-      const match = pattern.exec(siteExtras.uri)
-      if (match?.groups?.datasetName) {
+      const datasetName = getDatasetIdFromUri(siteExtras.uri, [
+        config.datagouvfr.base_url,
+        config.website.seo?.canonical_url
+      ])
+      if (datasetName) {
         try {
-          const dataset = await useDatasetStore().load(
-            match.groups.datasetName,
-            {
-              toasted: false
-            }
-          )
+          const dataset = await useDatasetStore().load(datasetName, {
+            toasted: false
+          })
           if (dataset !== undefined) {
             siteExtras.availability = Availability.LOCAL_AVAILABLE
             const resolved = router.resolve({

--- a/src/utils/__tests__/topic.test.ts
+++ b/src/utils/__tests__/topic.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { getDatasetIdFromUri } from '../topic'
+
+describe('getDatasetIdFromUri', () => {
+  const baseUrls = ['https://www.data.gouv.fr', 'https://ecologie.data.gouv.fr']
+
+  it('matches a www.data.gouv.fr URL', () => {
+    expect(
+      getDatasetIdFromUri(
+        'https://www.data.gouv.fr/datasets/61489f2f2de14040f348fa0b',
+        baseUrls
+      )
+    ).toBe('61489f2f2de14040f348fa0b')
+  })
+
+  it('matches a data.gouv.fr URL without www', () => {
+    expect(
+      getDatasetIdFromUri(
+        'https://data.gouv.fr/datasets/61489f2f2de14040f348fa0b',
+        baseUrls
+      )
+    ).toBe('61489f2f2de14040f348fa0b')
+  })
+
+  it('matches an ecologie.data.gouv.fr URL', () => {
+    expect(
+      getDatasetIdFromUri(
+        'https://ecologie.data.gouv.fr/datasets/61489f2f2de14040f348fa0b',
+        baseUrls
+      )
+    ).toBe('61489f2f2de14040f348fa0b')
+  })
+
+  it('matches when the URI has www but the base URL does not', () => {
+    expect(
+      getDatasetIdFromUri('https://www.data.gouv.fr/datasets/abc123', [
+        'https://data.gouv.fr'
+      ])
+    ).toBe('abc123')
+  })
+
+  it('matches a URL with a locale path prefix', () => {
+    expect(
+      getDatasetIdFromUri(
+        'https://www.data.gouv.fr/fr/datasets/abc123',
+        baseUrls
+      )
+    ).toBe('abc123')
+  })
+
+  it('matches a URL with a trailing slash', () => {
+    expect(
+      getDatasetIdFromUri('https://www.data.gouv.fr/datasets/abc123/', baseUrls)
+    ).toBe('abc123')
+  })
+
+  it('returns null for an unrecognized host', () => {
+    expect(
+      getDatasetIdFromUri('https://example.com/datasets/abc123', baseUrls)
+    ).toBeNull()
+  })
+
+  it('returns null for a non-dataset path', () => {
+    expect(
+      getDatasetIdFromUri('https://www.data.gouv.fr/datasets', baseUrls)
+    ).toBeNull()
+    expect(
+      getDatasetIdFromUri('https://www.data.gouv.fr/reuses/abc123', baseUrls)
+    ).toBeNull()
+  })
+
+  it('returns null for an invalid URL', () => {
+    expect(getDatasetIdFromUri('not a url', baseUrls)).toBeNull()
+    expect(
+      getDatasetIdFromUri('data.gouv.fr/datasets/abc123', baseUrls)
+    ).toBeNull()
+  })
+
+  it('returns null when no base URLs are provided', () => {
+    expect(
+      getDatasetIdFromUri('https://www.data.gouv.fr/datasets/abc123', [
+        undefined
+      ])
+    ).toBeNull()
+  })
+
+  it('ignores an invalid base URL and still matches valid ones', () => {
+    expect(
+      getDatasetIdFromUri('https://www.data.gouv.fr/datasets/abc123', [
+        'not a url',
+        'https://www.data.gouv.fr'
+      ])
+    ).toBe('abc123')
+  })
+})

--- a/src/utils/__tests__/topic.test.ts
+++ b/src/utils/__tests__/topic.test.ts
@@ -1,39 +1,45 @@
 import { describe, expect, it } from 'vitest'
-import { getDatasetIdFromUri } from '../topic'
+import { getSlugFromUri } from '../topic'
 
-describe('getDatasetIdFromUri', () => {
-  const baseUrls = ['https://www.data.gouv.fr', 'https://ecologie.data.gouv.fr']
+describe('getSlugFromUri', () => {
+  const datasetBaseUrls = [
+    'https://www.data.gouv.fr',
+    'https://ecologie.data.gouv.fr'
+  ]
 
   it('matches a www.data.gouv.fr URL', () => {
     expect(
-      getDatasetIdFromUri(
+      getSlugFromUri(
         'https://www.data.gouv.fr/datasets/61489f2f2de14040f348fa0b',
-        baseUrls
+        'datasets',
+        datasetBaseUrls
       )
     ).toBe('61489f2f2de14040f348fa0b')
   })
 
   it('matches a data.gouv.fr URL without www', () => {
     expect(
-      getDatasetIdFromUri(
+      getSlugFromUri(
         'https://data.gouv.fr/datasets/61489f2f2de14040f348fa0b',
-        baseUrls
+        'datasets',
+        datasetBaseUrls
       )
     ).toBe('61489f2f2de14040f348fa0b')
   })
 
   it('matches an ecologie.data.gouv.fr URL', () => {
     expect(
-      getDatasetIdFromUri(
+      getSlugFromUri(
         'https://ecologie.data.gouv.fr/datasets/61489f2f2de14040f348fa0b',
-        baseUrls
+        'datasets',
+        datasetBaseUrls
       )
     ).toBe('61489f2f2de14040f348fa0b')
   })
 
   it('matches when the URI has www but the base URL does not', () => {
     expect(
-      getDatasetIdFromUri('https://www.data.gouv.fr/datasets/abc123', [
+      getSlugFromUri('https://www.data.gouv.fr/datasets/abc123', 'datasets', [
         'https://data.gouv.fr'
       ])
     ).toBe('abc123')
@@ -41,44 +47,81 @@ describe('getDatasetIdFromUri', () => {
 
   it('matches a URL with a locale path prefix', () => {
     expect(
-      getDatasetIdFromUri(
+      getSlugFromUri(
         'https://www.data.gouv.fr/fr/datasets/abc123',
-        baseUrls
+        'datasets',
+        datasetBaseUrls
       )
     ).toBe('abc123')
   })
 
   it('matches a URL with a trailing slash', () => {
     expect(
-      getDatasetIdFromUri('https://www.data.gouv.fr/datasets/abc123/', baseUrls)
+      getSlugFromUri(
+        'https://www.data.gouv.fr/datasets/abc123/',
+        'datasets',
+        datasetBaseUrls
+      )
     ).toBe('abc123')
+  })
+
+  it('matches a different resource name (e.g. topics)', () => {
+    expect(
+      getSlugFromUri('https://ecologie.data.gouv.fr/topics/abc123', 'topics', [
+        'https://ecologie.data.gouv.fr'
+      ])
+    ).toBe('abc123')
+  })
+
+  it('does not match a data.gouv.fr URL when only the site base URL is allowed (topics/collections)', () => {
+    expect(
+      getSlugFromUri('https://www.data.gouv.fr/topics/abc123', 'topics', [
+        'https://ecologie.data.gouv.fr'
+      ])
+    ).toBeNull()
   })
 
   it('returns null for an unrecognized host', () => {
     expect(
-      getDatasetIdFromUri('https://example.com/datasets/abc123', baseUrls)
+      getSlugFromUri(
+        'https://example.com/datasets/abc123',
+        'datasets',
+        datasetBaseUrls
+      )
     ).toBeNull()
   })
 
-  it('returns null for a non-dataset path', () => {
+  it('returns null for a non-matching resource path', () => {
     expect(
-      getDatasetIdFromUri('https://www.data.gouv.fr/datasets', baseUrls)
+      getSlugFromUri(
+        'https://www.data.gouv.fr/datasets',
+        'datasets',
+        datasetBaseUrls
+      )
     ).toBeNull()
     expect(
-      getDatasetIdFromUri('https://www.data.gouv.fr/reuses/abc123', baseUrls)
+      getSlugFromUri(
+        'https://www.data.gouv.fr/reuses/abc123',
+        'datasets',
+        datasetBaseUrls
+      )
     ).toBeNull()
   })
 
   it('returns null for an invalid URL', () => {
-    expect(getDatasetIdFromUri('not a url', baseUrls)).toBeNull()
+    expect(getSlugFromUri('not a url', 'datasets', datasetBaseUrls)).toBeNull()
     expect(
-      getDatasetIdFromUri('data.gouv.fr/datasets/abc123', baseUrls)
+      getSlugFromUri(
+        'data.gouv.fr/datasets/abc123',
+        'datasets',
+        datasetBaseUrls
+      )
     ).toBeNull()
   })
 
   it('returns null when no base URLs are provided', () => {
     expect(
-      getDatasetIdFromUri('https://www.data.gouv.fr/datasets/abc123', [
+      getSlugFromUri('https://www.data.gouv.fr/datasets/abc123', 'datasets', [
         undefined
       ])
     ).toBeNull()
@@ -86,7 +129,7 @@ describe('getDatasetIdFromUri', () => {
 
   it('ignores an invalid base URL and still matches valid ones', () => {
     expect(
-      getDatasetIdFromUri('https://www.data.gouv.fr/datasets/abc123', [
+      getSlugFromUri('https://www.data.gouv.fr/datasets/abc123', 'datasets', [
         'not a url',
         'https://www.data.gouv.fr'
       ])

--- a/src/utils/topic.ts
+++ b/src/utils/topic.ts
@@ -22,12 +22,13 @@ export const isAvailable = (availability: Availability): boolean => {
 }
 
 /**
- * Extract a dataset id from a URI if it points to a dataset page on one of
- * the given base URLs, matching hostnames regardless of a "www" prefix
+ * Extract an id/slug from a URI if it points to a `resourceName` page on one
+ * of the given base URLs, matching hostnames regardless of a "www" prefix
  * (e.g. a `data.gouv.fr` base URL also matches `www.data.gouv.fr` URIs).
  */
-export const getDatasetIdFromUri = (
+export const getSlugFromUri = (
   uri: string,
+  resourceName: string,
   baseUrls: (string | undefined)[]
 ): string | null => {
   let url: URL
@@ -53,8 +54,10 @@ export const getDatasetIdFromUri = (
     return null
   }
 
-  const match = url.pathname.match(/\/datasets\/(?<datasetName>[a-zA-Z0-9_-]+)/)
-  return match?.groups?.datasetName ?? null
+  const match = url.pathname.match(
+    new RegExp(`/${resourceName}/(?<slug>[a-zA-Z0-9_-]+)`)
+  )
+  return match?.groups?.slug ?? null
 }
 
 /**

--- a/src/utils/topic.ts
+++ b/src/utils/topic.ts
@@ -22,6 +22,42 @@ export const isAvailable = (availability: Availability): boolean => {
 }
 
 /**
+ * Extract a dataset id from a URI if it points to a dataset page on one of
+ * the given base URLs, matching hostnames regardless of a "www" prefix
+ * (e.g. a `data.gouv.fr` base URL also matches `www.data.gouv.fr` URIs).
+ */
+export const getDatasetIdFromUri = (
+  uri: string,
+  baseUrls: (string | undefined)[]
+): string | null => {
+  let url: URL
+  try {
+    url = new URL(uri)
+  } catch {
+    return null
+  }
+
+  const normalizeHost = (host: string) => host.replace(/^www\./, '')
+  const recognizedHosts = baseUrls
+    .filter((base): base is string => !!base)
+    .map((base) => {
+      try {
+        return normalizeHost(new URL(base).hostname)
+      } catch {
+        return null
+      }
+    })
+    .filter((host): host is string => !!host)
+
+  if (!recognizedHosts.includes(normalizeHost(url.hostname))) {
+    return null
+  }
+
+  const match = url.pathname.match(/\/datasets\/(?<datasetName>[a-zA-Z0-9_-]+)/)
+  return match?.groups?.datasetName ?? null
+}
+
+/**
  * Build a fonctionnal Topic from clone source data
  */
 export const cloneTopic = async (

--- a/src/utils/topicReferencedContent.ts
+++ b/src/utils/topicReferencedContent.ts
@@ -8,25 +8,7 @@ import { useDatasetStore } from '@/store/OrganizationDatasetStore'
 import { useTopicStore } from '@/store/TopicStore'
 import { toastHttpError } from '@/utils/error'
 import { isNotFoundError } from '@/utils/http'
-
-/**
- * Generic function to extract a slug from a URI based on base URLs and resource path
- */
-const getSlugFromUri = (
-  uri: string,
-  resourceName: string,
-  baseUrls: (string | undefined)[]
-): string | null => {
-  const validBaseUrls = baseUrls.filter(Boolean)
-  if (validBaseUrls.length === 0) return null
-
-  for (const baseUrl of validBaseUrls) {
-    const match = uri.match(new RegExp(`${baseUrl}/${resourceName}/([^/]+)`))
-    if (match) return match[1]
-  }
-
-  return null
-}
+import { getSlugFromUri } from '@/utils/topic'
 
 /**
  * Generic function to load URI-referenced content (topics or dataservices) from factors


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1175

Now accepts "local" (ecologie) domains and doesn't care about www or not when saving an URL pointing to a dataset.

Also generalise the datasets domain matching when saving to topics and dataservices domain matching when displaying (no-www URLs for dataservices are now matched).