### PR TITLE
feat(ci): tag based docker build

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -79,6 +79,13 @@ jobs:
           echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Log parsed values
+        run: |
+          echo "matched: ${{ steps.parse.outputs.matched }}"
+          echo "site: ${{ steps.parse.outputs.site }}"
+          echo "environment: ${{ steps.parse.outputs.environment }}"
+          echo "version: ${{ steps.parse.outputs.version }}"
+
   build:
     needs: parse
     if: needs.parse.outputs.matched == 'true'

--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -1,17 +1,14 @@
+# Takes a tag like `<site>-<environment>-<YYYYMMDD>-<N>` and builds and pushes
+# `<site>-<environment>:<YYYYMMDD>-<N>` and `<site>-<environment>:latest` to registry
+
 name: Build and push site image
 run-name: Build and push ${{ github.event.inputs.tag || github.ref_name }}
 
 on:
   push:
     tags:
-      - 'ecospheres-*'
-      - 'meteo-france-*'
-      - 'logistique-*'
-      - 'accessibilite-*'
-      - 'defis-*'
-      - 'hackathon-*'
-      - 'simplifions-*'
-      - 'culture-*'
+      # Eligible tags are resolved later in `parse`, from SITES and ENVS vars
+      - '*'
   workflow_dispatch:
     inputs:
       tag:
@@ -19,31 +16,25 @@ on:
         required: true
         type: string
 
-env:
-  IMAGE_NAME: ecospheres-front
-
 jobs:
-  build:
+  parse:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
-      cancel-in-progress: false
+    outputs:
+      matched: ${{ steps.parse.outputs.matched }}
+      site: ${{ steps.parse.outputs.site }}
+      environment: ${{ steps.parse.outputs.environment }}
+      version: ${{ steps.parse.outputs.version }}
     steps:
-      - name: Resolve tag
-        id: resolve
-        run: echo "tag=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
-
-      # Sites and environments can't come from `vars` here: this parsing happens in a plain
-      # shell step, not a workflow input, so `vars`/`choice` typing doesn't apply.
       - name: Parse site, environment and version from tag
         id: parse
         shell: bash
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          SITES: ${{ vars.SITES }}
+          ENVIRONMENTS: ${{ vars.ENVS }}
         run: |
-          TAG="${{ steps.resolve.outputs.tag }}"
-          SITES="ecospheres meteo-france logistique accessibilite defis hackathon simplifions culture"
-          ENVIRONMENTS="demo preprod prod"
+          SITES="${SITES//|/ }"
+          ENVIRONMENTS="${ENVIRONMENTS//|/ }"
 
           SITE=""
           for s in $SITES; do
@@ -88,14 +79,22 @@ jobs:
           echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+  build:
+    needs: parse
+    if: needs.parse.outputs.matched == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
+      cancel-in-progress: false
+    steps:
       - name: Checkout
-        if: steps.parse.outputs.matched == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ steps.resolve.outputs.tag }}
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
 
       - name: Log in to container registry
-        if: steps.parse.outputs.matched == 'true'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ vars.CONTAINER_REGISTRY_SERVER }}
@@ -103,13 +102,12 @@ jobs:
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Build and push
-        if: steps.parse.outputs.matched == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true
           build-args: |
-            VITE_SITE_ID=${{ steps.parse.outputs.site }}
+            VITE_SITE_ID=${{ needs.parse.outputs.site }}
           tags: |
-            ${{ vars.CONTAINER_REGISTRY_SERVER }}/${{ vars.CONTAINER_REGISTRY_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ steps.parse.outputs.site }}-${{ steps.parse.outputs.environment }}-${{ steps.parse.outputs.version }}
-            ${{ vars.CONTAINER_REGISTRY_SERVER }}/${{ vars.CONTAINER_REGISTRY_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ steps.parse.outputs.site }}-${{ steps.parse.outputs.environment }}-latest
+            ${{ vars.CONTAINER_REGISTRY_SERVER }}/${{ vars.CONTAINER_REGISTRY_NAMESPACE }}/${{ needs.parse.outputs.site }}-${{ needs.parse.outputs.environment }}:${{ needs.parse.outputs.version }}
+            ${{ vars.CONTAINER_REGISTRY_SERVER }}/${{ vars.CONTAINER_REGISTRY_NAMESPACE }}/${{ needs.parse.outputs.site }}-${{ needs.parse.outputs.environment }}:latest

