### PR TITLE
feat(topics): enable discussion notification

### DIFF
--- a/configs/accessibilite/config.yaml
+++ b/configs/accessibilite/config.yaml
@@ -174,6 +174,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: false
       datasets:
         display: true
       reuses:
@@ -202,6 +203,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: false
       datasets:
         display: true
       reuses:

--- a/configs/accessibilite/config.yaml
+++ b/configs/accessibilite/config.yaml
@@ -174,7 +174,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
       reuses:
@@ -203,7 +203,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
       reuses:

--- a/configs/culture/config.yaml
+++ b/configs/culture/config.yaml
@@ -185,7 +185,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
       reuses:
@@ -264,7 +264,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
       reuses:

--- a/configs/culture/config.yaml
+++ b/configs/culture/config.yaml
@@ -185,6 +185,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: false
       datasets:
         display: true
       reuses:
@@ -263,6 +264,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: false
       datasets:
         display: true
       reuses:

--- a/configs/defis/config.yaml
+++ b/configs/defis/config.yaml
@@ -329,6 +329,7 @@ pages:
       discussions:
         display: false
         create: false
+        notify_external_url: false
       datasets:
         display: true
       reuses:
@@ -372,6 +373,7 @@ pages:
       discussions:
         display: false
         create: false
+        notify_external_url: false
       datasets:
         display: true
       reuses:

--- a/configs/defis/config.yaml
+++ b/configs/defis/config.yaml
@@ -329,7 +329,7 @@ pages:
       discussions:
         display: false
         create: false
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
       reuses:
@@ -373,7 +373,7 @@ pages:
       discussions:
         display: false
         create: false
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
       reuses:

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -250,8 +250,8 @@ definitions: &definitions
 #         display: {bool}             # display discussions tab on detail page
 #         create: {bool}              # create discussions tab on detail page
 #         notify_external_url: {bool} # on discussion creation, send extras.notification.external_url (this site's page for the subject)
-#                                      # so udata notification emails link back here instead of the subject's canonical udata page.
-#                                      # requires the site's domain to be allow-listed on the udata side (DISCUSSION_ALLOWED_EXTERNAL_DOMAINS). defaults to false.
+#                                     # so udata notification emails link back here instead of the subject's canonical udata page.
+#                                     # requires the site's domain to be allow-listed on the udata side (DISCUSSION_ALLOWED_EXTERNAL_DOMAINS).
 #       datasets:
 #         display: {bool}             # display datasets tab on detail page
 #       reuses:

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -249,6 +249,9 @@ definitions: &definitions
 #       discussions:
 #         display: {bool}             # display discussions tab on detail page
 #         create: {bool}              # create discussions tab on detail page
+#         notify_external_url: {bool} # on discussion creation, send extras.notification.external_url (this site's page for the subject)
+#                                      # so udata notification emails link back here instead of the subject's canonical udata page.
+#                                      # requires the site's domain to be allow-listed on the udata side (DISCUSSION_ALLOWED_EXTERNAL_DOMAINS). defaults to false.
 #       datasets:
 #         display: {bool}             # display datasets tab on detail page
 #       reuses:
@@ -298,6 +301,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: false
       datasets:
         display: true
       reuses:
@@ -417,6 +421,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: false
       datasets:
         display: true
       reuses:
@@ -565,6 +570,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: false
       datasets:
         display: true
     editable: false
@@ -605,6 +611,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: true
       datasets:
         display: true
       reuses:

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -249,9 +249,9 @@ definitions: &definitions
 #       discussions:
 #         display: {bool}             # display discussions tab on detail page
 #         create: {bool}              # create discussions tab on detail page
-#         notify_external_url: {bool} # on discussion creation, send extras.notification.external_url (this site's page for the subject)
-#                                     # so udata notification emails link back here instead of the subject's canonical udata page.
-#                                     # requires the site's domain to be allow-listed on the udata side (DISCUSSION_ALLOWED_EXTERNAL_DOMAINS).
+#         notify_external_url: {bool} # when true, email notifications will link back to this site's pages instead of the canonical udata pages.
+#                                     # website.seo.canonical_url must be set and the site domain must be allowed in the udata config 
+#                                     # (DISCUSSION_ALLOWED_EXTERNAL_DOMAINS).
 #       datasets:
 #         display: {bool}             # display datasets tab on detail page
 #       reuses:

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -249,8 +249,8 @@ definitions: &definitions
 #       discussions:
 #         display: {bool}             # display discussions tab on detail page
 #         create: {bool}              # create discussions tab on detail page
