### PR TITLE
fix: gate localStorage access

### DIFF
--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -85,28 +85,12 @@ describe('Home Page', () => {
   })
 
   it('should not have console errors', () => {
-    // Use window:before:load so the stub is set on the NEW window before any
-    // app code runs — cy.stub() on the old window wouldn't survive a reload.
-    cy.on('window:before:load', (win) => {
-      cy.stub(win.console, 'error').as('consoleError')
-    })
-
-    // Reload the page to trigger any potential errors
+    cy.trackConsoleErrors()
     cy.reload()
 
-    // app.mount() runs inside routerPromise.then(), so Vue mounts asynchronously
-    // after cy.reload() resolves. Wait for the h1 to confirm mounting is done,
-    // then wait for any async data fetching (e.g. Grist on the culture site).
     cy.get('h1').should('be.visible')
     cy.contains('p', 'Chargement...').should('not.exist')
 
-    cy.get('@consoleError').then((rawStub) => {
-      const stub = rawStub as unknown as sinon.SinonSpy
-      if (stub.called) {
-        throw new Error(
-          `console.error was called ${stub.callCount} time(s):\n${stub.args.map((a: unknown[], i: number) => `Call ${i + 1}: ${JSON.stringify(a)}`).join('\n')}`
-        )
-      }
-    })
+    cy.expectNoConsoleErrors()
   })
 })

--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -1,0 +1,35 @@
+describe('Login', () => {
+  beforeEach(() => {
+    cy.mockMatomo()
+    cy.mockStaticDatagouv()
+    cy.mockGristRecords('*')
+    cy.mockDatagouvObjectList('topics', [])
+  })
+
+  it('redirects to home with a toast when localStorage is unavailable', () => {
+    if (Cypress.env('siteConfig')?.website?.oauth_option !== true) {
+      cy.log('oauth is not configured for this site, skipping')
+      return
+    }
+
+    cy.trackConsoleErrors()
+    cy.on('window:before:load', (win) => {
+      // simulate a browser blocking storage access
+      const throwSecurityError = () => {
+        throw new DOMException('The operation is insecure.', 'SecurityError')
+      }
+      cy.stub(win.localStorage, 'getItem').callsFake(throwSecurityError)
+      cy.stub(win.localStorage, 'setItem').callsFake(throwSecurityError)
+      cy.stub(win.localStorage, 'removeItem').callsFake(throwSecurityError)
+    })
+
+    cy.visit('/login')
+
+    cy.url().should('eq', `${Cypress.config().baseUrl}/`)
+    cy.get('[data-sonner-toast][data-type="error"]')
+      .should('be.visible')
+      .and('contain.text', 'stockage local')
+
+    cy.expectNoConsoleErrors()
+  })
+})

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -7,6 +7,17 @@
 import './authentication'
 import './filters'
 