--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -1,5 +1,5 @@
-# Takes a tag like `<site>-<environment>-<YYYYMMDD>-<N>` and builds and pushes
-# `<site>-<environment>:<YYYYMMDD>-<N>` and `<site>-<environment>:latest` to registry
+# Takes a tag like `<site>-<env>-<YYYYMMDD>-<N>` and builds and pushes
+# `<site>-<env>:<YYYYMMDD>-<N>` and `<site>-<env>:latest` to registry
 
 name: Build and push site image
 run-name: Build and push ${{ github.event.inputs.tag || github.ref_name }}
@@ -19,6 +19,7 @@ on:
 jobs:
   parse:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       matched: ${{ steps.parse.outputs.matched }}
       site: ${{ steps.parse.outputs.site }}
@@ -32,52 +33,23 @@ jobs:
           TAG: ${{ github.event.inputs.tag || github.ref_name }}
           SITES: ${{ vars.SITES }}
           ENVIRONMENTS: ${{ vars.ENVS }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          SITES="${SITES//|/ }"
-          ENVIRONMENTS="${ENVIRONMENTS//|/ }"
-
-          SITE=""
-          for s in $SITES; do
-            if [[ "$TAG" == "$s-"* ]]; then
-              SITE="$s"
-              break
-            fi
-          done
-
-          if [[ -z "$SITE" ]]; then
-            echo "Tag '$TAG' does not start with a known site, skipping"
-            echo "matched=false" >> "$GITHUB_OUTPUT"
+          if [[ "$TAG" =~ ^($SITES)-($ENVIRONMENTS)-([0-9]{8}-[0-9]+)$ ]]; then
+            echo "matched=true" >> "$GITHUB_OUTPUT"
+            echo "site=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "environment=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+            echo "version=${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          REST="${TAG#"$SITE"-}"
+          echo "Tag '$TAG' does not match <site>-<environment>-<YYYYMMDD>-<N> (known sites: $SITES; known environments: $ENVIRONMENTS)"
+          echo "matched=false" >> "$GITHUB_OUTPUT"
 
-          ENVIRONMENT=""
-          for e in $ENVIRONMENTS; do
-            if [[ "$REST" == "$e-"* ]]; then
-              ENVIRONMENT="$e"
-              break
-            fi
-          done
-
-          if [[ -z "$ENVIRONMENT" ]]; then
-            echo "Tag '$TAG' does not contain a known environment, skipping"
-            echo "matched=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "::error::Explicitly dispatched tag did not match - check vars.SITES/vars.ENVS are in sync with tag-image-release.yml's choice lists"
+            exit 1
           fi
-
-          VERSION="${REST#"$ENVIRONMENT"-}"
-
-          if [[ ! "$VERSION" =~ ^[0-9]{8}-[0-9]+$ ]]; then
-            echo "Version '$VERSION' does not match <YYYYMMDD>-<N>, skipping"
-            echo "matched=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "matched=true" >> "$GITHUB_OUTPUT"
-          echo "site=$SITE" >> "$GITHUB_OUTPUT"
-          echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Log parsed values
         run: |

--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -1,0 +1,115 @@
+name: Build and push site image
+run-name: Build and push ${{ github.event.inputs.tag || github.ref_name }}
+
+on:
+  push:
+    tags:
+      - 'ecospheres-*'
+      - 'meteo-france-*'
+      - 'logistique-*'
+      - 'accessibilite-*'
+      - 'defis-*'
+      - 'hackathon-*'
+      - 'simplifions-*'
+      - 'culture-*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (format: <site>-<environment>-<YYYYMMDD>-<N>)'
+        required: true
+        type: string
+
+env:
+  IMAGE_NAME: ecospheres-front
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
+      cancel-in-progress: false
+    steps:
+      - name: Resolve tag
+        id: resolve
+        run: echo "tag=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+
+      # Sites and environments can't come from `vars` here: this parsing happens in a plain
+      # shell step, not a workflow input, so `vars`/`choice` typing doesn't apply.
+      - name: Parse site, environment and version from tag
+        id: parse
+        shell: bash
+        run: |
+          TAG="${{ steps.resolve.outputs.tag }}"
+          SITES="ecospheres meteo-france logistique accessibilite defis hackathon simplifions culture"
+          ENVIRONMENTS="demo preprod prod"
+
+          SITE=""
+          for s in $SITES; do
+            if [[ "$TAG" == "$s-"* ]]; then
+              SITE="$s"
+              break
+            fi
+          done
+
+          if [[ -z "$SITE" ]]; then
+            echo "Tag '$TAG' does not start with a known site, skipping"
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          REST="${TAG#"$SITE"-}"
+
+          ENVIRONMENT=""
+          for e in $ENVIRONMENTS; do
+            if [[ "$REST" == "$e-"* ]]; then
+              ENVIRONMENT="$e"
+              break
+            fi
+          done
+
+          if [[ -z "$ENVIRONMENT" ]]; then
+            echo "Tag '$TAG' does not contain a known environment, skipping"
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          VERSION="${REST#"$ENVIRONMENT"-}"
+
+          if [[ ! "$VERSION" =~ ^[0-9]{8}-[0-9]+$ ]]; then
+            echo "Version '$VERSION' does not match <YYYYMMDD>-<N>, skipping"
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "matched=true" >> "$GITHUB_OUTPUT"
+          echo "site=$SITE" >> "$GITHUB_OUTPUT"
+          echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.parse.outputs.matched == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.resolve.outputs.tag }}
+
+      - name: Log in to container registry
+        if: steps.parse.outputs.matched == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ vars.CONTAINER_REGISTRY_SERVER }}
+          username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+          password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+
+      - name: Build and push
+        if: steps.parse.outputs.matched == 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: true
+          build-args: |
+            VITE_SITE_ID=${{ steps.parse.outputs.site }}
+          tags: |
+            ${{ vars.CONTAINER_REGISTRY_SERVER }}/${{ vars.CONTAINER_REGISTRY_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ steps.parse.outputs.site }}-${{ steps.parse.outputs.environment }}-${{ steps.parse.outputs.version }}
+            ${{ vars.CONTAINER_REGISTRY_SERVER }}/${{ vars.CONTAINER_REGISTRY_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ steps.parse.outputs.site }}-${{ steps.parse.outputs.environment }}-latest

