### PR TITLE
chore(docs): fix typos and dead link in docs and comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ TL;DR:
 - Code and code documentation are in [English (BR)](https://en.wikipedia.org/wiki/English_as_a_lingua_franca).
 - Code documentation is in the [JSDoc](https://jsdoc.app/) format.
 - Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
-- Code styling is progamatically enforced and follows [Standard](https://standardjs.com/).
+- Code styling is programmatically enforced and follows [Standard](https://standardjs.com/).
 - Testing is done with [Vutest](https://vutest.dev) and [Cypress](https://www.cypress.io/).
 - Pull requests, reviews, and merging, follow [GitHub Flow](https://guides.github.com/introduction/flow/).
 - Change advertising follows [SemVer](http://semver.org/).

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ On utilise la librairie [mimicry-js](https://github.com/Stivooo/mimicry-js) comm
 pnpm run lint
 ```
 
-#### Typage via [TSc](https://www.typescriptlang.org/docs/handbook/compiler-options.html/)
+#### Typage via [tsc](https://www.typescriptlang.org/docs/handbook/compiler-options.html)
 
 ```sh
 pnpm run hint
@@ -334,9 +334,9 @@ Pour des raisons de sécurité, le déploiement est effectué par un dépôt pri
   - On commence par créer une Pull Request depuis `main` vers `{site}-preprod` ;
   - Une fois cette PR validée, on déploie soit via un message de commit normé soit via l'UI GitHub Actions (cf plus haut).
 - La branche `{site}-prod` est utilisée pour les déploiements sur <https://{site}.data.gouv.fr>.
-  - Même processus que pour la preprod, mais en créant une PR depuis `{site}-preprod` vers `{site})-prod`.
+  - Même processus que pour la preprod, mais en créant une PR depuis `{site}-preprod` vers `{site}-prod`.
 
-NB : dans certains cas, il possible de créer et de déployer des Pull Requests depuis une _feature branch_ vers `{site}-(pre)prod`, par exemple pour définir une configuration spécifique à l'environnement de preprod ou de prod.
+NB : dans certains cas, il est possible de créer et de déployer des Pull Requests depuis une _feature branch_ vers `{site}-(pre)prod`, par exemple pour définir une configuration spécifique à l'environnement de preprod ou de prod.
 
 ## 📚 Bibliothèques et plugins utilisés
 

--- a/configs/ecospheres/config.yaml
+++ b/configs/ecospheres/config.yaml
@@ -233,7 +233,7 @@ definitions: &definitions
 #     universe_query: {dict}          # used to define a "universe" on a given {page_id}, through query args
 #     filter_prefix: {string}         # prefix/namespace for filter value (eg ?tag={filter_prefix}-{value})
 #     title: {string}                 # title for the list page
-#     breadcrumb_title: {string}      # title in breadcrumb (optionnal, falls back to title)
+#     breadcrumb_title: {string}      # title in breadcrumb (optional, falls back to title)
 #     default_sort: {string}          # default sort option. Options are described in the List endpoints of Topics, Datasets and Dataservices, in the "sort" parameter.
 #     labels:                         # how to call the object that is displayed by the page
 #       singular: {string}            # singular name for the object
@@ -242,7 +242,7 @@ definitions: &definitions
 #     search:
 #       input: {string}               # label displayed above the search input
 #       placeholder: {string?|null?}  # input placeholder (null = no placeholder, omit = data.gouv.fr default)
-#     banner:                         # banner for the list page (optionnal)
+#     banner:                         # banner for the list page (optional)
 #       title: {string}               # title for the banner
 #       content: {string}             # content for the banner
 #     resources_tabs:                 # resources tabs at the bottom of a detail page

--- a/cypress/e2e/custom/ecospheres/topics/support.ts
+++ b/cypress/e2e/custom/ecospheres/topics/support.ts
@@ -181,7 +181,7 @@ export function createTestFactors(
 
 // Create test topic with proper setup
 export function createTestTopic(overrides = {}): Topic {
-  // user owned Topic to faciliate permission tests
+  // user owned Topic to facilitate permission tests
   const owner = UserFactory.one({
     overrides: {
       id: 'test-user-id',

--- a/src/model/topic.ts
+++ b/src/model/topic.ts
@@ -67,7 +67,7 @@ class ResolvedGenericElement implements GenericElement {
   }
 
   unresolved<T extends GenericElement = GenericElement>(): T {
-    // explicitely pick the required attributes for GenericElement
+    // explicitly pick the required attributes for GenericElement
     // const {removeMe, ...element} = this would not trigger type error if removeMe is not enough
     const { id, title, description, tags, extras, element } = this
     return { id, title, description, tags, extras, element } as T

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -29,7 +29,7 @@ export default class AuthService {
   }
 
   /**
-   * Retrive an oauth token from a verification code
+   * Retrieve an oauth token from a verification code
    */
   async retrieveToken(code, state) {
     const storedState = localStorage.getItem('pkceState')

--- a/src/services/api/DatagouvfrAPI.ts
+++ b/src/services/api/DatagouvfrAPI.ts
@@ -45,7 +45,7 @@ export default class DatagouvfrAPI {
   }
 
   /**
-   * Make a `method` request to URL and optionnaly attach a toaster to the error
+   * Make a `method` request to URL and optionally attach a toaster to the error
    */
   async request(requestConfig: RequestConfig): Promise<AxiosResponseData> {
     const response = await axios(requestConfig).catch((error: AxiosError) => {

--- a/src/store/TopicStore.ts
+++ b/src/store/TopicStore.ts
@@ -77,7 +77,7 @@ export const useTopicStore = defineStore('topic', {
      */
     async loadTopicsForUniverse(pageKey?: string): Promise<Topic[]> {
       const mergedApiParams = useUniverseQuery(pageKey || 'topics', {})
-      // make sure our user has registerd its permissions
+      // make sure our user has registered its permissions
       await useUserStore().waitForStoreInit()
       let response = await topicsAPI.list({
         params: {

--- a/src/utils/topic.ts
+++ b/src/utils/topic.ts
@@ -61,7 +61,7 @@ export const getSlugFromUri = (
 }
 
 /**
- * Build a fonctionnal Topic from clone source data
+ * Build a functional Topic from clone source data
  */
 export const cloneTopic = async (
   topic: Topic,

--- a/src/views/topics/TopicFormView.vue
+++ b/src/views/topics/TopicFormView.vue
@@ -78,7 +78,7 @@ const errorMsg = ref('')
 
 const isReadyForForm = computed(() => {
   const extras = topic.value?.extras?.[useSiteId()]
-  // condition for form mouting based on topic data load: edit || create raw || create cloned
+  // condition for form mounting based on topic data load: edit || create raw || create cloned
   return (
     topic.value.id ||
     (props.isCreate && !routeQuery.clone) ||


### PR DESCRIPTION
## What changed
- Fixed 11 typos across docs, code comments, a config comment, and a Cypress comment.
- Fixed 1 dead link in the README (TypeScript compiler-options URL 404'd due to a trailing slash).

## Why
Self-found gap during a docs/comment cleanup pass. All fixes are plain misspellings or a broken link — no meaning, wording, or behavior changes.

## How to verify
```sh
git fetch https://github.com/olitreadwell/udata-front-kit.git fix/docs-and-comment-typos
git checkout FETCH_HEAD
pnpm run format:check
pnpm run lint
pnpm run type-check
```