+// call before the cy.visit()/cy.reload() that triggers the page load
+Cypress.Commands.add('trackConsoleErrors', () => {
+  cy.on('window:before:load', (win) => {
+    cy.stub(win.console, 'error').as('consoleError')
+  })
+})
+
+Cypress.Commands.add('expectNoConsoleErrors', () => {
+  cy.get('@consoleError').should('not.have.been.called')
+})
+
 Cypress.Commands.add('checkRGAAContrast', () => {
   cy.checkA11y(undefined, {
     runOnly: {

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -9,6 +9,7 @@ declare global {
       checkRGAAContrast(): Chainable<void>
       clickCheckbox(checkbox_name: string): Chainable<void>
       expectActionToCallApi(action: () => void, resourceName: string, expectedParams: Record<string, string | string[]>, options?: { drain?: boolean }): Chainable<void>
+      expectNoConsoleErrors(): Chainable<void>
       expectRequestWithParams(resourceName: string, requestParamsString: string | RegExp): Chainable<void>
       isInViewport(options?: { threshold?: number; wait?: number }): Chainable<Element>
       mockDatagouvObject(resourceName: string, resourceId: string, data?: object): Chainable<void>
@@ -40,6 +41,7 @@ declare global {
       selectFilterValue(selectLabel: string, optionLabel: string): Chainable<void>
       simulateConnectedUser(userData?: object): Chainable<void>
       simulateDisconnectedUser(): Chainable<void>
+      trackConsoleErrors(): Chainable<void>
     }
   }
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,8 +2,10 @@ import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
 
 import config from '@/config'
 import type { StaticPageConfig } from '@/model/config'
+import LocalStorageService from '@/services/LocalStorageService'
 import NotFoundView from '@/views/NotFoundView.vue'
 import StaticPageView from '@/views/StaticPageView.vue'
+import { toast } from '@datagouv/components-next'
 
 // common/default routes
 const defaultRoutes: RouteRecordRaw[] = [
@@ -45,6 +47,15 @@ if (config.website.oauth_option === true) {
     {
       path: '/login',
       name: 'login',
+      // the oauth flow relies on localStorage to persist PKCE state across the redirect
+      beforeEnter: () => {
+        if (!LocalStorageService.isAvailable()) {
+          toast.error(
+            'La connexion nécessite que votre navigateur autorise le stockage local.'
+          )
+          return { name: 'home' }
+        }
+      },
       component: async () => await import('@/views/LoginView.vue')
     },
     {

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -1,6 +1,7 @@
 import config from '@/config'
 
 import OauthAPI from './api/OauthAPI'
+import LocalStorageService from './LocalStorageService'
 
 const api = new OauthAPI()
 
@@ -22,8 +23,8 @@ export default class AuthService {
     const encodedState = encodeURIComponent(state)
     const encodedCC = encodeURIComponent(codeChallenge)
 
-    localStorage.setItem('pkceCodeVerifier', codeVerifier)
-    localStorage.setItem('pkceState', state)
+    LocalStorageService.setItem('pkceCodeVerifier', codeVerifier)
+    LocalStorageService.setItem('pkceState', state)
 
     return `${this.baseURL}/oauth/authorize?redirect_uri=${redirectURI}&response_type=code&state=${encodedState}&client_id=${this.clientId}&scope=default&code_challenge=${encodedCC}&code_challenge_method=S256`
   }
@@ -32,13 +33,13 @@ export default class AuthService {
    * Retrieve an oauth token from a verification code
    */
   async retrieveToken(code, state) {
-    const storedState = localStorage.getItem('pkceState')
+    const storedState = LocalStorageService.getItem('pkceState')
     if (state !== storedState) {
       const error = `Unmatching states: ${state} vs ${storedState}`
       console.error(error)
       throw new Error(error)
     }
-    const pkceCodeVerifier = localStorage.getItem('pkceCodeVerifier')
+    const pkceCodeVerifier = LocalStorageService.getItem('pkceCodeVerifier')
     return await api.token({
       code,
       pkceCodeVerifier,
@@ -58,8 +59,8 @@ export default class AuthService {
    * Cleanup after login flow
    */
   cleanup() {
-    localStorage.removeItem('pkceCodeVerifier')
-    localStorage.removeItem('pkceState')
+    LocalStorageService.removeItem('pkceCodeVerifier')
+    LocalStorageService.removeItem('pkceState')
   }
 
   /**

--- a/src/services/LocalStorageService.ts
+++ b/src/services/LocalStorageService.ts
@@ -1,13 +1,34 @@
 export default {
+  isAvailable(): boolean {
+    const testKey = '__storage_test__'
+    try {
+      localStorage.setItem(testKey, testKey)
+      localStorage.removeItem(testKey)
+      return true
+    } catch {
+      return false
+    }
+  },
   setItem(key: string, value: object | string) {
-    if (typeof value === 'object') {
-      localStorage.setItem(key, JSON.stringify(value))
-    } else {
-      localStorage.setItem(key, value)
+    try {
+      if (typeof value === 'object') {
+        localStorage.setItem(key, JSON.stringify(value))
+      } else {
+        localStorage.setItem(key, value)
+      }
+    } catch (err) {
+      // localStorage can be unavailable (blocked cookies, private browsing, sandboxed iframe...)
+      console.warn(`Failed to write to localStorage (key: ${key})`, err)
     }
   },
   getItem(key: string) {
-    const item = localStorage.getItem(key)
+    let item: string | null
+    try {
+      item = localStorage.getItem(key)
+    } catch (err) {
+      console.warn(`Failed to read from localStorage (key: ${key})`, err)
+      return undefined
+    }
     if (item !== null) {
       try {
         return JSON.parse(item)
@@ -17,6 +38,10 @@ export default {
     }
   },
   removeItem(key: string) {
-    localStorage.removeItem(key)
+    try {
+      localStorage.removeItem(key)
+    } catch (err) {
+      console.warn(`Failed to remove from localStorage (key: ${key})`, err)
+    }
   }
 }

--- a/src/store/UserStore.ts
+++ b/src/store/UserStore.ts
@@ -49,8 +49,8 @@ export const useUserStore = defineStore('user', {
      * If we have a token, fetch user infos from API
      */
     async init(): Promise<User | undefined> {
-      const token = localStorage.getItem(STORAGE_KEY)
-      if (token !== null) {
+      const token = LocalStorageService.getItem(STORAGE_KEY)
+      if (token !== undefined) {
         this.token = token
         this.isLoggedIn = true
         let userData: User | undefined
@@ -103,7 +103,7 @@ export const useUserStore = defineStore('user', {
     login(token: string) {
       this.isLoggedIn = true
       this.token = token
-      localStorage.setItem(STORAGE_KEY, token)
+      LocalStorageService.setItem(STORAGE_KEY, token)
     },
     /**
      * Reflet logged-out state
@@ -112,7 +112,7 @@ export const useUserStore = defineStore('user', {
       this.isLoggedIn = false
       this.token = undefined
       this.data = undefined
-      localStorage.removeItem(STORAGE_KEY)
+      LocalStorageService.removeItem(STORAGE_KEY)
     },
     /**
      * Store user infos


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/301483/
Fix https://github.com/ecolabdata/ecospheres/issues/1245

Gracefully supports local storage not enabled on browser:
- errors are caught and logged, not breaking anymore
- connexion feature is explicitly disabled, with an explanation