--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -47,7 +47,7 @@ jobs:
           echo "matched=false" >> "$GITHUB_OUTPUT"
 
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "::error::Explicitly dispatched tag did not match - check vars.SITES/vars.ENVS are in sync with tag-image-release.yml's choice lists"
+            echo "::error::Explicitly dispatched tag did not match - check vars.SITES/vars.ENVS are in sync with create-deploy-release-via-tag.yml's choice lists"
             exit 1
           fi
 

--- a/.github/workflows/create-deploy-release-via-tag.yml
+++ b/.github/workflows/create-deploy-release-via-tag.yml
@@ -95,7 +95,7 @@ jobs:
       # build-push-image.yml's `push: tags` event (GitHub's anti-recursion rule).
       # We dispatch it explicitly instead.
       - name: Dispatch build workflow
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # ref: branch where the target workflow file exists

--- a/.github/workflows/create-deploy-release-via-tag.yml
+++ b/.github/workflows/create-deploy-release-via-tag.yml
@@ -69,17 +69,18 @@ jobs:
           SITE="${{ inputs.site }}"
           ENVIRONMENT="${{ inputs.environment }}"
           TODAY=$(date +%Y%m%d)
-          PATTERN="${SITE}-${ENVIRONMENT}-${TODAY}-[0-9]+"
+          PREFIX="${SITE}-${ENVIRONMENT}-${TODAY}"
+          PATTERN="${PREFIX}-[0-9]+"
 
           EXISTING=$(git ls-remote --tags origin | grep -Eo "refs/tags/${PATTERN}$" | sed 's#refs/tags/##' || true)
 
           NEXT=1
           if [[ -n "$EXISTING" ]]; then
-            MAX=$(echo "$EXISTING" | sed -E "s/^${SITE}-${ENVIRONMENT}-${TODAY}-//" | sort -n | tail -1)
+            MAX=$(echo "$EXISTING" | sed -E "s/^${PREFIX}-//" | sort -n | tail -1)
             NEXT=$((MAX + 1))
           fi
 
-          TAG="${SITE}-${ENVIRONMENT}-${TODAY}-${NEXT}"
+          TAG="${PREFIX}-${NEXT}"
           echo "Computed tag: $TAG"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/create-deploy-release-via-tag.yml
+++ b/.github/workflows/create-deploy-release-via-tag.yml
@@ -15,14 +15,14 @@ on:
         required: true
         type: choice
         options:
-          - ecospheres
-          - meteo-france
-          - logistique
           - accessibilite
-          - defis
-          - hackathon
-          - simplifions
           - culture
