### PR TITLE
feat(tracking): track custom filters usage

### DIFF
--- a/src/components/search/SearchOrganizationFilter.vue
+++ b/src/components/search/SearchOrganizationFilter.vue
@@ -31,5 +31,5 @@ const selectConfig = computed(() => ({
 </script>
 
 <template>
-  <SearchSelectFilter :config="selectConfig" />
+  <SearchSelectFilter :config="selectConfig" :page-key="config.pageKey" />
 </template>

--- a/src/components/search/SearchSelectFilter.vue
+++ b/src/components/search/SearchSelectFilter.vue
@@ -23,7 +23,7 @@ const model = computed<FilterOption | null>({
     if (opt) {
       trackEvent(
         `Filter ${props.pageKey} list`,
-        `Trigger filter ${props.config.urlParam}`,
+        `Trigger custom filter ${props.config.urlParam}`,
         opt.value
       )
     }

--- a/src/components/search/SearchSelectFilter.vue
+++ b/src/components/search/SearchSelectFilter.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import type { SelectFilterConfig } from '@/router/utils'
+import { trackEvent } from '@/utils/matomo'
 import { SearchableSelect, useSearchFilter } from '@datagouv/components-next'
 import { computed } from 'vue'
 
 type FilterOption = SelectFilterConfig['values'][number]
 
-const props = defineProps<{ config: SelectFilterConfig }>()
+const props = defineProps<{ config: SelectFilterConfig; pageKey: string }>()
 
 const urlValue = useSearchFilter(props.config.urlParam, {
   apiParam: props.config.apiParam,
@@ -18,6 +19,14 @@ const model = computed<FilterOption | null>({
     props.config.values.find((v) => v.value === urlValue.value) ?? null,
   set: (opt) => {
     urlValue.value = opt?.value ?? undefined
+    // Track the selection, not the clear, so Matomo only sees actual filter usage
+    if (opt) {
+      trackEvent(
+        `Filter ${props.pageKey} list`,
+        `Trigger filter ${props.config.urlParam}`,
+        opt.value
+      )
+    }
   }
 })
 </script>

--- a/src/views/UnifiedSearchView.vue
+++ b/src/views/UnifiedSearchView.vue
@@ -151,7 +151,11 @@ onMounted(() => {
             v-for="filter in route.meta.customFilters"
             :key="filter.urlParam"
           >
-            <SearchSelectFilter v-if="'values' in filter" :config="filter" />
+            <SearchSelectFilter
+              v-if="'values' in filter"
+              :config="filter"
+              :page-key="pageKey"
+            />
             <SearchOrganizationFilter
               v-else-if="'pageKey' in filter"
               :config="filter"


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1249

Tracks usage of custom filters in Matomo as events (native filters would need to be handled upstream) as so:
- Category: Filter {pageKey} list (e.g. Filter datasets list)
- Action: Trigger filter {filter.id} (filter.id = the config's urlParam, e.g. Trigger filter theme)
- Value: the selected option's id (opt.value, e.g. sante)