### PR TITLE
feat: add object counts on tabs

### DIFF
--- a/cypress/e2e/custom/ecospheres/dataservices/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/dataservices/detail.cy.ts
@@ -238,7 +238,6 @@ describe('Dataservices (API) - Detail Page', () => {
 
   describe('Tab counts', () => {
     it('should show the linked datasets count on the Données tab and the discussions count on the Discussions tab', () => {
-      // distinct, non-equal values so a field mix-up can't pass by coincidence
       const countsDataservice = createMockedDataservice(
         {
           metrics: {

--- a/cypress/e2e/custom/ecospheres/dataservices/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/dataservices/detail.cy.ts
@@ -236,6 +236,32 @@ describe('Dataservices (API) - Detail Page', () => {
     })
   })
 
+  describe('Tab counts', () => {
+    it('should show the linked datasets count on the Données tab and the discussions count on the Discussions tab', () => {
+      // distinct, non-equal values so a field mix-up can't pass by coincidence
+      const countsDataservice = createMockedDataservice(
+        {
+          metrics: {
+            discussions: 6,
+            discussions_open: 0,
+            followers: 0,
+            reuses: 0,
+            views: 0
+          }
+        },
+        datasetFactory.many(3)
+      )
+
+      cy.visit(`/dataservices/${countsDataservice.id}`)
+      cy.wait(`@get_dataservices_${countsDataservice.id}`)
+      cy.wait('@getDataserviceDatasets')
+
+      cy.contains('button', 'Données (3)').should('be.visible')
+      cy.contains('button', 'Discussions (6)').should('be.visible')
+      cy.contains('button', 'Informations').find('sup').should('not.exist')
+    })
+  })
+
   describe('Access Type And Availability Variations', () => {
     it('should display "Ouvert avec compte" badge for open_with_account access', () => {
       const restrictedDataservice = createMockedDataservice({

--- a/cypress/e2e/custom/ecospheres/datasets/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/datasets/detail.cy.ts
@@ -1,19 +1,12 @@
-import type { DatasetV2 } from '@datagouv/components-next'
-import { dataserviceFactory } from 'cypress/support/factories/dataservices_factory'
 import { datasetFactory } from 'cypress/support/factories/datasets_factory'
 import { resourceFactory } from 'cypress/support/factories/resources_factory'
-import { reuseFactory } from 'cypress/support/factories/reuses_factory'
 
 describe('Dataset Page - Tab counts', () => {
-  let testDataset: DatasetV2
-
-  beforeEach(() => {
+  it('should show distinct counts on each tab', () => {
     cy.mockMatomo()
     cy.mockStaticDatagouv()
 
-    // distinct, non-zero values so a field mix-up (e.g. summing the wrong
-    // metric, or reading a list length instead of resources.total) fails loudly
-    testDataset = datasetFactory.one({
+    const testDataset = datasetFactory.one({
       overrides: {
         metrics: {
           discussions: 7,
@@ -27,32 +20,14 @@ describe('Dataset Page - Tab counts', () => {
       }
     })
 
-    cy.mockDatasetAndRelatedObjects(
-      testDataset,
-      resourceFactory.many(4),
-      // list content is intentionally smaller than metrics.dataservices/reuses
-      // above, so the tab count can't accidentally match a list length instead
-      dataserviceFactory.many(1),
-      reuseFactory.many(1)
-    )
+    cy.mockDatasetAndRelatedObjects(testDataset, resourceFactory.many(4))
 
     cy.visit(`/datasets/${testDataset.id}`)
     cy.wait(`@get_datasets_${testDataset.id}`)
-  })
 
-  it('should show the resources count on the Fichiers tab', () => {
     cy.contains('button', 'Fichiers (4)').should('be.visible')
-  })
-
-  it('should show the combined reuses + dataservices count on the Réutilisations et API tab', () => {
     cy.contains('button', 'Réutilisations et API (5)').should('be.visible')
-  })
-
-  it('should show the discussions count on the Discussions tab', () => {
     cy.contains('button', 'Discussions (7)').should('be.visible')
-  })
-
-  it('should not show a count on the Informations tab', () => {
     cy.contains('button', 'Informations').find('sup').should('not.exist')
   })
 })

--- a/cypress/e2e/custom/ecospheres/datasets/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/datasets/detail.cy.ts
@@ -1,0 +1,58 @@
+import type { DatasetV2 } from '@datagouv/components-next'
+import { dataserviceFactory } from 'cypress/support/factories/dataservices_factory'
+import { datasetFactory } from 'cypress/support/factories/datasets_factory'
+import { resourceFactory } from 'cypress/support/factories/resources_factory'
+import { reuseFactory } from 'cypress/support/factories/reuses_factory'
+
+describe('Dataset Page - Tab counts', () => {
+  let testDataset: DatasetV2
+
+  beforeEach(() => {
+    cy.mockMatomo()
+    cy.mockStaticDatagouv()
+
+    // distinct, non-zero values so a field mix-up (e.g. summing the wrong
+    // metric, or reading a list length instead of resources.total) fails loudly
+    testDataset = datasetFactory.one({
+      overrides: {
+        metrics: {
+          discussions: 7,
+          discussions_open: 0,
+          reuses: 3,
+          dataservices: 2,
+          followers: 0,
+          views: 0,
+          resources_downloads: 0
+        }
+      }
+    })
+
+    cy.mockDatasetAndRelatedObjects(
+      testDataset,
+      resourceFactory.many(4),
+      // list content is intentionally smaller than metrics.dataservices/reuses
+      // above, so the tab count can't accidentally match a list length instead
+      dataserviceFactory.many(1),
+      reuseFactory.many(1)
+    )
+
+    cy.visit(`/datasets/${testDataset.id}`)
+    cy.wait(`@get_datasets_${testDataset.id}`)
+  })
+
+  it('should show the resources count on the Fichiers tab', () => {
+    cy.contains('button', 'Fichiers (4)').should('be.visible')
+  })
+
+  it('should show the combined reuses + dataservices count on the Réutilisations et API tab', () => {
+    cy.contains('button', 'Réutilisations et API (5)').should('be.visible')
+  })
+
+  it('should show the discussions count on the Discussions tab', () => {
+    cy.contains('button', 'Discussions (7)').should('be.visible')
+  })
+
+  it('should not show a count on the Informations tab', () => {
+    cy.contains('button', 'Informations').find('sup').should('not.exist')
+  })
+})

--- a/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
@@ -126,8 +126,6 @@ describe('Indicator Detail View', () => {
 
   describe('Tab counts', () => {
     it('should show distinct counts on each tab', () => {
-      // distinct, non-zero, non-equal values so a field mix-up (wrong metric,
-      // or a list length used instead of the sum) can't pass by coincidence
       const countsIndicator = createIndicator(
         {
           metrics: {
@@ -160,14 +158,7 @@ describe('Indicator Detail View', () => {
           enable_visualization: false
         }
       )
-      cy.mockDatasetAndRelatedObjects(
-        countsIndicator,
-        resourceFactory.many(5),
-        // list content intentionally smaller than metrics above, so the
-        // count can't accidentally match a list length instead
-        dataserviceFactory.many<Dataservice>(1),
-        reuseFactory.many<Reuse>(1)
-      )
+      cy.mockDatasetAndRelatedObjects(countsIndicator, resourceFactory.many(5))
 
       cy.visit(`/indicators/${countsIndicator.id}`)
 

--- a/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/indicators/detail.cy.ts
@@ -1,6 +1,7 @@
 import type { Indicator } from '@/custom/ecospheres/model/indicator'
 import type { Dataservice, Reuse } from '@datagouv/components-next'
 import { dataserviceFactory } from 'cypress/support/factories/dataservices_factory'
+import { resourceFactory } from 'cypress/support/factories/resources_factory'
 import { reuseFactory } from 'cypress/support/factories/reuses_factory'
 import { createIndicator } from './support'
 
@@ -120,6 +121,61 @@ describe('Indicator Detail View', () => {
 
     it('should display source URL', () => {
       cy.contains('https://example.com/source1').should('be.visible')
+    })
+  })
+
+  describe('Tab counts', () => {
+    it('should show distinct counts on each tab', () => {
+      // distinct, non-zero, non-equal values so a field mix-up (wrong metric,
+      // or a list length used instead of the sum) can't pass by coincidence
+      const countsIndicator = createIndicator(
+        {
+          metrics: {
+            discussions: 9,
+            discussions_open: 0,
+            reuses: 3,
+            dataservices: 4,
+            followers: 0,
+            views: 0,
+            resources_downloads: 0
+          }
+        },
+        {
+          sources: [
+            {
+              nom: 'Source 1',
+              url: 'https://example.com/source1',
+              description: 'Description de la source 1',
+              producteur: 'Producteur 1',
+              distributeur: 'Distributeur 1'
+            },
+            {
+              nom: 'Source 2',
+              url: 'https://example.com/source2',
+              description: 'Description de la source 2',
+              producteur: 'Producteur 2',
+              distributeur: 'Distributeur 2'
+            }
+          ],
+          enable_visualization: false
+        }
+      )
+      cy.mockDatasetAndRelatedObjects(
+        countsIndicator,
+        resourceFactory.many(5),
+        // list content intentionally smaller than metrics above, so the
+        // count can't accidentally match a list length instead
+        dataserviceFactory.many<Dataservice>(1),
+        reuseFactory.many<Reuse>(1)
+      )
+
+      cy.visit(`/indicators/${countsIndicator.id}`)
+
+      cy.contains('button', 'Fichiers (5)').should('be.visible')
+      cy.contains('button', 'Sources (2)').should('be.visible')
+      cy.contains('button', 'Réutilisations et API (7)').should('be.visible')
+      cy.contains('button', 'Discussions (9)').should('be.visible')
+      cy.contains('button', 'Informations').find('sup').should('not.exist')
     })
   })
 

--- a/cypress/e2e/custom/ecospheres/topics/activity.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/activity.cy.ts
@@ -48,10 +48,10 @@ describe('Topic Activity List', () => {
         activityFactory.one({ traits: ['topic_updated'] })
       ]
 
-      const { testTopic } = setupTopicWithExistingFactors(
-        testFactors,
+      const { testTopic } = setupTopicWithExistingFactors({
+        factors: testFactors,
         activities
-      )
+      })
 
       visitTopic(testTopic.slug)
       cy.wait('@getElementsDataset')
@@ -84,10 +84,10 @@ describe('Topic Activity List', () => {
         activityFactory.one({ traits: ['topic_updated'] })
       ]
 
-      const { testTopic } = setupTopicWithExistingFactors(
-        testFactors,
+      const { testTopic } = setupTopicWithExistingFactors({
+        factors: testFactors,
         activities
-      )
+      })
 
       visitTopic(testTopic.slug)
       cy.wait('@getElementsDataset')
@@ -111,7 +111,7 @@ describe('Topic Activity List', () => {
         activityFactory.one({ traits: ['topic_updated'] })
       ]
 
-      const { testTopic } = setupTopicWithExistingFactors(undefined, activities)
+      const { testTopic } = setupTopicWithExistingFactors({ activities })
 
       visitTopic(testTopic.slug)
       cy.wait('@getElementsDataset')
@@ -134,7 +134,7 @@ describe('Topic Activity List', () => {
         })
       ]
 
-      const { testTopic } = setupTopicWithExistingFactors(undefined, activities)
+      const { testTopic } = setupTopicWithExistingFactors({ activities })
 
       visitTopic(testTopic.slug)
       cy.wait('@getElementsDataset')
@@ -161,10 +161,10 @@ describe('Topic Activity List', () => {
         })
       ]
 
-      const { testTopic } = setupTopicWithExistingFactors(
-        testFactors,
+      const { testTopic } = setupTopicWithExistingFactors({
+        factors: testFactors,
         activities
-      )
+      })
 
       visitTopic(testTopic.slug)
       cy.wait('@getElementsDataset')
@@ -202,10 +202,10 @@ describe('Topic Activity List', () => {
         })
       ]
 
-      const { testTopic } = setupTopicWithExistingFactors(
-        testFactors,
+      const { testTopic } = setupTopicWithExistingFactors({
+        factors: testFactors,
         activities
-      )
+      })
 
       visitTopic(testTopic.slug)
       cy.wait('@getElementsDataset')
@@ -279,7 +279,9 @@ describe('Topic Activity List', () => {
 
     it('should update activity list immediately after modifying a factor', () => {
       const testFactors = createTestFactors(1)
-      const { testTopic } = setupTopicWithExistingFactors(testFactors)
+      const { testTopic } = setupTopicWithExistingFactors({
+        factors: testFactors
+      })
       visitTopic(testTopic.slug)
       cy.wait('@getElementsDataset')
 
@@ -329,7 +331,9 @@ describe('Topic Activity List', () => {
 
     it('should update activity list immediately after deleting a factor', () => {
       const testFactors = createTestFactors(1)
-      const { testTopic } = setupTopicWithExistingFactors(testFactors)
+      const { testTopic } = setupTopicWithExistingFactors({
+        factors: testFactors
+      })
       visitTopic(testTopic.slug)
       cy.wait('@getElementsDataset')
 

--- a/cypress/e2e/custom/ecospheres/topics/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/detail.cy.ts
@@ -2,9 +2,7 @@ import type { Discussion } from '@/model/discussion'
 import { UserFactory } from 'cypress/support/factories/users_factory'
 import {
   createTestFactors,
-  createTestTopicWithElements,
-  mockTopicAndRelatedObjects,
-  mockTopicElementsByClass,
+  setupTopicWithExistingFactors,
   visitTopic
 } from './support'
 
@@ -25,22 +23,18 @@ function buildDiscussions(count: number, topicId: string): Discussion[] {
 
 describe('Topic Detail View - Tab counts', () => {
   it('should show distinct counts on the Données and Discussions tabs', () => {
-    cy.mockMatomo()
-    cy.mockStaticDatagouv()
-    cy.simulateDisconnectedUser()
-
-    const testFactors = createTestFactors(3)
-    const testTopic = createTestTopicWithElements(testFactors)
-
-    mockTopicAndRelatedObjects(testTopic, { factors: testFactors })
-    mockTopicElementsByClass(testTopic.id, testFactors, [], [])
-    // override mockTopicAndRelatedObjects' default empty discussions mock
+    const { testTopic, testFactors } = setupTopicWithExistingFactors(
+      createTestFactors(3)
+    )
+    // override setupTopicWithExistingFactors' default empty discussions mock
     cy.mockDatagouvObjectList('discussions', buildDiscussions(5, testTopic.id))
 
     visitTopic(testTopic.slug)
     cy.wait('@getElementsDataset')
 
-    cy.contains('button', 'Données (3)').should('be.visible')
+    cy.contains('button', `Données (${testFactors.length})`).should(
+      'be.visible'
+    )
     cy.contains('button', 'Discussions (5)').should('be.visible')
   })
 })

--- a/cypress/e2e/custom/ecospheres/topics/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/detail.cy.ts
@@ -1,0 +1,47 @@
+import type { Discussion } from '@/model/discussion'
+import { UserFactory } from 'cypress/support/factories/users_factory'
+import {
+  createTestFactors,
+  createTestTopicWithElements,
+  mockTopicAndRelatedObjects,
+  mockTopicElementsByClass,
+  visitTopic
+} from './support'
+
+function buildDiscussions(count: number, topicId: string): Discussion[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `discussion-${i}`,
+    title: `Discussion ${i}`,
+    subject: { class: 'Topic' as const, id: topicId },
+    discussion: [
+      {
+        content: 'Sample comment',
+        posted_by: UserFactory.one(),
+        posted_on: new Date().toISOString()
+      }
+    ]
+  }))
+}
+
+describe('Topic Detail View - Tab counts', () => {
+  it('should show distinct counts on the Données and Discussions tabs', () => {
+    cy.mockMatomo()
+    cy.mockStaticDatagouv()
+    cy.simulateDisconnectedUser()
+
+    // distinct, non-equal values so a field mix-up can't pass by coincidence
+    const testFactors = createTestFactors(3)
+    const testTopic = createTestTopicWithElements(testFactors)
+
+    mockTopicAndRelatedObjects(testTopic, { factors: testFactors })
+    mockTopicElementsByClass(testTopic.id, testFactors, [], [])
+    // override mockTopicAndRelatedObjects' default empty discussions mock
+    cy.mockDatagouvObjectList('discussions', buildDiscussions(5, testTopic.id))
+
+    visitTopic(testTopic.slug)
+    cy.wait('@getElementsDataset')
+
+    cy.contains('button', 'Données (3)').should('be.visible')
+    cy.contains('button', 'Discussions (5)').should('be.visible')
+  })
+})

--- a/cypress/e2e/custom/ecospheres/topics/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/detail.cy.ts
@@ -29,7 +29,6 @@ describe('Topic Detail View - Tab counts', () => {
     cy.mockStaticDatagouv()
     cy.simulateDisconnectedUser()
 
-    // distinct, non-equal values so a field mix-up can't pass by coincidence
     const testFactors = createTestFactors(3)
     const testTopic = createTestTopicWithElements(testFactors)
 

--- a/cypress/e2e/custom/ecospheres/topics/detail.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/detail.cy.ts
@@ -1,33 +1,16 @@
-import type { Discussion } from '@/model/discussion'
-import { UserFactory } from 'cypress/support/factories/users_factory'
+import { discussionFactory } from 'cypress/support/factories/discussions_factory'
 import {
   createTestFactors,
   setupTopicWithExistingFactors,
   visitTopic
 } from './support'
 
-function buildDiscussions(count: number, topicId: string): Discussion[] {
-  return Array.from({ length: count }, (_, i) => ({
-    id: `discussion-${i}`,
-    title: `Discussion ${i}`,
-    subject: { class: 'Topic' as const, id: topicId },
-    discussion: [
-      {
-        content: 'Sample comment',
-        posted_by: UserFactory.one(),
-        posted_on: new Date().toISOString()
-      }
-    ]
-  }))
-}
-
 describe('Topic Detail View - Tab counts', () => {
   it('should show distinct counts on the Données and Discussions tabs', () => {
-    const { testTopic, testFactors } = setupTopicWithExistingFactors(
-      createTestFactors(3)
-    )
-    // override setupTopicWithExistingFactors' default empty discussions mock
-    cy.mockDatagouvObjectList('discussions', buildDiscussions(5, testTopic.id))
+    const { testTopic, testFactors } = setupTopicWithExistingFactors({
+      factors: createTestFactors(3),
+      discussions: discussionFactory.many(5)
+    })
 
     visitTopic(testTopic.slug)
     cy.wait('@getElementsDataset')

--- a/cypress/e2e/custom/ecospheres/topics/elements/deeplink.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/elements/deeplink.cy.ts
@@ -104,10 +104,9 @@ describe('Topic Elements - Deep Linking', () => {
       const ungroupedFactors = factorFactory.many(2, {
         traits: ['missing_no_group']
       })
-      const { testTopic } = setupTopicWithExistingFactors([
-        ...ungroupedFactors,
-        ...groupedFactors
-      ])
+      const { testTopic } = setupTopicWithExistingFactors({
+        factors: [...ungroupedFactors, ...groupedFactors]
+      })
       const targetFactor = ungroupedFactors[0]
 
       if (!targetFactor) throw Error('Could not find any ungrouped factor')

--- a/cypress/e2e/custom/ecospheres/topics/elements/list.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/elements/list.cy.ts
@@ -71,8 +71,9 @@ describe('Topic Elements - Factor List Display', () => {
       const ungroupedFactors = factorFactory.many(2, {
         traits: ['missing_no_group']
       })
-      const { testTopic, testFactors } =
-        setupTopicWithExistingFactors(ungroupedFactors)
+      const { testTopic, testFactors } = setupTopicWithExistingFactors({
+        factors: ungroupedFactors
+      })
       visitTopic(testTopic.slug)
 
       cy.wait('@getElementsNone')

--- a/cypress/e2e/custom/ecospheres/topics/elements/list.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/elements/list.cy.ts
@@ -54,22 +54,6 @@ describe('Topic Elements - Factor List Display', () => {
       cy.get('.test__add_dataset_btn').should('be.visible')
     })
 
-    it('should show the factors count on the Données tab', () => {
-      cy.contains('button', `Données (${testFactors.length})`).should(
-        'be.visible'
-      )
-    })
-
-    it('should show a zero count on the Données tab when the topic has no elements', () => {
-      const { testTopic: emptyTopic } = setupEmptyTopic()
-      visitTopic(emptyTopic.slug)
-
-      // this one will always fired and is easy to catch, signals that the page is loaded
-      cy.wait('@getElementsReuse')
-
-      cy.contains('button', 'Données (0)').should('be.visible')
-    })
-
     it('should handle empty factors list', () => {
       const { testTopic: emptyTopic } = setupEmptyTopic()
       visitTopic(emptyTopic.slug)

--- a/cypress/e2e/custom/ecospheres/topics/elements/list.cy.ts
+++ b/cypress/e2e/custom/ecospheres/topics/elements/list.cy.ts
@@ -54,6 +54,22 @@ describe('Topic Elements - Factor List Display', () => {
       cy.get('.test__add_dataset_btn').should('be.visible')
     })
 
+    it('should show the factors count on the Données tab', () => {
+      cy.contains('button', `Données (${testFactors.length})`).should(
+        'be.visible'
+      )
+    })
+
+    it('should show a zero count on the Données tab when the topic has no elements', () => {
+      const { testTopic: emptyTopic } = setupEmptyTopic()
+      visitTopic(emptyTopic.slug)
+
+      // this one will always fired and is easy to catch, signals that the page is loaded
+      cy.wait('@getElementsReuse')
+
+      cy.contains('button', 'Données (0)').should('be.visible')
+    })
+
     it('should handle empty factors list', () => {
       const { testTopic: emptyTopic } = setupEmptyTopic()
       visitTopic(emptyTopic.slug)

--- a/cypress/e2e/custom/ecospheres/topics/support.ts
+++ b/cypress/e2e/custom/ecospheres/topics/support.ts
@@ -7,6 +7,7 @@ import type {
 } from '@datagouv/components-next'
 
 import type { Activity } from '@/model/activity'
+import type { Discussion } from '@/model/discussion'
 import type { Resource } from '@/model/resource'
 import type { Factor, SiteId, Topic } from '@/model/topic'
 import { Availability } from '@/model/topic'
@@ -280,6 +281,8 @@ export interface MockTopicOptions {
   referencedDataservices?: Dataservice[]
   // Activity history for the topic
   activities?: Activity[]
+  // Discussions on the topic
+  discussions?: Discussion[]
   // Dataset resources mapped by dataset ID
   datasetResources?: Record<string, Resource[]>
   /** Custom datasets mapped by dataset ID (overrides auto-generated ones) */
@@ -298,6 +301,7 @@ export function mockTopicAndRelatedObjects(
     referencedTopics = [],
     referencedDataservices = [],
     activities = [],
+    discussions = [],
     datasetResources = {},
     datasets = {}
   } = options
@@ -343,7 +347,7 @@ export function mockTopicAndRelatedObjects(
       }
     ).as(`getDataserviceDatasets_${refDataservice.id}`)
   })
-  cy.mockDatagouvObjectList('discussions')
+  cy.mockDatagouvObjectList('discussions', discussions)
   cy.mockDatagouvObjectList('reuses')
   cy.mockDatagouvObjectList('activity', activities)
 
@@ -360,16 +364,25 @@ export function expandDisclosureGroup(groupName = 'Test Group') {
 }
 
 // Combined setup for tests with existing factors
-export function setupTopicWithExistingFactors(
-  factors?: Factor[],
-  activities: Activity[] = []
-) {
+export function setupTopicWithExistingFactors({
+  factors,
+  activities = [],
+  discussions = []
+}: {
+  factors?: Factor[]
+  activities?: Activity[]
+  discussions?: Discussion[]
+} = {}) {
   setupElementTest()
 
   const testFactors = factors || createTestFactors(2)
   const testTopic = createTestTopicWithElements(testFactors)
 
-  mockTopicAndRelatedObjects(testTopic, { factors: testFactors, activities })
+  mockTopicAndRelatedObjects(testTopic, {
+    factors: testFactors,
+    activities,
+    discussions
+  })
 
   // Determine element class distribution based on factor traits
   const datasetFactors = testFactors.filter(

--- a/cypress/support/factories/discussions_factory.ts
+++ b/cypress/support/factories/discussions_factory.ts
@@ -1,0 +1,18 @@
+import type { Discussion } from '@/model/discussion'
+import { build, sequence } from 'mimicry-js'
+import { UserFactory } from './users_factory'
+
+export const discussionFactory = build<Discussion>({
+  fields: {
+    id: sequence((x) => `discussion-${x}`),
+    title: sequence((x) => `Sample Discussion ${x}`),
+    subject: { class: 'Dataset', id: 'default-subject-id' },
+    discussion: [
+      {
+        content: 'Sample discussion comment',
+        posted_by: UserFactory.one(),
+        posted_on: '2026-02-10T20:28:06.645000+00:00'
+      }
+    ]
+  }
+})

--- a/src/components/TabsWithCounts.vue
+++ b/src/components/TabsWithCounts.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+export type TabWithCount = {
+  title: string
+  count?: number
+  tabId: string
+  panelId: string
+}
+
+defineProps<{
+  tabs: TabWithCount[]
+  tabListName: string
+}>()
+
+const activeTab = defineModel<number>({ required: true })
+</script>
+
+<template>
+  <DsfrTabs v-model="activeTab" :tab-list-name="tabListName">
+    <template #tab-items>
+      <DsfrTabItem
+        v-for="(tab, index) in tabs"
+        :key="tab.tabId"
+        :tab-id="tab.tabId"
+        :panel-id="tab.panelId"
+        @click="activeTab = index"
+        @next="activeTab = index === tabs.length - 1 ? 0 : index + 1"
+        @previous="activeTab = index === 0 ? tabs.length - 1 : index - 1"
+        @first="activeTab = 0"
+        @last="activeTab = tabs.length - 1"
+      >
+        {{ tab.title }}
+        <sup v-if="tab.count !== undefined" class="tab-count fr-ml-1v">
+          ({{ tab.count }})
+        </sup>
+      </DsfrTabItem>
+    </template>
+    <slot />
+  </DsfrTabs>
+</template>
+
+<style scoped>
+.tab-count {
+  font-weight: normal;
+  /* .fr-tabs__tab is display:inline-flex, which makes vertical-align a no-op on its children */
+  position: relative;
+  top: -0.4em;
+}
+</style>

--- a/src/components/TabsWithCounts.vue
+++ b/src/components/TabsWithCounts.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-export type TabWithCount = {
+import type { DsfrTabItemProps } from '@gouvminint/vue-dsfr'
+
+export type TabWithCount = DsfrTabItemProps & {
   title: string
   count?: number
-  tabId: string
-  panelId: string
 }
 
 defineProps<{
@@ -22,6 +22,7 @@ const activeTab = defineModel<number>({ required: true })
         :key="tab.tabId"
         :tab-id="tab.tabId"
         :panel-id="tab.panelId"
+        :icon="tab.icon"
         @click="activeTab = index"
         @next="activeTab = index === tabs.length - 1 ? 0 : index + 1"
         @previous="activeTab = index === 0 ? tabs.length - 1 : index - 1"

--- a/src/components/topics/TopicReusesList.vue
+++ b/src/components/topics/TopicReusesList.vue
@@ -26,6 +26,8 @@ onMounted(() => {
     .getReusesFromElementsRel(props.topic.elements)
     .then((data) => (reuses.value = data))
 })
+
+defineExpose({ reuses })
 </script>
 
 <template>

--- a/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
+++ b/src/custom/ecospheres/views/indicators/IndicatorDetailView.vue
@@ -5,6 +5,7 @@ import { capitalize, computed, onMounted, ref } from 'vue'
 
 import DiscussionsList from '@/components/DiscussionsList.vue'
 import GenericContainer from '@/components/GenericContainer.vue'
+import TabsWithCounts from '@/components/TabsWithCounts.vue'
 import DatasetAddToTopicModal from '@/components/datasets/DatasetAddToTopicModal.vue'
 import DatasetDataservicesList from '@/components/datasets/DatasetDataservicesList.vue'
 import DatasetReusesList from '@/components/datasets/DatasetReusesList.vue'
@@ -46,7 +47,7 @@ const links = computed(() => [
   { text: indicator.value?.title || '' }
 ])
 
-const tabTitles = computed(() => [
+const tabs = computed(() => [
   // only display the visualization tab if the indicator has visualization enabled
   ...(indicator.value?.extras['ecospheres-indicateurs'].enable_visualization
     ? [
@@ -59,17 +60,28 @@ const tabTitles = computed(() => [
     : []),
   {
     title: 'Fichiers',
+    count: indicator.value?.resources.total ?? 0,
     tabId: 'tab-files',
     panelId: 'tab-content-files'
   },
-  { title: 'Sources', tabId: 'tab-sources', panelId: 'tab-content-sources' },
+  {
+    title: 'Sources',
+    count:
+      indicator.value?.extras['ecospheres-indicateurs'].sources.length ?? 0,
+    tabId: 'tab-sources',
+    panelId: 'tab-content-sources'
+  },
   {
     title: 'Réutilisations et API',
+    count:
+      (indicator.value?.metrics.reuses ?? 0) +
+      (indicator.value?.metrics.dataservices ?? 0),
     tabId: 'tab-reuses',
     panelId: 'tab-content-reuses'
   },
   {
     title: 'Discussions',
+    count: indicator.value?.metrics.discussions ?? 0,
     tabId: 'tab-discussions',
     panelId: 'tab-content-discussions'
   },
@@ -149,11 +161,11 @@ onMounted(() => {
       <DatasetSidebar :dataset="indicator" />
     </div>
 
-    <DsfrTabs
+    <TabsWithCounts
       v-model="activeTab"
       class="fr-mt-2w"
       tab-list-name="Groupes d'attributs du jeu de données"
-      :tab-titles="tabTitles"
+      :tabs="tabs"
     >
       <!-- Fichiers -->
       <DsfrTabContent panel-id="tab-content-files" tab-id="tab-files">
@@ -205,7 +217,7 @@ onMounted(() => {
       <DsfrTabContent panel-id="tab-content-infos" tab-id="tab-infos">
         <IndicatorInformationPanel :indicator="indicator" />
       </DsfrTabContent>
-    </DsfrTabs>
+    </TabsWithCounts>
   </GenericContainer>
 </template>
 

--- a/src/views/dataservices/DataserviceDetailView.vue
+++ b/src/views/dataservices/DataserviceDetailView.vue
@@ -10,6 +10,7 @@ import MetricsStatBoxes from '@/components/MetricsStatBoxes.vue'
 import SidebarItem from '@/components/SidebarItem.vue'
 import SidebarList from '@/components/SidebarList.vue'
 import SidebarOwner from '@/components/SidebarOwner.vue'
+import TabsWithCounts from '@/components/TabsWithCounts.vue'
 import VIconDsfr from '@/components/VIconDsfr.vue'
 import { useCurrentPageConf, useRouteParamsAsString } from '@/router/utils'
 import { useDataserviceStore } from '@/store/DataserviceStore'
@@ -69,11 +70,21 @@ const links = computed(() => {
   return breadcrumbs
 })
 
-const tabTitles = [
-  { title: 'Données', tabId: 'tab-0', panelId: 'tab-content-0' },
-  { title: 'Discussions', tabId: 'tab-1', panelId: 'tab-content-1' },
+const tabs = computed(() => [
+  {
+    title: 'Données',
+    count: total.value,
+    tabId: 'tab-0',
+    panelId: 'tab-content-0'
+  },
+  {
+    title: 'Discussions',
+    count: dataservice.value?.metrics.discussions ?? 0,
+    tabId: 'tab-1',
+    panelId: 'tab-content-1'
+  },
   { title: 'Informations', tabId: 'tab-2', panelId: 'tab-content-2' }
-]
+])
 
 const activeTab = ref(0)
 
@@ -231,11 +242,11 @@ onMounted(() => {
       />
     </div>
 
-    <DsfrTabs
+    <TabsWithCounts
       v-model="activeTab"
       class="fr-mt-4w"
       tab-list-name="Groupes d'attributs de l'API"
-      :tab-titles="tabTitles"
+      :tabs="tabs"
     >
       <!-- Données -->
       <DsfrTabContent panel-id="tab-content-0" tab-id="tab-0">
@@ -329,7 +340,7 @@ onMounted(() => {
           </div>
         </div>
       </DsfrTabContent>
-    </DsfrTabs>
+    </TabsWithCounts>
   </GenericContainer>
 </template>
 

--- a/src/views/datasets/DatasetDetailView.vue
+++ b/src/views/datasets/DatasetDetailView.vue
@@ -4,6 +4,7 @@ import { capitalize, computed, onMounted, ref } from 'vue'
 
 import DiscussionsList from '@/components/DiscussionsList.vue'
 import GenericContainer from '@/components/GenericContainer.vue'
+import TabsWithCounts from '@/components/TabsWithCounts.vue'
 import DatasetAddToTopicModal from '@/components/datasets/DatasetAddToTopicModal.vue'
 import DatasetDataservicesList from '@/components/datasets/DatasetDataservicesList.vue'
 import DatasetInformationPanel from '@/components/datasets/DatasetInformationPanel.vue'
@@ -88,12 +89,29 @@ const links = computed(() => {
   return breadcrumbs
 })
 
-const tabTitles = [
-  { title: 'Fichiers', tabId: 'tab-0', panelId: 'tab-content-0' },
-  { title: 'Réutilisations et API', tabId: 'tab-1', panelId: 'tab-content-1' },
-  { title: 'Discussions', tabId: 'tab-2', panelId: 'tab-content-2' },
+const tabs = computed(() => [
+  {
+    title: 'Fichiers',
+    count: dataset.value?.resources.total ?? 0,
+    tabId: 'tab-0',
+    panelId: 'tab-content-0'
+  },
+  {
+    title: 'Réutilisations et API',
+    count:
+      (dataset.value?.metrics.reuses ?? 0) +
+      (dataset.value?.metrics.dataservices ?? 0),
+    tabId: 'tab-1',
+    panelId: 'tab-content-1'
+  },
+  {
+    title: 'Discussions',
+    count: dataset.value?.metrics.discussions ?? 0,
+    tabId: 'tab-2',
+    panelId: 'tab-content-2'
+  },
   { title: 'Informations', tabId: 'tab-3', panelId: 'tab-content-3' }
-]
+])
 
 const activeTab = ref(0)
 
@@ -204,11 +222,11 @@ onMounted(() => {
       <DatasetSidebar :dataset="dataset" />
     </div>
 
-    <DsfrTabs
+    <TabsWithCounts
       v-model="activeTab"
       class="fr-mt-2w"
       tab-list-name="Groupes d'attributs du jeu de données"
-      :tab-titles="tabTitles"
+      :tabs="tabs"
     >
       <!-- Fichiers -->
       <DsfrTabContent panel-id="tab-content-0" tab-id="tab-0">
@@ -271,6 +289,6 @@ onMounted(() => {
           <DatasetInformationPanel :dataset="dataset" />
         </div>
       </DsfrTabContent>
-    </DsfrTabs>
+    </TabsWithCounts>
   </GenericContainer>
 </template>

--- a/src/views/topics/TopicDetailView.vue
+++ b/src/views/topics/TopicDetailView.vue
@@ -12,6 +12,9 @@ import GenericContainer from '@/components/GenericContainer.vue'
 import SidebarItem from '@/components/SidebarItem.vue'
 import SidebarList from '@/components/SidebarList.vue'
 import SidebarOwner from '@/components/SidebarOwner.vue'
+import TabsWithCounts, {
+  type TabWithCount
+} from '@/components/TabsWithCounts.vue'
 import TagComponent from '@/components/TagComponent.vue'
 import TopicActivityList from '@/components/topics/TopicActivityList.vue'
 import TopicFactorsList from '@/components/topics/TopicFactorsList.vue'
@@ -25,6 +28,7 @@ import {
   useRouteMeta,
   useRouteParamsAsStringReactive
 } from '@/router/utils'
+import { useDiscussionStore } from '@/store/DiscussionStore'
 import { useTopicStore } from '@/store/TopicStore'
 import { useUserStore } from '@/store/UserStore'
 import { descriptionFromMarkdown, formatDate } from '@/utils'
@@ -57,6 +61,7 @@ const customDescriptionComponent = useAsyncComponent(
 )
 
 const userStore = useUserStore()
+const discussionStore = useDiscussionStore()
 const canEdit = computed(() => {
   return userStore.hasEditPermissions(topic.value) && pageConf.editable
 })
@@ -70,7 +75,7 @@ const showReuses = pageConf.resources_tabs.reuses.display
 const tags = useTagsByRef(pageKey, topic)
 
 const { clonedFrom } = useExtras(topic)
-const { factors } = useTopicFactors(topic)
+const { factors, nbFactors } = useTopicFactors(topic)
 const topicFactorsListRef = ref<InstanceType<typeof TopicFactorsList> | null>(
   null
 )
@@ -78,6 +83,9 @@ const discussionsListRef = ref<InstanceType<typeof DiscussionsList> | null>(
   null
 )
 const topicActivityListRef = ref<InstanceType<typeof TopicActivityList> | null>(
+  null
+)
+const topicReusesListRef = ref<InstanceType<typeof TopicReusesList> | null>(
   null
 )
 
@@ -100,39 +108,44 @@ const breadcrumbLinks = computed(() => {
 
 const showActivity = computed(() => canEdit.value)
 
-const tabTitles = computed(() => {
-  const tabs: { title: string; tabId: string; panelId: string }[] = []
+const tabs = computed(() => {
+  const result: TabWithCount[] = []
 
   if (showDatasets) {
-    tabs.push({
+    result.push({
       title: 'Données',
+      count: nbFactors.value,
       tabId: 'tab-datasets',
       panelId: 'tab-content-datasets'
     })
   }
   if (showDiscussions) {
-    tabs.push({
+    result.push({
       title: 'Discussions',
+      count: topic.value
+        ? (discussionStore.getDiscussionsForSubject(topic.value.id)?.total ?? 0)
+        : 0,
       tabId: 'tab-discussions',
       panelId: 'tab-content-discussions'
     })
   }
   if (showReuses) {
-    tabs.push({
+    result.push({
       title: 'Réutilisations',
+      count: topicReusesListRef.value?.reuses.length ?? 0,
       tabId: 'tab-reuses',
       panelId: 'tab-content-reuses'
     })
   }
   if (showActivity.value) {
-    tabs.push({
+    result.push({
       title: 'Activité',
       tabId: 'tab-activity',
       panelId: 'tab-content-activity'
     })
   }
 
-  return tabs
+  return result
 })
 
 const activeTab = ref(0)
@@ -256,7 +269,7 @@ watch(
       )
       clearHash()
     } else if (hash.startsWith('#discussion-')) {
-      const tabIndex = tabTitles.value.findIndex(
+      const tabIndex = tabs.value.findIndex(
         (t) => t.tabId === 'tab-discussions'
       )
       if (tabIndex !== -1) activeTab.value = tabIndex
@@ -437,11 +450,11 @@ watch(
       </div>
     </div>
 
-    <DsfrTabs
-      v-if="tabTitles.length > 0"
+    <TabsWithCounts
+      v-if="tabs.length > 0"
       v-model="activeTab"
       class="fr-mt-2w"
-      :tab-titles="tabTitles"
+      :tabs="tabs"
       :tab-list-name="`Groupes d'attributs ${labels.articles.du} ${labels.singular}`"
     >
       <!-- Jeux de données -->
@@ -488,7 +501,7 @@ watch(
         panel-id="tab-content-reuses"
         tab-id="tab-reuses"
       >
-        <TopicReusesList :topic="topic" />
+        <TopicReusesList ref="topicReusesListRef" :topic="topic" />
       </DsfrTabContent>
       <!-- Activité -->
       <DsfrTabContent
@@ -503,7 +516,7 @@ watch(
           @navigate-to-factor="handleNavigateToFactor"
         />
       </DsfrTabContent>
-    </DsfrTabs>
+    </TabsWithCounts>
   </GenericContainer>
 </template>
 


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1227

Done for:
- datasets
- indicators (including sources)
- dataservices
- topics / collections (not including activity)

<img width="747" height="310" alt="Capture d’écran 2026-09-07 à 09 40 10" src="https://github.com/user-attachments/assets/ffd97806-79e1-46cd-8d21-b23eee3400ba" />