+          - defis
+          - ecospheres
+          - hackathon
+          - logistique
+          - meteo-france
+          - simplifions
       # Same restriction as above: kept in sync by hand with vars.ENVS.
       environment:
         description: 'Target environment'

--- a/.github/workflows/create-deploy-release-via-tag.yml
+++ b/.github/workflows/create-deploy-release-via-tag.yml
@@ -1,13 +1,10 @@
+# Creates a tag on the deploy branch of `site` for `env`
+# and calls the `build-push-image` workflow on that tag
+
 name: Deployment of a given site on a given env
 run-name: Trigger deploy ${{ inputs.site }}-${{ inputs.environment }}
 
 on:
-  # TEMP: registers this workflow_dispatch-only workflow with GitHub so it becomes
-  # dispatchable before this branch is merged (a workflow_dispatch trigger can't
-  # bootstrap its own discovery). Remove this `push:` block before merging.
-  push:
-    branches:
-      - feat/ci/build-image
   workflow_dispatch:
     inputs:
       # workflow_dispatch `options:` can't reference vars (no expressions allowed here),
@@ -48,7 +45,6 @@ permissions:
 
 jobs:
   tag:
-    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Determine ref

--- a/.github/workflows/create-deploy-release-via-tag.yml
+++ b/.github/workflows/create-deploy-release-via-tag.yml
@@ -2,6 +2,12 @@ name: Deployment of a given site on a given env
 run-name: Deploy ${{ inputs.site }} (${{ inputs.environment }})
 
 on:
+  # TEMP: registers this workflow_dispatch-only workflow with GitHub so it becomes
+  # dispatchable before this branch is merged (a workflow_dispatch trigger can't
+  # bootstrap its own discovery). Remove this `push:` block before merging.
+  push:
+    branches:
+      - feat/ci/build-image
   workflow_dispatch:
     inputs:
       # workflow_dispatch `options:` can't reference vars (no expressions allowed here),
@@ -42,6 +48,7 @@ permissions:
 
 jobs:
   tag:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Determine ref

--- a/.github/workflows/create-deploy-release-via-tag.yml
+++ b/.github/workflows/create-deploy-release-via-tag.yml
@@ -1,5 +1,5 @@
-name: Create image release tag
-run-name: Tag ${{ inputs.site }} (${{ inputs.environment }}) for image build
+name: Deployment of a given site on a given env
+run-name: Deploy ${{ inputs.site }} (${{ inputs.environment }})
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ on:
       # so this list must be kept in sync by hand with the vars.SITES repo variable
       # that build-push-image.yml's parse step reads.
       site:
-        description: 'Site to build an image for'
+        description: 'Site to deploy'
         required: true
         type: choice
         options:
@@ -22,15 +22,17 @@ on:
           - culture
       # Same restriction as above: kept in sync by hand with vars.ENVS.
       environment:
-        description: 'Environment whose branch/config to build from'
+        description: 'Target environment'
         required: true
         type: choice
         options:
           - demo
           - preprod
           - prod
+          # FIXME:
+          - test
       ref:
-        description: 'Git ref to tag and build (defaults to <site>-<environment>)'
+        description: 'Git ref (branch) to deploy (defaults to <site>-<environment>)'
         required: false
         type: string
 
@@ -49,6 +51,7 @@ jobs:
           if [[ -z "$REF" ]]; then
             REF="${{ inputs.site }}-${{ inputs.environment }}"
           fi
+          echo "Computed ref: $REF"
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
@@ -67,7 +70,7 @@ jobs:
 
           EXISTING=$(git ls-remote --tags origin | grep -Eo "refs/tags/${PATTERN}$" | sed 's#refs/tags/##' || true)
 
-          NEXT=0
+          NEXT=1
           if [[ -n "$EXISTING" ]]; then
             MAX=$(echo "$EXISTING" | sed -E "s/^${SITE}-${ENVIRONMENT}-${TODAY}-//" | sort -n | tail -1)
             NEXT=$((MAX + 1))
@@ -84,19 +87,15 @@ jobs:
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
 
-      # This push uses the default GITHUB_TOKEN, so it will NOT itself trigger
+      # The above push uses the default GITHUB_TOKEN, so it will NOT itself trigger
       # build-push-image.yml's `push: tags` event (GitHub's anti-recursion rule).