-#         notify_external_url: {bool} # when true, email notifications will link back to this site's pages instead of the canonical udata pages.
-#                                     # website.seo.canonical_url must be set and the site domain must be allowed in the udata config 
+#         notify_url_override: {bool} # when true, email notifications will link back to this site's pages instead of the canonical udata pages.
+#                                     # website.seo.canonical_url must be set and the site domain must be allowed in the udata config
 #                                     # (DISCUSSION_ALLOWED_EXTERNAL_DOMAINS).
 #       datasets:
 #         display: {bool}             # display datasets tab on detail page
@@ -301,7 +301,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
       reuses:
@@ -421,7 +421,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
       reuses:
@@ -570,7 +570,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
     editable: false
@@ -611,7 +611,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: true
+        notify_url_override: true
       datasets:
         display: true
       reuses:

--- a/configs/hackathon/config.yaml
+++ b/configs/hackathon/config.yaml
@@ -166,6 +166,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: false
       datasets:
         display: true
       reuses:
@@ -205,6 +206,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: false
       datasets:
         display: true
       reuses:

--- a/configs/hackathon/config.yaml
+++ b/configs/hackathon/config.yaml
@@ -166,7 +166,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
       reuses:
@@ -206,7 +206,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
       reuses:

--- a/configs/logistique/config.yaml
+++ b/configs/logistique/config.yaml
@@ -176,6 +176,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: false
       datasets:
         display: true
       reuses:
@@ -203,6 +204,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: false
       datasets:
         display: true
       reuses:

--- a/configs/logistique/config.yaml
+++ b/configs/logistique/config.yaml
@@ -176,7 +176,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
       reuses:
@@ -204,7 +204,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
       reuses:

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -201,7 +201,7 @@ pages:
       discussions:
         display: true
         create: false
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: true
       reuses:

--- a/configs/meteo-france/config.yaml
+++ b/configs/meteo-france/config.yaml
@@ -201,6 +201,7 @@ pages:
       discussions:
         display: true
         create: false
+        notify_external_url: false
       datasets:
         display: true
       reuses:

--- a/configs/simplifions/config.yaml
+++ b/configs/simplifions/config.yaml
@@ -286,6 +286,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: false
       datasets:
         display: false
       reuses:
@@ -342,6 +343,7 @@ pages:
       discussions:
         display: true
         create: true
+        notify_external_url: false
       datasets:
         display: false
       reuses:

--- a/configs/simplifions/config.yaml
+++ b/configs/simplifions/config.yaml
@@ -286,7 +286,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: false
       reuses:
@@ -343,7 +343,7 @@ pages:
       discussions:
         display: true
         create: true
-        notify_external_url: false
+        notify_url_override: false
       datasets:
         display: false
       reuses:

