### PR TITLE
fix(ecologie): tags spacing on hp

### DIFF
--- a/src/custom/ecospheres/components/home/HomeCollections.vue
+++ b/src/custom/ecospheres/components/home/HomeCollections.vue
@@ -203,7 +203,7 @@ onMounted(() => {
   .fr-tags-group {
     flex-wrap: wrap;
     margin: 0;
-    gap: 0.5rem 0.25rem;
+    gap: 0.5rem;
 
     > li {
       line-height: 1.5rem;

--- a/src/custom/ecospheres/components/home/HomeCollections.vue
+++ b/src/custom/ecospheres/components/home/HomeCollections.vue
@@ -96,17 +96,13 @@ onMounted(() => {
           <div class="card-footer">
             <ul class="fr-tags-group">
               <li>
-                <p
-                  class="fr-tag fr-icon-database-line fr-tag--icon-left fr-mb-0"
-                >
+                <p class="fr-tag fr-icon-database-line fr-tag--icon-left">
                   {{ nbDatasetsPerCollection[collection.slug] || '...' }} jeux
                   de données
                 </p>
               </li>
               <li>
-                <p
-                  class="fr-tag fr-icon-map-pin-2-line fr-tag--icon-left fr-mb-0"
-                >
+                <p class="fr-tag fr-icon-map-pin-2-line fr-tag--icon-left">
                   {{ collection.maille }}
                 </p>
               </li>
@@ -206,8 +202,15 @@ onMounted(() => {
 
   .fr-tags-group {
     flex-wrap: wrap;
+    margin: 0;
+    gap: 0.5rem 0.25rem;
+
     > li {
       line-height: 1.5rem;
+    }
+
+    .fr-tag {
+      margin: 0;
     }
   }
 }


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1163

<img width="397" height="630" alt="Capture d’écran 2026-08-11 à 15 27 36" src="https://github.com/user-attachments/assets/bf8ed04f-a090-45b5-a26c-cfcb219e9250" />