-      # We dispatch it explicitly instead, same mechanism as deploy-review-from-comment.yml.
-      #
-      # `ref` below selects which copy of the workflow *file* runs, not what gets built
-      # (build-push-image.yml checks out the tag itself) - it must be a ref where the
-      # file exists. Using github.ref_name (the ref this workflow was itself run from)
-      # rather than a hardcoded branch means it self-adjusts: 'main' once merged there,
-      # or the current feature branch when testing this workflow before merge.
+      # We dispatch it explicitly instead.
       - name: Dispatch build workflow
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # ref: branch where the target workflow file exists
+          # FIXME: maybe use hardcoded main
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,

--- a/.github/workflows/create-deploy-release-via-tag.yml
+++ b/.github/workflows/create-deploy-release-via-tag.yml
@@ -2,12 +2,6 @@ name: Deployment of a given site on a given env
 run-name: Deploy ${{ inputs.site }} (${{ inputs.environment }})
 
 on:
-  # TEMP: registers this workflow_dispatch-only workflow with GitHub so it becomes
-  # dispatchable before this branch is merged (a workflow_dispatch trigger can't
-  # bootstrap its own discovery). Remove this `push:` block before merging.
-  push:
-    branches:
-      - feat/ci/build-image
   workflow_dispatch:
     inputs:
       # workflow_dispatch `options:` can't reference vars (no expressions allowed here),
@@ -48,7 +42,6 @@ permissions:
 
 jobs:
   tag:
-    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Determine ref

--- a/.github/workflows/create-deploy-release-via-tag.yml
+++ b/.github/workflows/create-deploy-release-via-tag.yml
@@ -1,5 +1,5 @@
 name: Deployment of a given site on a given env
-run-name: Deploy ${{ inputs.site }} (${{ inputs.environment }})
+run-name: Trigger deploy ${{ inputs.site }}-${{ inputs.environment }}
 
 on:
   # TEMP: registers this workflow_dispatch-only workflow with GitHub so it becomes

--- a/.github/workflows/create-deploy-release-via-tag.yml
+++ b/.github/workflows/create-deploy-release-via-tag.yml
@@ -32,8 +32,6 @@ on:
           - demo
           - preprod
           - prod
-          # FIXME:
-          - test
       ref:
         description: 'Git ref (branch) to deploy (defaults to <site>-<environment>)'
         required: false
@@ -98,8 +96,8 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # ref: branch where the target workflow file exists
-          # FIXME: maybe use hardcoded main
+          # ref picks which build-push-image.yml definition runs, not the code it builds
+          # (that comes from the tag): dispatch from main, or from your branch to test CI
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,

--- a/.github/workflows/deploy-review-from-comment.yml
+++ b/.github/workflows/deploy-review-from-comment.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Get PR branch
         if: steps.parse.outputs.should_deploy == 'true'
         id: get_pr
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -65,7 +65,7 @@ jobs:
     if: needs.check_comment.outputs.should_deploy == 'true'
     steps:
       - name: Trigger review app workflow
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/tag-image-release.yml
+++ b/.github/workflows/tag-image-release.yml
@@ -86,7 +86,9 @@ jobs:
       #
       # `ref` below selects which copy of the workflow *file* runs, not what gets built
       # (build-push-image.yml checks out the tag itself) - it must be a ref where the
-      # file exists, so this stays 'main' rather than the site/env deploy branch.
+      # file exists. Using github.ref_name (the ref this workflow was itself run from)
+      # rather than a hardcoded branch means it self-adjusts: 'main' once merged there,
+      # or the current feature branch when testing this workflow before merge.
       - name: Dispatch build workflow
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
@@ -96,7 +98,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'build-push-image.yml',
-              ref: 'main',
+              ref: '${{ github.ref_name }}',
               inputs: {
                 tag: '${{ steps.version.outputs.tag }}'
               }