--- a/src/components/DiscussionsList.vue
+++ b/src/components/DiscussionsList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import type { ComputedRef, Ref } from 'vue'
-import { computed, nextTick, ref, watch, watchEffect } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import BlankState from '@/components/BlankState.vue'
@@ -143,22 +143,18 @@ watch(
 
 // Used by parent views to deep-link to a discussion
 // Only looks at the currently loaded page: discussions on further pages are a known limitation.
-const navigateToDiscussion = (discussionId: DiscussionId) => {
-  let done = false
-  const stopWatching = watchEffect(() => {
-    if (done || discussions.value === undefined) return
-    done = true
-    nextTick(() => {
-      const el = document.getElementById(`discussion-${discussionId}`)
-      if (!el) {
-        console.warn(
-          `Trying to scroll to discussion ${discussionId}, not found.`
-        )
-        return
-      }
-      el.scrollIntoView({ block: 'start' })
-    })
-    stopWatching()
+const navigateToDiscussion = async (discussionId: DiscussionId) => {
+  await discussionStore.loadDiscussionsForSubject(
+    props.subject.id,
+    currentPage.value
+  )
+  nextTick(() => {
+    const el = document.getElementById(`discussion-${discussionId}`)
+    if (!el) {
+      console.warn(`Trying to scroll to discussion ${discussionId}, not found.`)
+      return
+    }
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' })
   })
 }
 

--- a/src/components/DiscussionsList.vue
+++ b/src/components/DiscussionsList.vue
@@ -141,10 +141,8 @@ watch(
   { immediate: true }
 )
 
-// Used by parent views to deep-link to a discussion (e.g. from a
-// notification email's `#discussion-{id}` fragment, see udata's
-// `Discussion.notification_url`). Only looks at the currently loaded page:
-// discussions on further pages are a known limitation.
+// Used by parent views to deep-link to a discussion
+// Only looks at the currently loaded page: discussions on further pages are a known limitation.
 const navigateToDiscussion = (discussionId: DiscussionId) => {
   let done = false
   const stopWatching = watchEffect(() => {

--- a/src/components/DiscussionsList.vue
+++ b/src/components/DiscussionsList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import type { ComputedRef, Ref } from 'vue'
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import BlankState from '@/components/BlankState.vue'
@@ -26,7 +26,7 @@ const router = useRouter()
 const discussionStore = useDiscussionStore()
 const userStore = useUserStore()
 
-const { pageConf } = useCurrentPageConf()
+const { pageKey, pageConf } = useCurrentPageConf()
 
 const { loggedIn } = storeToRefs(userStore)
 const currentPage: Ref<number> = ref(1)
@@ -73,6 +73,27 @@ const pages = computed(() => {
 
 const allowDiscussionCreation = pageConf.resources_tabs.discussions.create
 
+// Topics don't have a canonical page on data.gouv.fr that makes sense to
+// notify users on, so we ask udata to link back to this site's own page
+// instead, via the discussion's `extras.notification.external_url`.
+// See https://github.com/ecolabdata/ecospheres/issues/263.
+// The site's public URL (not `window.location.origin`) is used since this
+// value is persisted on the discussion and reused later in emails: it must
+// stay stable and match the domain udata allow-lists, unlike a dev/preview
+// origin.
+const getNotificationExternalUrl = (): string | null => {
+  if (props.subjectClass !== 'Topic') return null
+  const canonicalUrl = config.website.seo?.canonical_url
+  if (!canonicalUrl) return null
+  const slug = (props.subject as { slug?: string }).slug
+  if (!slug) return null
+  const path = router.resolve({
+    name: `${pageKey}_detail`,
+    params: { item_id: slug }
+  }).href
+  return `${canonicalUrl}${path}`
+}
+
 const getUserAvatar = (post: Post) => {
   if (post.posted_by.avatar_thumbnail) {
     return post.posted_by.avatar_thumbnail
@@ -86,7 +107,14 @@ const triggerLogin = () => {
 }
 
 const createDiscussion = () => {
-  discussionStore.createDiscussion(discussionForm.value).then((d) => {
+  const externalUrl = getNotificationExternalUrl()
+  const payload: DiscussionForm = {
+    ...discussionForm.value,
+    ...(externalUrl
+      ? { extras: { notification: { external_url: externalUrl } } }
+      : {})
+  }
+  discussionStore.createDiscussion(payload).then((d) => {
     if (d !== undefined) {
       discussionForm.value.title = ''
       discussionForm.value.comment = ''
@@ -119,6 +147,31 @@ watch(
   },
   { immediate: true }
 )
+
+// Used by parent views to deep-link to a discussion (e.g. from a
+// notification email's `#discussion-{id}` fragment, see udata's
+// `Discussion.notification_url`). Only looks at the currently loaded page:
+// discussions on further pages are a known limitation.
+const navigateToDiscussion = (discussionId: DiscussionId) => {
+  let done = false
+  const stopWatching = watchEffect(() => {
+    if (done || discussions.value === undefined) return
+    done = true
+    nextTick(() => {
+      const el = document.getElementById(`discussion-${discussionId}`)
+      if (!el) {
+        console.warn(
+          `Trying to scroll to discussion ${discussionId}, not found.`
+        )
+        return
+      }
+      el.scrollIntoView({ block: 'start' })
+    })
+    stopWatching()
+  })
+}
+
+defineExpose({ navigateToDiscussion })
 </script>
 
 <template>
@@ -196,7 +249,7 @@ watch(
       :key="discussion.id"
       class="fr-mb-6w"
     >
-      <p :id="discussion.id" class="discussion-title fr-mb-3v">
+      <p :id="`discussion-${discussion.id}`" class="discussion-title fr-mb-3v">
         {{ discussion.title }}
       </p>
       <div class="discussion-subtitle">
@@ -262,7 +315,7 @@ watch(
           type="button"
           class="fr-btn fr-btn--sm fr-btn--secondary fr-icon-chat-3-line fr-btn--icon-left"
           aria-label="Répondre à la discussion"
-          :aria-describedby="discussion.id"
+          :aria-describedby="`discussion-${discussion.id}`"
           @click.stop.prevent="
             () => {
               postForm.comment = ''

--- a/src/components/DiscussionsList.vue
+++ b/src/components/DiscussionsList.vue
@@ -75,7 +75,7 @@ const allowDiscussionCreation = pageConf.resources_tabs.discussions.create
 
 // If configured, construct an external notification url from canonical_url for udata to use
 const getNotificationExternalUrl = (): string | null => {
-  if (!pageConf.resources_tabs.discussions.notify_external_url) return null
+  if (!pageConf.resources_tabs.discussions.notify_url_override) return null
   const canonicalUrl = config.website.seo?.canonical_url
   if (!canonicalUrl) return null
   const slug = (props.subject as { slug?: string }).slug

--- a/src/components/DiscussionsList.vue
+++ b/src/components/DiscussionsList.vue
@@ -73,16 +73,9 @@ const pages = computed(() => {
 
 const allowDiscussionCreation = pageConf.resources_tabs.discussions.create
 
-// Topics don't have a canonical page on data.gouv.fr that makes sense to
-// notify users on, so we ask udata to link back to this site's own page
-// instead, via the discussion's `extras.notification.external_url`.
-// See https://github.com/ecolabdata/ecospheres/issues/263.
-// The site's public URL (not `window.location.origin`) is used since this
-// value is persisted on the discussion and reused later in emails: it must
-// stay stable and match the domain udata allow-lists, unlike a dev/preview
-// origin.
+// If configured, construct an external notification url from canonical_url for udata to use
 const getNotificationExternalUrl = (): string | null => {
-  if (props.subjectClass !== 'Topic') return null
+  if (!pageConf.resources_tabs.discussions.notify_external_url) return null
   const canonicalUrl = config.website.seo?.canonical_url
   if (!canonicalUrl) return null
   const slug = (props.subject as { slug?: string }).slug

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -98,7 +98,7 @@ export type PageConf = {
     discussions: {
       display: boolean
       create: boolean
-      notify_external_url?: boolean
+      notify_url_override?: boolean
     }
     datasets: {
       display: boolean

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -98,6 +98,7 @@ export type PageConf = {
     discussions: {
       display: boolean
       create: boolean
+      notify_external_url?: boolean
     }
     datasets: {
       display: boolean

--- a/src/model/discussion.ts
+++ b/src/model/discussion.ts
@@ -15,6 +15,13 @@ interface DiscussionForm {
   title: string
   comment: string
   subject: Subject
+  extras?: DiscussionExtras
+}
+
+interface DiscussionExtras {
+  notification?: {
+    external_url: string
+  }
 }
 
 interface Post {
@@ -42,6 +49,7 @@ interface DiscussionResponse extends GenericResponse {
 
 export type {
   Discussion,
+  DiscussionExtras,
   DiscussionForm,
   DiscussionId,
   DiscussionResponse,

--- a/src/views/topics/TopicDetailView.vue
+++ b/src/views/topics/TopicDetailView.vue
@@ -215,52 +215,55 @@ useMeta({
   noIndex: () => topic.value?.private
 })
 
-// Handle factor deeplinks: #factor-{id} switches to Données tab and scrolls to factor
+// Wait until `ready()` is true (e.g. a child component is mounted and its
+// data has loaded), then run `action()` once.
+const runWhenReady = (ready: () => boolean, action: () => void) => {
+  let done = false
+  const stop = watchEffect(() => {
+    if (done || !ready()) return
+    done = true
+    action()
+    stop()
+  })
+}
+
+// Clear the hash immediately using replaceState to avoid adding a history
+// entry and to avoid interfering with the deeplink's own scroll behavior.
+// TODO: proper way would be to implement deeplinking for tabs
+const clearHash = () => {
+  const url = new URL(window.location.href)
+  url.hash = ''
+  window.history.replaceState(window.history.state, '', url.toString())
+}
+
+// Handle deeplinks: #factor-{id} switches to Données tab and scrolls to the
+// factor; #discussion-{id} switches to the Discussions tab and
+// scrolls to the discussion.
 watch(
   () => router.currentRoute.value.hash,
   (hash) => {
     if (hash.startsWith('#factor-')) {
       activeTab.value = 0
       const elementId = hash.replace('#factor-', '')
-
-      // Wait for component and data to be ready before navigating
-      let stopWatching: (() => void) | undefined = undefined
-      stopWatching = watchEffect(() => {
-        if (topicFactorsListRef.value && factors.value.length > 0) {
-          nextTick(() => {
+      runWhenReady(
+        () => !!topicFactorsListRef.value && factors.value.length > 0,
+        () =>
+          nextTick(() =>
             topicFactorsListRef.value?.navigateToElement(elementId)
-          })
-          stopWatching?.()
-        }
-      })
-
-      // Clear hash immediately using replaceState to avoid adding history entry
-      // and to avoid interfering with navigateToElement's scroll behavior
-      // TODO: proper way would be implement deeplinking for tabs
-      const url = new URL(window.location.href)
-      url.hash = ''
-      window.history.replaceState(window.history.state, '', url.toString())
+          )
+      )
+      clearHash()
     } else if (hash.startsWith('#discussion-')) {
-      // Deeplink from a discussion notification email (udata's
-      // `Discussion.notification_url` appends `#discussion-{id}`):
-      // switch to the Discussions tab and scroll to it.
       const tabIndex = tabTitles.value.findIndex(
         (t) => t.tabId === 'tab-discussions'
       )
       if (tabIndex !== -1) activeTab.value = tabIndex
       const discussionId = hash.replace('#discussion-', '')
-
-      let done = false
-      const stopWatching = watchEffect(() => {
-        if (done || !discussionsListRef.value) return
-        done = true
-        discussionsListRef.value.navigateToDiscussion(discussionId)
-        stopWatching()
-      })
-
-      const url = new URL(window.location.href)
-      url.hash = ''
-      window.history.replaceState(window.history.state, '', url.toString())
+      runWhenReady(
+        () => !!discussionsListRef.value,
+        () => discussionsListRef.value?.navigateToDiscussion(discussionId)
+      )
+      clearHash()
     }
   },
   { immediate: true }

--- a/src/views/topics/TopicDetailView.vue
+++ b/src/views/topics/TopicDetailView.vue
@@ -218,10 +218,12 @@ useMeta({
 // Wait until `ready()` is true (e.g. a child component is mounted and its
 // data has loaded), then run `action()` once.
 const runWhenReady = (ready: () => boolean, action: () => void) => {
-  let done = false
+  if (ready()) {
+    action()
+    return
+  }
   const stop = watchEffect(() => {
-    if (done || !ready()) return
-    done = true
+    if (!ready()) return
     action()
     stop()
   })

--- a/src/views/topics/TopicDetailView.vue
+++ b/src/views/topics/TopicDetailView.vue
@@ -74,6 +74,9 @@ const { factors } = useTopicFactors(topic)
 const topicFactorsListRef = ref<InstanceType<typeof TopicFactorsList> | null>(
   null
 )
+const discussionsListRef = ref<InstanceType<typeof DiscussionsList> | null>(
+  null
+)
 const topicActivityListRef = ref<InstanceType<typeof TopicActivityList> | null>(
   null
 )
@@ -234,6 +237,27 @@ watch(
       // Clear hash immediately using replaceState to avoid adding history entry
       // and to avoid interfering with navigateToElement's scroll behavior
       // TODO: proper way would be implement deeplinking for tabs
+      const url = new URL(window.location.href)
+      url.hash = ''
+      window.history.replaceState(window.history.state, '', url.toString())
+    } else if (hash.startsWith('#discussion-')) {
+      // Deeplink from a discussion notification email (udata's
+      // `Discussion.notification_url` appends `#discussion-{id}`):
+      // switch to the Discussions tab and scroll to it.
+      const tabIndex = tabTitles.value.findIndex(
+        (t) => t.tabId === 'tab-discussions'
+      )
+      if (tabIndex !== -1) activeTab.value = tabIndex
+      const discussionId = hash.replace('#discussion-', '')
+
+      let done = false
+      const stopWatching = watchEffect(() => {
+        if (done || !discussionsListRef.value) return
+        done = true
+        discussionsListRef.value.navigateToDiscussion(discussionId)
+        stopWatching()
+      })
+
       const url = new URL(window.location.href)
       url.hash = ''
       window.history.replaceState(window.history.state, '', url.toString())
@@ -447,6 +471,7 @@ watch(
         tab-id="tab-discussions"
       >
         <DiscussionsList
+          ref="discussionsListRef"
           :subject="topic"
           subject-class="Topic"
           :empty-message="`Il n'y a pas encore de discussion pour ${labels.articles.ce} ${labels.singular}.`"


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/263

**This feature is only enabled for ecologie's collections.** Github is pinging everyone for review because I put the default value for the config flag to false on every site.

This plugs into the udata feature introduced in https://github.com/opendatateam/udata/pull/3765: when configured on a given page, add an extra with the "local" url for udata to point back to it in its notification email.

The notification email will include a deeplink like `#discussion-xxx` that is now handled. It currently does not handle pagination (target discussion has to be on first page). I think it's acceptable for this use case (notification should be fresh enough, and the discussion volume on topics is very low).

⚠️ The feature can not be tested e2e on demo.data.gouv.fr since it doesn't send emails. We can only verify the correct extra is sent and the deeplink is handled.