--- a/.github/workflows/tag-image-release.yml
+++ b/.github/workflows/tag-image-release.yml
@@ -1,0 +1,103 @@
+name: Create image release tag
+run-name: Tag ${{ inputs.site }} (${{ inputs.environment }}) for image build
+
+on:
+  workflow_dispatch:
+    inputs:
+      site:
+        description: 'Site to build an image for'
+        required: true
+        type: choice
+        options:
+          - ecospheres
+          - meteo-france
+          - logistique
+          - accessibilite
+          - defis
+          - hackathon
+          - simplifions
+          - culture
+      environment:
+        description: 'Environment whose branch/config to build from'
+        required: true
+        type: choice
+        options:
+          - demo
+          - preprod
+          - prod
+      ref:
+        description: 'Git ref to tag and build (defaults to <site>-<environment>)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine ref
+        id: ref
+        run: |
+          REF="${{ inputs.ref }}"
+          if [[ -z "$REF" ]]; then
+            REF="${{ inputs.site }}-${{ inputs.environment }}"
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+
+      - name: Compute next tag
+        id: version
+        shell: bash
+        run: |
+          SITE="${{ inputs.site }}"
+          ENVIRONMENT="${{ inputs.environment }}"
+          TODAY=$(date +%Y%m%d)
+          PATTERN="${SITE}-${ENVIRONMENT}-${TODAY}-[0-9]+"
+
+          EXISTING=$(git ls-remote --tags origin | grep -Eo "refs/tags/${PATTERN}$" | sed 's#refs/tags/##' || true)
+
+          NEXT=0
+          if [[ -n "$EXISTING" ]]; then
+            MAX=$(echo "$EXISTING" | sed -E "s/^${SITE}-${ENVIRONMENT}-${TODAY}-//" | sort -n | tail -1)
+            NEXT=$((MAX + 1))
+          fi
+
+          TAG="${SITE}-${ENVIRONMENT}-${TODAY}-${NEXT}"
+          echo "Computed tag: $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      # This push uses the default GITHUB_TOKEN, so it will NOT itself trigger
+      # build-push-image.yml's `push: tags` event (GitHub's anti-recursion rule).
+      # We dispatch it explicitly instead, same mechanism as deploy-review-from-comment.yml.
+      #
+      # `ref` below selects which copy of the workflow *file* runs, not what gets built
+      # (build-push-image.yml checks out the tag itself) - it must be a ref where the
+      # file exists, so this stays 'main' rather than the site/env deploy branch.
+      - name: Dispatch build workflow
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build-push-image.yml',
+              ref: 'main',
+              inputs: {
+                tag: '${{ steps.version.outputs.tag }}'
+              }
+            });

--- a/.github/workflows/tag-image-release.yml
+++ b/.github/workflows/tag-image-release.yml
@@ -4,6 +4,9 @@ run-name: Tag ${{ inputs.site }} (${{ inputs.environment }}) for image build
 on:
   workflow_dispatch:
     inputs:
+      # workflow_dispatch `options:` can't reference vars (no expressions allowed here),
+      # so this list must be kept in sync by hand with the vars.SITES repo variable
+      # that build-push-image.yml's parse step reads.
       site:
         description: 'Site to build an image for'
         required: true
@@ -17,6 +20,7 @@ on:
           - hackathon
           - simplifions
           - culture
+      # Same restriction as above: kept in sync by hand with vars.ENVS.
       environment:
         description: 'Environment whose branch/config to build from'
         required: true


### PR DESCRIPTION
This introduces a new paradigm for future deployments: a normalised tag triggers a docker build and push.

Tag is `{site}-{env}-{YYYYMMDD}-{N}` like what the deploy script is already doing.

Two workflows:
- `build-push-image`: on a given tag (auto-triggered or passed via arg), build and push the docker image `{site}-{env}` for the given site with docker tags `{YYYYMMDD}-{N}` and `latest`.
- `create-deploy-release-via-tag`: meant to be used through GitHub UI, like `create-deploy-release`. Computes and creates the normalised tag, and calls `build-push-image` explicitly on that tag (GitHub won't trigger it automatically in that case).

The "real" deploy step still needs to be plugged-in. The new deploy infra is capable of auto-pulling `latest`, this should work right now. `deploy.sh` will need to be modified for the new workflow, either by relying on the latest trick or by triggering a deploy explicitly. This can be done later.

Re registry, the variable names and workflow are taken from https://github.com/datagouv/schema.data.gouv.fr/blob/main/.github/workflows/build-release.yml.

Actions view of a full chain:

<img width="826" height="156" alt="Capture d’écran 2026-08-21 à 12 19 57" src="https://github.com/user-attachments/assets/222c86e0-251c-4b41-8edf-d56765cbdc0b" />

Command to test the UI workflow while not merged on main (tags `ecospheres-demo` branch and uses the `test` env):

```
gh workflow run create-deploy-release-via-tag.yml --repo opendatateam/udata-front-kit --ref feat/ci/build-image -f site=ecospheres -f environment=test -f ref=ecospheres-demo
```

Example build: https://github.com/opendatateam/udata-front-kit/actions/runs/32471960311